### PR TITLE
Add Shift-held trigs for MD/MM parameter locks

### DIFF
--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -68,3 +68,12 @@ endif()
 
 # Build an independent MM product from the shared editor/controller code.
 target_compile_definitions(mmJucePlugin PRIVATE MD_JUCEPLUGIN_MONOMACHINE=1)
+
+if(BUILD_TESTING)
+	add_executable(mdShiftTriggerLatchTest mdShiftTriggerLatchTest.cpp)
+	target_link_libraries(mdShiftTriggerLatchTest PRIVATE mdLib)
+	target_include_directories(mdShiftTriggerLatchTest PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR})
+	set_property(TARGET mdShiftTriggerLatchTest PROPERTY FOLDER "Elektron/test")
+	add_test(NAME mdShiftTriggerLatchTest COMMAND mdShiftTriggerLatchTest)
+endif()

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -484,10 +484,12 @@ namespace mdJucePlugin
 				if(auto* hw = getHardware())
 					hw->sendPanelEvent(combined.row, combined.mask);
 			}
-
-			if(getModel() == md::MachineModel::Monomachine)
-				releasePatternBankLatch();
 		});
+
+		// A pattern bank acts as the modifier in the MM bank + trig chord. Let go
+		// of every target trig before releasing that modifier.
+		if(getModel() == md::MachineModel::Monomachine)
+			releasePatternBankLatch();
 	}
 
 	void Editor::releaseAllPanelInputs()
@@ -1079,6 +1081,10 @@ namespace mdJucePlugin
 		if(!_knob)
 			return;
 
+		// Shift belongs to the MD/MM trig-hold gesture. Keep normal drag speed
+		// while it is down; RmlUi's existing Command/Ctrl modifier remains the
+		// 20% fine-adjustment gesture.
+		_knob->SetAttribute("speedScaleShift", 1.0f);
 		_knob->setMinValue(0.0f);
 		_knob->setMaxValue(g_encoderRange);
 		_knob->setEndless(true);

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -30,6 +30,7 @@
 #include "juceRmlUi/juceRmlComponent.h"
 
 #include "RmlUi/Core/Element.h"
+#include "RmlUi/Core/ElementDocument.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -172,6 +173,7 @@ namespace mdJucePlugin
 	{
 		m_panelSteps.clear();
 		endPanelGesture();
+		releaseShiftHeldTriggers();
 		releasePatternBankLatch();
 		releaseAllPanelInputs();
 		stopTimer();
@@ -248,6 +250,7 @@ namespace mdJucePlugin
 
 	void Editor::createButtons()
 	{
+		releaseShiftHeldTriggers();
 		releasePatternBankLatch();
 		m_panelRows.reset();
 		const auto model = getModel();
@@ -277,9 +280,17 @@ namespace mdJucePlugin
 				continue;
 			}
 
+			if(isTrigger(pb.control))
+				b->SetAttribute("title",
+					"Shift-click to hold this trig; release Shift to let go");
+
 			juceRmlUi::EventListener::Add(b, Rml::EventId::Mousedown,
-				[this, b, packet, model, control = pb.control](Rml::Event&)
+				[this, b, packet, model, control = pb.control](Rml::Event& _event)
 			{
+				const bool shiftLatch = isTrigger(control)
+					&& _event.GetParameter<int>("shift_key", 0) != 0;
+				if(shiftLatch && !m_shiftTriggerLatch.latch(control))
+					return;
 				if(model == md::MachineModel::Monomachine && !isTrigger(control))
 					releasePatternBankLatch();
 				juceRmlUi::ElemButton::setChecked(b, true);
@@ -293,6 +304,8 @@ namespace mdJucePlugin
 			// Mouseout releases too, otherwise dragging off a button leaves it held.
 			const auto release = [this, b, packet, model, control = pb.control](Rml::Event&)
 			{
+				if(m_shiftTriggerLatch.contains(control))
+					return;
 				if(!b->isChecked())
 					return;
 				juceRmlUi::ElemButton::setChecked(b, false);
@@ -307,6 +320,14 @@ namespace mdJucePlugin
 			juceRmlUi::EventListener::Add(b, Rml::EventId::Mouseup, release);
 			juceRmlUi::EventListener::Add(b, Rml::EventId::Mouseout, release);
 		}
+
+		if(auto* const document = getDocument())
+			juceRmlUi::EventListener::Add(document, Rml::EventId::Keyup,
+				[this](const Rml::Event& _event)
+				{
+					if(_event.GetParameter<int>("shift_key", 0) == 0)
+						releaseShiftHeldTriggers();
+				});
 	}
 
 	void Editor::createPanelAffordances()
@@ -444,6 +465,29 @@ namespace mdJucePlugin
 
 		m_panelGesturePackets.clear();
 		m_panelGestureElement = nullptr;
+	}
+
+	void Editor::releaseShiftHeldTriggers()
+	{
+		m_shiftTriggerLatch.releaseAll([this](const md::PanelControl _control)
+		{
+			const auto trigger = static_cast<size_t>(static_cast<int>(_control)
+				- static_cast<int>(md::PanelControl::Trigger1));
+			if(trigger < 16)
+				if(auto* const button = findChild<juceRmlUi::ElemButton>(
+					("trigKey" + std::to_string(trigger)).c_str(), false))
+					juceRmlUi::ElemButton::setChecked(button, false);
+
+			if(const auto packet = md::panelPacket(getModel(), _control))
+			{
+				const auto combined = m_panelRows.release(*packet);
+				if(auto* hw = getHardware())
+					hw->sendPanelEvent(combined.row, combined.mask);
+			}
+
+			if(getModel() == md::MachineModel::Monomachine)
+				releasePatternBankLatch();
+		});
 	}
 
 	void Editor::releaseAllPanelInputs()
@@ -1249,6 +1293,13 @@ namespace mdJucePlugin
 
 	void Editor::timerCallback()
 	{
+		// Some plugin hosts can lose the modifier key-up when focus moves to
+		// another window. Poll the native state as a fail-safe so no panel row can
+		// remain held indefinitely.
+		if(!m_shiftTriggerLatch.empty()
+			&& !juce::ModifierKeys::getCurrentModifiersRealtime().isShiftDown())
+			releaseShiftHeldTriggers();
+
 		m_frontPanelSnapshotValid = refreshFrontPanelSnapshot();
 		servicePanelQueue();
 

--- a/source/elektron/md/mdJucePlugin/mdEditor.h
+++ b/source/elektron/md/mdJucePlugin/mdEditor.h
@@ -85,6 +85,7 @@ namespace mdJucePlugin
 		void beginPanelGesture(Rml::Element* _element,
 			std::initializer_list<md::PanelControl> _controls);
 		void endPanelGesture();
+		void releaseShiftHeldTriggers();
 		void releaseAllPanelInputs();
 		void queuePanelPulse(md::PanelControl _control, int _count = 1);
 		void servicePanelQueue();
@@ -138,6 +139,7 @@ namespace mdJucePlugin
 		std::optional<md::PanelPacket> m_patternBankPacket;
 		Rml::Element* m_panelGestureElement = nullptr;
 		std::vector<md::PanelPacket> m_panelGesturePackets;
+		panelAffordances::ShiftTriggerLatch m_shiftTriggerLatch;
 
 		struct PanelStep
 		{

--- a/source/elektron/md/mdJucePlugin/mdPanelAffordances.h
+++ b/source/elektron/md/mdJucePlugin/mdPanelAffordances.h
@@ -33,6 +33,71 @@ namespace mdJucePlugin::panelAffordances
 		int count;
 	};
 
+	// Tracks trigs pinned by Shift-click independently of the panel row masks.
+	// The editor owns the actual press/release edges and visible button state;
+	// keeping this policy JUCE-free makes duplicate suppression and release order
+	// straightforward to verify.
+	class ShiftTriggerLatch
+	{
+	public:
+		static constexpr size_t g_triggerCount = 16;
+
+		bool latch(const md::PanelControl _control)
+		{
+			const auto index = triggerIndex(_control);
+			if(!index || m_held[*index])
+				return false;
+
+			m_held[*index] = true;
+			m_order[m_size++] = _control;
+			return true;
+		}
+
+		bool contains(const md::PanelControl _control) const
+		{
+			const auto index = triggerIndex(_control);
+			return index && m_held[*index];
+		}
+
+		bool empty() const
+		{
+			return m_size == 0;
+		}
+
+		size_t size() const
+		{
+			return m_size;
+		}
+
+		template<typename Release>
+		void releaseAll(Release&& _release)
+		{
+			while(m_size != 0)
+			{
+				const auto control = m_order[--m_size];
+				const auto index = triggerIndex(control);
+				if(index)
+					m_held[*index] = false;
+				_release(control);
+			}
+		}
+
+	private:
+		static std::optional<size_t> triggerIndex(const md::PanelControl _control)
+		{
+			if(_control < md::PanelControl::Trigger1
+				|| _control > md::PanelControl::Trigger16)
+				return std::nullopt;
+
+			return static_cast<size_t>(static_cast<int>(_control)
+				- static_cast<int>(md::PanelControl::Trigger1));
+		}
+
+		std::array<bool, g_triggerCount> m_held{};
+		std::array<md::PanelControl, g_triggerCount> m_order{};
+		size_t m_size = 0;
+	};
+
 	// A direct-selection target is replaced, rather than appended, when the user
 	// clicks again while the firmware is still processing the previous request.
 	// The editor advances one panel pulse at a time and clears the target only

--- a/source/elektron/md/mdJucePlugin/mdShiftTriggerLatchTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdShiftTriggerLatchTest.cpp
@@ -1,0 +1,98 @@
+#include "mdPanelAffordances.h"
+
+#include <array>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+namespace
+{
+	using mdJucePlugin::panelAffordances::ShiftTriggerLatch;
+
+	void expect(const bool _condition, const char* const _message)
+	{
+		if(_condition)
+			return;
+
+		std::cerr << "mdShiftTriggerLatchTest: " << _message << '\n';
+		std::exit(1);
+	}
+
+	void checkLatchPolicy()
+	{
+		ShiftTriggerLatch latch;
+		expect(latch.empty() && latch.size() == 0, "new latch is not empty");
+		expect(!latch.latch(md::PanelControl::Function),
+			"non-trig control was accepted");
+		expect(latch.latch(md::PanelControl::Trigger1), "first trig was rejected");
+		expect(!latch.latch(md::PanelControl::Trigger1),
+			"duplicate trig was accepted");
+		expect(latch.latch(md::PanelControl::Trigger8), "second trig was rejected");
+		expect(latch.latch(md::PanelControl::Trigger16), "last trig was rejected");
+		expect(latch.size() == 3, "latch size is wrong");
+		expect(latch.contains(md::PanelControl::Trigger1)
+			&& latch.contains(md::PanelControl::Trigger8)
+			&& latch.contains(md::PanelControl::Trigger16),
+			"latched trig was not retained");
+
+		std::vector<md::PanelControl> released;
+		latch.releaseAll([&released](const md::PanelControl _control)
+		{
+			released.push_back(_control);
+		});
+
+		const std::vector<md::PanelControl> expected
+		{
+			md::PanelControl::Trigger16,
+			md::PanelControl::Trigger8,
+			md::PanelControl::Trigger1,
+		};
+		expect(released == expected, "trigs were not released in reverse order");
+		expect(latch.empty() && !latch.contains(md::PanelControl::Trigger1),
+			"release did not clear latch state");
+	}
+
+	void checkPanelRows(const md::MachineModel _model)
+	{
+		ShiftTriggerLatch latch;
+		md::PanelRowState rows;
+		constexpr std::array controls
+		{
+			md::PanelControl::Trigger1,
+			md::PanelControl::Trigger6,
+			md::PanelControl::Trigger11,
+			md::PanelControl::Trigger16,
+		};
+
+		for(const auto control : controls)
+		{
+			const auto packet = md::panelPacket(_model, control);
+			expect(packet.has_value(), "trig has no panel packet");
+			expect(latch.latch(control), "unique trig was rejected");
+			rows.press(*packet);
+		}
+
+		size_t releaseCount = 0;
+		latch.releaseAll([&](const md::PanelControl _control)
+		{
+			const auto packet = md::panelPacket(_model, _control);
+			expect(packet.has_value(), "latched trig lost its panel packet");
+			rows.release(*packet);
+			++releaseCount;
+		});
+
+		expect(releaseCount == controls.size(), "not every held trig was released");
+		for(uint8_t row = 0x20; row <= 0x25; ++row)
+			expect(rows.mask(row) == 0, "release left a panel row held");
+	}
+}
+
+int main()
+{
+	checkLatchPolicy();
+	checkPanelRows(md::MachineModel::Machinedrum);
+	checkPanelRows(md::MachineModel::Monomachine);
+
+	std::cout << "mdShiftTriggerLatchTest: PASS\n";
+	return 0;
+}

--- a/source/juceRmlUi/rmlElemKnob.cpp
+++ b/source/juceRmlUi/rmlElemKnob.cpp
@@ -154,10 +154,13 @@ namespace juceRmlUi
 
 		float mod = 1.0f;
 
-		if (helper::getKeyModShift(_event))
-			mod = m_speedScaleShift;
-		else if (helper::getKeyModCommand(_event))
+		// The primary fine-adjustment modifier wins when combined with Shift.
+		// Device editors can then reserve Shift for a separate gesture while
+		// retaining fine knob control with Shift + Command/Ctrl.
+		if (helper::getKeyModCommand(_event))
 			mod = m_speedScaleCtrl;
+		else if (helper::getKeyModShift(_event))
+			mod = m_speedScaleShift;
 		else if (helper::getKeyModAlt(_event))
 			mod = m_speedScaleAlt;
 


### PR DESCRIPTION
## Summary

- Shift-click one or more trig keys to keep their real panel inputs held until Shift is released
- reserve Shift for the MD/MM trig-hold gesture, leaving encoder movement at normal speed
- use Shift plus Command/Ctrl for the existing 20% fine encoder adjustment
- release all held trigs before an MM pattern-bank latch
- add focused coverage for duplicate suppression, release ordering, and complete MD/MM panel-row cleanup

## Validation

- Release arm64 builds completed for mdJucePlugin and mmJucePlugin
- mdShiftTriggerLatchTest passes
- git diff --check passes

## Follow-up

A ROM-backed UI smoke test is still recommended for p-lock creation, multi-trig holds, focus-loss cleanup, and MM bank-plus-trig pattern selection.