### PR TITLE
Expose MD/MM parameters to DAW automation

### DIFF
--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -13,7 +13,7 @@ set(SOURCES
 	mdStorageImage.cpp mdStorageImage.h
 	mdPluginEntry.cpp
 
-	parameterDescriptions_md.json
+	parameterDescriptions_md.json parameterDescriptions_mm.json
 
 	skins/mdDefault/mdDefault.rml
 	skins/mdDefault/mdKnobs.rcss
@@ -31,6 +31,7 @@ set(COMMON_ASSETS
 	"../../../jucePluginData/elektronButtonBevelAtlas.png"
 	"../../../jucePluginData/elektronPlayTriangle.png"
 	"parameterDescriptions_md.json"
+	"parameterDescriptions_mm.json"
 	"../../../jucePluginData/elektron_panel.rcss"
 	"../../../jucePluginData/elektron_materials.rcss")
 file(GLOB MD_SKIN_ASSETS CONFIGURE_DEPENDS
@@ -76,4 +77,24 @@ if(BUILD_TESTING)
 		${CMAKE_CURRENT_SOURCE_DIR})
 	set_property(TARGET mdShiftTriggerLatchTest PROPERTY FOLDER "Elektron/test")
 	add_test(NAME mdShiftTriggerLatchTest COMMAND mdShiftTriggerLatchTest)
+
+	add_executable(mdAutomationParameterTest mdAutomationParameterTest.cpp)
+	target_link_libraries(mdAutomationParameterTest PRIVATE
+		jucePluginLib mdLib juce_plugin_modules)
+	target_compile_definitions(mdAutomationParameterTest PRIVATE
+		JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1
+		MD_AUTOMATION_PARAMETER_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+	set_property(TARGET mdAutomationParameterTest PROPERTY FOLDER "Elektron/test")
+	add_test(NAME mdAutomationParameterTest COMMAND mdAutomationParameterTest)
+
+	add_executable(mdAutomationFirmwareTest mdAutomationFirmwareTest.cpp)
+	target_link_libraries(mdAutomationFirmwareTest PRIVATE
+		mdJucePlugin jucePluginEditorLib mdLib juce_plugin_modules)
+	target_include_directories(mdAutomationFirmwareTest PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+	target_compile_definitions(mdAutomationFirmwareTest PRIVATE
+		JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1)
+	set_property(TARGET mdAutomationFirmwareTest PROPERTY FOLDER "Elektron/test")
+	add_test(NAME mdAutomationFirmwareTest COMMAND mdAutomationFirmwareTest)
+	set_tests_properties(mdAutomationFirmwareTest PROPERTIES LABELS "Integration")
 endif()

--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -97,4 +97,16 @@ if(BUILD_TESTING)
 	set_property(TARGET mdAutomationFirmwareTest PROPERTY FOLDER "Elektron/test")
 	add_test(NAME mdAutomationFirmwareTest COMMAND mdAutomationFirmwareTest)
 	set_tests_properties(mdAutomationFirmwareTest PROPERTIES LABELS "Integration")
+
+	add_executable(mdAutomationRobustnessTest mdAutomationRobustnessTest.cpp)
+	target_link_libraries(mdAutomationRobustnessTest PRIVATE
+		mdJucePlugin jucePluginEditorLib mdLib juce_plugin_modules)
+	target_include_directories(mdAutomationRobustnessTest PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+	target_compile_definitions(mdAutomationRobustnessTest PRIVATE
+		JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1)
+	set_property(TARGET mdAutomationRobustnessTest PROPERTY FOLDER "Elektron/test")
+	add_test(NAME mdAutomationRobustnessTest COMMAND mdAutomationRobustnessTest)
+	set_tests_properties(mdAutomationRobustnessTest PROPERTIES
+		LABELS "Integration;Soak" TIMEOUT 900)
 endif()

--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -87,26 +87,41 @@ if(BUILD_TESTING)
 	set_property(TARGET mdAutomationParameterTest PROPERTY FOLDER "Elektron/test")
 	add_test(NAME mdAutomationParameterTest COMMAND mdAutomationParameterTest)
 
-	add_executable(mdAutomationFirmwareTest mdAutomationFirmwareTest.cpp)
-	target_link_libraries(mdAutomationFirmwareTest PRIVATE
-		mdJucePlugin jucePluginEditorLib mdLib juce_plugin_modules)
-	target_include_directories(mdAutomationFirmwareTest PRIVATE
-		${CMAKE_CURRENT_SOURCE_DIR}/../../..)
-	target_compile_definitions(mdAutomationFirmwareTest PRIVATE
-		JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1)
-	set_property(TARGET mdAutomationFirmwareTest PROPERTY FOLDER "Elektron/test")
+	function(add_md_automation_firmware_test TARGET_NAME SOURCE_FILE)
+		add_executable(${TARGET_NAME} ${SOURCE_FILE} mdAutomationTestSupport.h)
+		target_link_libraries(${TARGET_NAME} PRIVATE
+			mdJucePlugin jucePluginEditorLib mdLib juce_plugin_modules)
+		target_include_directories(${TARGET_NAME} PRIVATE
+			${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+		target_compile_definitions(${TARGET_NAME} PRIVATE
+			JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1)
+		set_property(TARGET ${TARGET_NAME} PROPERTY FOLDER "Elektron/test")
+	endfunction()
+
+	add_md_automation_firmware_test(mdAutomationFirmwareTest
+		mdAutomationFirmwareTest.cpp)
 	add_test(NAME mdAutomationFirmwareTest COMMAND mdAutomationFirmwareTest)
 	set_tests_properties(mdAutomationFirmwareTest PROPERTIES LABELS "Integration")
 
-	add_executable(mdAutomationRobustnessTest mdAutomationRobustnessTest.cpp)
-	target_link_libraries(mdAutomationRobustnessTest PRIVATE
-		mdJucePlugin jucePluginEditorLib mdLib juce_plugin_modules)
-	target_include_directories(mdAutomationRobustnessTest PRIVATE
-		${CMAKE_CURRENT_SOURCE_DIR}/../../..)
-	target_compile_definitions(mdAutomationRobustnessTest PRIVATE
-		JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1)
-	set_property(TARGET mdAutomationRobustnessTest PROPERTY FOLDER "Elektron/test")
+	add_md_automation_firmware_test(mdAutomationRobustnessTest
+		mdAutomationRobustnessTest.cpp)
 	add_test(NAME mdAutomationRobustnessTest COMMAND mdAutomationRobustnessTest)
 	set_tests_properties(mdAutomationRobustnessTest PROPERTIES
-		LABELS "Integration;Soak" TIMEOUT 900)
+		LABELS "Integration" TIMEOUT 300)
+
+	add_md_automation_firmware_test(mdAutomationSoakTest
+		mdAutomationSoakTest.cpp)
+	add_test(NAME mdAutomationSoakTest COMMAND mdAutomationSoakTest
+		--soak-writes=256 --multi-writes=128)
+	set_tests_properties(mdAutomationSoakTest PROPERTIES
+		LABELS "Integration" TIMEOUT 300)
+
+	option(MD_AUTOMATION_REGISTER_FULL_SOAK_TEST
+		"Register the full MD/MM automation soak with CTest" OFF)
+	if(MD_AUTOMATION_REGISTER_FULL_SOAK_TEST)
+		add_test(NAME mdAutomationFullSoakTest COMMAND mdAutomationSoakTest
+			--soak-writes=8192 --multi-writes=2048)
+		set_tests_properties(mdAutomationFullSoakTest PROPERTIES
+			LABELS "Integration;Soak" TIMEOUT 900)
+	endif()
 endif()

--- a/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
@@ -1,113 +1,34 @@
-#include "mdController.h"
-#include "mdPluginProcessor.h"
+#include "mdAutomationTestSupport.h"
 
-#include "mdLib/mdautomation.h"
-#include "mdLib/mddevice.h"
-#include "juce_events/juce_events.h"
-
-#include <cstdlib>
 #include <iostream>
-#include <stdexcept>
 #include <string>
 
 namespace
 {
-	void require(const bool _condition, const std::string& _message)
-	{
-		if(_condition)
-			return;
-		throw std::runtime_error(_message);
-	}
+	using namespace mdAutomationTest;
 
-	void process(mdJucePlugin::AudioPluginAudioProcessor& _processor,
-		const int _blocks)
-	{
-		juce::AudioBuffer<float> audio(2, 128);
-		juce::MidiBuffer midi;
-		auto& audioProcessor = static_cast<juce::AudioProcessor&>(_processor);
-		for(int block = 0; block < _blocks; ++block)
-		{
-			audio.clear();
-			midi.clear();
-			audioProcessor.processBlock(audio, midi);
-			_processor.getController().processPendingMidiMessages();
-		}
-	}
-
-	struct MidiTelemetry
-	{
-		uint64_t consumed = 0;
-		size_t overflows = 0;
-	};
-
-	MidiTelemetry midiTelemetry(
-		mdJucePlugin::AudioPluginAudioProcessor& _processor)
-	{
-		MidiTelemetry result;
-		_processor.getPlugin().withDeviceLocked(
-			[&result](synthLib::Device* const _device)
-			{
-				if(const auto* const device = dynamic_cast<md::Device*>(_device))
-				{
-					result.consumed = device->getHardware().midiRxConsumedCount();
-					result.overflows = device->getHardware().midiRxOverflowCount();
-				}
-			});
-		return result;
-	}
-
-	bool waitForSynchronization(mdJucePlugin::AudioPluginAudioProcessor& _processor,
-		mdJucePlugin::Controller& _controller)
-	{
-		for(int attempt = 0; attempt < 2500; ++attempt)
-		{
-			process(_processor, 1);
-			if(_controller.isAutomationSynchronized())
-				return true;
-		}
-		return false;
-	}
-
-	bool hasLocalFirmware(mdJucePlugin::AudioPluginAudioProcessor& _processor)
-	{
-		return _processor.getPlugin().withDeviceLocked(
-			[](synthLib::Device* const _device)
-			{
-				return dynamic_cast<md::Device*>(_device) != nullptr;
-			});
-	}
-
-	pluginLib::Parameter& parameter(mdJucePlugin::Controller& _controller,
-		const md::MachineModel)
+	pluginLib::Parameter& parameter(mdJucePlugin::Controller& _controller)
 	{
 		auto* const result = _controller.getParameter("Level", 0);
 		require(result != nullptr, "test parameter was not registered");
 		return *result;
 	}
 
-	void hostWrite(pluginLib::Parameter& _parameter, const int _value)
-	{
-		_parameter.setValue(_parameter.getNormalisableRange().convertTo0to1(
-			static_cast<float>(_value)));
-	}
-
 	void verifyModel(const md::MachineModel _model)
 	{
-		mdJucePlugin::AudioPluginAudioProcessor processor(_model,
-			mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig{}, false);
-		auto& audioProcessor = static_cast<juce::AudioProcessor&>(processor);
-		audioProcessor.prepareToPlay(48000.0, 128);
-		if(!hasLocalFirmware(processor))
+		Harness harness(_model);
+		if(!harness.hasLocalFirmware())
 		{
 			std::cout << "mdAutomationFirmwareTest: SKIP "
-				<< (_model == md::MachineModel::Monomachine ? "MM" : "MD")
+				<< modelName(_model)
 				<< " (firmware unavailable)\n";
 			return;
 		}
+		harness.prepare();
 
-		auto& controller = dynamic_cast<mdJucePlugin::Controller&>(
-			processor.getController());
-		require(waitForSynchronization(processor, controller),
+		auto& audioProcessor = harness.audioProcessor;
+		auto& controller = harness.controller;
+		require(harness.synchronize(),
 			"initial firmware synchronization timed out (global "
 			+ std::to_string(controller.hasAutomationGlobalSnapshot()) + ", kit "
 			+ std::to_string(controller.hasAutomationKitSnapshot()) + ", base "
@@ -115,38 +36,38 @@ namespace
 		require(controller.getAutomationBaseChannel() < 16,
 			"firmware Global has MIDI base channel set to NONE");
 
-		auto& probe = parameter(controller, _model);
+		auto& probe = parameter(controller);
 		const auto beforeTransmitCount =
 			controller.getTransmittedAutomationChangeCount();
 
 		// Make the cache say zero without touching firmware, then require an explicit
 		// repeated/default host write to reach and be consumed by the firmware UART.
 		probe.setValueFromSynth(0, pluginLib::Parameter::Origin::PresetChange);
-		const auto beforeZero = midiTelemetry(processor);
+		const auto beforeZero = harness.telemetry();
 		hostWrite(probe, 0);
 		require(controller.getTransmittedAutomationChangeCount()
 			== beforeTransmitCount + 1,
 			"host write did not produce exactly one automation CC");
-		process(processor, 32);
-		const auto afterZero = midiTelemetry(processor);
+		harness.process(32);
+		const auto afterZero = harness.telemetry();
 		require(afterZero.consumed >= beforeZero.consumed + 3
 			&& afterZero.overflows == beforeZero.overflows,
 			"explicit zero automation CC was not consumed losslessly by firmware");
 
-		const auto beforeChanged = midiTelemetry(processor);
+		const auto beforeChanged = harness.telemetry();
 		hostWrite(probe, 127);
 		require(controller.getTransmittedAutomationChangeCount()
 			== beforeTransmitCount + 2,
 			"changed host write did not produce exactly one automation CC");
-		process(processor, 32);
-		const auto afterChanged = midiTelemetry(processor);
+		harness.process(32);
+		const auto afterChanged = harness.telemetry();
 		require(afterChanged.consumed >= beforeChanged.consumed + 3
 			&& afterChanged.overflows == beforeChanged.overflows,
 			"changed automation CC was not consumed losslessly by firmware");
 
 		const auto beforeStressCount =
 			controller.getTransmittedAutomationChangeCount();
-		const auto beforeStressMidi = midiTelemetry(processor);
+		const auto beforeStressMidi = harness.telemetry();
 		size_t expectedWrites = 0;
 		int ordinal = 0;
 		for(auto* const audioParameter : audioProcessor.getParameters())
@@ -165,32 +86,32 @@ namespace
 			hostWrite(*automationParameter, value);
 			++expectedWrites;
 			if((++ordinal & 31) == 0)
-				process(processor, 4);
+				harness.process(4);
 		}
-		process(processor, 64);
+		harness.process(64);
 		require(controller.getTransmittedAutomationChangeCount()
 			== beforeStressCount + expectedWrites,
 			"automation stress pass did not transmit every host write");
-		const auto afterStressMidi = midiTelemetry(processor);
+		const auto afterStressMidi = harness.telemetry();
 		require(afterStressMidi.consumed
 			>= beforeStressMidi.consumed + expectedWrites * 3
 			&& afterStressMidi.overflows == beforeStressMidi.overflows,
 			"automation stress stream was not consumed losslessly by firmware");
 
 		hostWrite(probe, 47);
-		process(processor, 32);
+		harness.process(32);
 		juce::MemoryBlock savedState;
 		audioProcessor.getStateInformation(savedState);
 		require(!savedState.isEmpty(), "processor produced empty persisted state");
 		hostWrite(probe, 12);
-		process(processor, 32);
+		harness.process(32);
 		require(probe.getUnnormalizedValue() == 12,
 			"pre-restore control write failed");
 		audioProcessor.setStateInformation(savedState.getData(),
 			static_cast<int>(savedState.getSize()));
 		const auto beforeRestoreFlush =
 			controller.getTransmittedAutomationChangeCount();
-		require(waitForSynchronization(processor, controller),
+		require(harness.synchronize(),
 			"state restore did not resynchronize automation");
 		require(probe.getUnnormalizedValue() == 47,
 			"firmware-backed automation value was not restored from DAW state");
@@ -198,9 +119,8 @@ namespace
 			>= beforeRestoreFlush + audioProcessor.getParameters().size(),
 			"DAW-state automation snapshot was not flushed back to firmware");
 
-		audioProcessor.releaseResources();
 		std::cout << "mdAutomationFirmwareTest: "
-			<< (_model == md::MachineModel::Monomachine ? "MM" : "MD")
+			<< modelName(_model)
 			<< " PASS\n";
 	}
 }

--- a/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
@@ -1,0 +1,225 @@
+#include "mdController.h"
+#include "mdPluginProcessor.h"
+
+#include "mdLib/mdautomation.h"
+#include "mdLib/mddevice.h"
+#include "juce_events/juce_events.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace
+{
+	void require(const bool _condition, const std::string& _message)
+	{
+		if(_condition)
+			return;
+		throw std::runtime_error(_message);
+	}
+
+	void process(mdJucePlugin::AudioPluginAudioProcessor& _processor,
+		const int _blocks)
+	{
+		juce::AudioBuffer<float> audio(2, 128);
+		juce::MidiBuffer midi;
+		auto& audioProcessor = static_cast<juce::AudioProcessor&>(_processor);
+		for(int block = 0; block < _blocks; ++block)
+		{
+			audio.clear();
+			midi.clear();
+			audioProcessor.processBlock(audio, midi);
+			_processor.getController().processPendingMidiMessages();
+		}
+	}
+
+	struct MidiTelemetry
+	{
+		uint64_t consumed = 0;
+		size_t overflows = 0;
+	};
+
+	MidiTelemetry midiTelemetry(
+		mdJucePlugin::AudioPluginAudioProcessor& _processor)
+	{
+		MidiTelemetry result;
+		_processor.getPlugin().withDeviceLocked(
+			[&result](synthLib::Device* const _device)
+			{
+				if(const auto* const device = dynamic_cast<md::Device*>(_device))
+				{
+					result.consumed = device->getHardware().midiRxConsumedCount();
+					result.overflows = device->getHardware().midiRxOverflowCount();
+				}
+			});
+		return result;
+	}
+
+	bool waitForSynchronization(mdJucePlugin::AudioPluginAudioProcessor& _processor,
+		mdJucePlugin::Controller& _controller)
+	{
+		for(int attempt = 0; attempt < 2500; ++attempt)
+		{
+			process(_processor, 1);
+			if(_controller.isAutomationSynchronized())
+				return true;
+		}
+		return false;
+	}
+
+	bool hasLocalFirmware(mdJucePlugin::AudioPluginAudioProcessor& _processor)
+	{
+		return _processor.getPlugin().withDeviceLocked(
+			[](synthLib::Device* const _device)
+			{
+				return dynamic_cast<md::Device*>(_device) != nullptr;
+			});
+	}
+
+	pluginLib::Parameter& parameter(mdJucePlugin::Controller& _controller,
+		const md::MachineModel)
+	{
+		auto* const result = _controller.getParameter("Level", 0);
+		require(result != nullptr, "test parameter was not registered");
+		return *result;
+	}
+
+	void hostWrite(pluginLib::Parameter& _parameter, const int _value)
+	{
+		_parameter.setValue(_parameter.getNormalisableRange().convertTo0to1(
+			static_cast<float>(_value)));
+	}
+
+	void verifyModel(const md::MachineModel _model)
+	{
+		mdJucePlugin::AudioPluginAudioProcessor processor(_model,
+			mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig{}, false);
+		auto& audioProcessor = static_cast<juce::AudioProcessor&>(processor);
+		audioProcessor.prepareToPlay(48000.0, 128);
+		if(!hasLocalFirmware(processor))
+		{
+			std::cout << "mdAutomationFirmwareTest: SKIP "
+				<< (_model == md::MachineModel::Monomachine ? "MM" : "MD")
+				<< " (firmware unavailable)\n";
+			return;
+		}
+
+		auto& controller = dynamic_cast<mdJucePlugin::Controller&>(
+			processor.getController());
+		require(waitForSynchronization(processor, controller),
+			"initial firmware synchronization timed out (global "
+			+ std::to_string(controller.hasAutomationGlobalSnapshot()) + ", kit "
+			+ std::to_string(controller.hasAutomationKitSnapshot()) + ", base "
+			+ std::to_string(controller.getAutomationBaseChannel()) + ")");
+		require(controller.getAutomationBaseChannel() < 16,
+			"firmware Global has MIDI base channel set to NONE");
+
+		auto& probe = parameter(controller, _model);
+		const auto beforeTransmitCount =
+			controller.getTransmittedAutomationChangeCount();
+
+		// Make the cache say zero without touching firmware, then require an explicit
+		// repeated/default host write to reach and be consumed by the firmware UART.
+		probe.setValueFromSynth(0, pluginLib::Parameter::Origin::PresetChange);
+		const auto beforeZero = midiTelemetry(processor);
+		hostWrite(probe, 0);
+		require(controller.getTransmittedAutomationChangeCount()
+			== beforeTransmitCount + 1,
+			"host write did not produce exactly one automation CC");
+		process(processor, 32);
+		const auto afterZero = midiTelemetry(processor);
+		require(afterZero.consumed >= beforeZero.consumed + 3
+			&& afterZero.overflows == beforeZero.overflows,
+			"explicit zero automation CC was not consumed losslessly by firmware");
+
+		const auto beforeChanged = midiTelemetry(processor);
+		hostWrite(probe, 127);
+		require(controller.getTransmittedAutomationChangeCount()
+			== beforeTransmitCount + 2,
+			"changed host write did not produce exactly one automation CC");
+		process(processor, 32);
+		const auto afterChanged = midiTelemetry(processor);
+		require(afterChanged.consumed >= beforeChanged.consumed + 3
+			&& afterChanged.overflows == beforeChanged.overflows,
+			"changed automation CC was not consumed losslessly by firmware");
+
+		const auto beforeStressCount =
+			controller.getTransmittedAutomationChangeCount();
+		const auto beforeStressMidi = midiTelemetry(processor);
+		size_t expectedWrites = 0;
+		int ordinal = 0;
+		for(auto* const audioParameter : audioProcessor.getParameters())
+		{
+			auto* const automationParameter = dynamic_cast<pluginLib::Parameter*>(
+				audioParameter);
+			if(!automationParameter)
+				continue;
+			const auto& description = automationParameter->getDescription();
+			const auto mutePage = _model == md::MachineModel::Monomachine
+				? md::automation::monomachine::Mute
+				: md::automation::machinedrum::Mute;
+			if(description.page == mutePage)
+				continue;
+			const auto value = (ordinal * 37 + 19) & 0x7f;
+			hostWrite(*automationParameter, value);
+			++expectedWrites;
+			if((++ordinal & 31) == 0)
+				process(processor, 4);
+		}
+		process(processor, 64);
+		require(controller.getTransmittedAutomationChangeCount()
+			== beforeStressCount + expectedWrites,
+			"automation stress pass did not transmit every host write");
+		const auto afterStressMidi = midiTelemetry(processor);
+		require(afterStressMidi.consumed
+			>= beforeStressMidi.consumed + expectedWrites * 3
+			&& afterStressMidi.overflows == beforeStressMidi.overflows,
+			"automation stress stream was not consumed losslessly by firmware");
+
+		hostWrite(probe, 47);
+		process(processor, 32);
+		juce::MemoryBlock savedState;
+		audioProcessor.getStateInformation(savedState);
+		require(!savedState.isEmpty(), "processor produced empty persisted state");
+		hostWrite(probe, 12);
+		process(processor, 32);
+		require(probe.getUnnormalizedValue() == 12,
+			"pre-restore control write failed");
+		audioProcessor.setStateInformation(savedState.getData(),
+			static_cast<int>(savedState.getSize()));
+		const auto beforeRestoreFlush =
+			controller.getTransmittedAutomationChangeCount();
+		require(waitForSynchronization(processor, controller),
+			"state restore did not resynchronize automation");
+		require(probe.getUnnormalizedValue() == 47,
+			"firmware-backed automation value was not restored from DAW state");
+		require(controller.getTransmittedAutomationChangeCount()
+			>= beforeRestoreFlush + audioProcessor.getParameters().size(),
+			"DAW-state automation snapshot was not flushed back to firmware");
+
+		audioProcessor.releaseResources();
+		std::cout << "mdAutomationFirmwareTest: "
+			<< (_model == md::MachineModel::Monomachine ? "MM" : "MD")
+			<< " PASS\n";
+	}
+}
+
+int main(const int _argc, const char* const* _argv)
+{
+	juce::ScopedJuceInitialiser_GUI juce;
+	try
+	{
+		const auto only = _argc > 1 ? std::string(_argv[1]) : std::string();
+		if(only != "--mm")
+			verifyModel(md::MachineModel::Machinedrum);
+		if(only != "--md")
+			verifyModel(md::MachineModel::Monomachine);
+		return 0;
+	}
+	catch(const std::exception& error)
+	{
+		std::cerr << "mdAutomationFirmwareTest: " << error.what() << '\n';
+		return 1;
+	}
+}

--- a/source/elektron/md/mdJucePlugin/mdAutomationParameterTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationParameterTest.cpp
@@ -1,0 +1,80 @@
+#include "jucePluginLib/parameterdescriptions.h"
+#include "mdLib/mdautomation.h"
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <set>
+#include <string>
+
+namespace
+{
+	void require(const bool _condition, const std::string& _message)
+	{
+		if(_condition)
+			return;
+		std::cerr << "mdAutomationParameterTest: " << _message << '\n';
+		std::exit(1);
+	}
+
+	pluginLib::ParameterDescriptions load(const char* const _filename)
+	{
+		const std::string path = std::string(MD_AUTOMATION_PARAMETER_DIR) + "/" + _filename;
+		std::ifstream file(path, std::ios::binary);
+		require(file.good(), "could not open " + path);
+		return pluginLib::ParameterDescriptions(
+			std::string(std::istreambuf_iterator<char>(file), {}));
+	}
+
+	void verify(const char* const _filename, const md::MachineModel _model,
+		const size_t _trackParameterCount, const uint8_t _trackCount,
+		const size_t _expectedHostParameterCount)
+	{
+		const auto descriptions = load(_filename);
+		require(descriptions.isValid(), descriptions.getErrors());
+		require(descriptions.getDescriptions().size() == _trackParameterCount,
+			std::string(_filename) + " has the wrong description count");
+
+		std::set<std::pair<uint8_t, uint8_t>> addresses;
+		for(const auto& description : descriptions.getDescriptions())
+		{
+			require(!description.isNonPartSensitive(),
+				"automation parameters must belong to firmware tracks");
+
+			if(_model == md::MachineModel::Monomachine
+				&& description.page == md::automation::monomachine::Effects)
+			{
+				if(description.index == 3)
+					require(description.name == "EffectsDelayTime",
+						"MM CC 83 must be labelled Delay Time");
+				if(description.index == 4)
+					require(description.name == "EffectsDelaySend",
+						"MM CC 84 must be labelled Delay Send");
+			}
+
+			require(addresses.emplace(description.page, description.index).second,
+				"duplicate track parameter address");
+			for(uint8_t track = 0; track < _trackCount; ++track)
+			{
+				const md::automation::ParameterChange change{
+					description.page, track, description.index, 0};
+				require(md::automation::encodeParameterChange(_model, change, 0).has_value(),
+					"host parameter has no MIDI mapping");
+			}
+		}
+
+		require(_trackParameterCount * _trackCount
+			== _expectedHostParameterCount, "host parameter count changed");
+	}
+}
+
+int main()
+{
+	verify("parameterDescriptions_md.json", md::MachineModel::Machinedrum,
+		26, md::automation::machinedrum::TrackCount, 416);
+	verify("parameterDescriptions_mm.json", md::MachineModel::Monomachine,
+		58, md::automation::monomachine::TrackCount, 348);
+	std::cout << "mdAutomationParameterTest: PASS\n";
+	return 0;
+}

--- a/source/elektron/md/mdJucePlugin/mdAutomationParameterTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationParameterTest.cpp
@@ -2,6 +2,7 @@
 #include "mdLib/mdautomation.h"
 
 #include <cstdlib>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <iterator>
@@ -27,9 +28,65 @@ namespace
 			std::string(std::istreambuf_iterator<char>(file), {}));
 	}
 
+	void hashByte(uint64_t& _hash, const uint8_t _value)
+	{
+		_hash ^= _value;
+		_hash *= 1099511628211ull;
+	}
+
+	void hashInteger(uint64_t& _hash, const int64_t _value)
+	{
+		for(unsigned int shift = 0; shift < 64; shift += 8)
+			hashByte(_hash, static_cast<uint8_t>(
+				static_cast<uint64_t>(_value) >> shift));
+	}
+
+	void hashString(uint64_t& _hash, const std::string& _value)
+	{
+		hashInteger(_hash, static_cast<int64_t>(_value.size()));
+		for(const auto character : _value)
+			hashByte(_hash, static_cast<uint8_t>(character));
+	}
+
+	uint64_t hostContractFingerprint(
+		const pluginLib::ParameterDescriptions& _descriptions,
+		const uint8_t _trackCount)
+	{
+		uint64_t hash = 14695981039346656037ull;
+		size_t hostIndex = 0;
+		for(uint8_t track = 0; track < _trackCount; ++track)
+		{
+			for(const auto& description : _descriptions.getDescriptions())
+			{
+				// This mirrors Parameter::genId() and Controller::registerParams(). Any
+				// change here is a DAW project/automation compatibility decision.
+				const auto id = std::to_string(description.page) + "_"
+					+ std::to_string(track) + "_"
+					+ std::to_string(description.index);
+				const auto name = "Track " + std::to_string(track + 1) + " "
+					+ description.displayName;
+				hashInteger(hash, static_cast<int64_t>(hostIndex++));
+				hashString(hash, id);
+				hashInteger(hash, description.version);
+				hashString(hash, name);
+				hashInteger(hash, description.range.getStart());
+				hashInteger(hash, description.range.getEnd());
+				hashInteger(hash,
+					description.defaultValue == pluginLib::Description::NoDefaultValue
+						? 0 : description.defaultValue);
+				hashInteger(hash, description.isDiscrete);
+				hashInteger(hash, description.isBool);
+				hashInteger(hash, description.isBipolar);
+				hashInteger(hash, description.step);
+			}
+		}
+		return hash;
+	}
+
 	void verify(const char* const _filename, const md::MachineModel _model,
 		const size_t _trackParameterCount, const uint8_t _trackCount,
-		const size_t _expectedHostParameterCount)
+		const size_t _expectedHostParameterCount,
+		const uint64_t _expectedHostContractFingerprint)
 	{
 		const auto descriptions = load(_filename);
 		require(descriptions.isValid(), descriptions.getErrors());
@@ -66,15 +123,22 @@ namespace
 
 		require(_trackParameterCount * _trackCount
 			== _expectedHostParameterCount, "host parameter count changed");
+		const auto fingerprint = hostContractFingerprint(descriptions, _trackCount);
+		if(fingerprint != _expectedHostContractFingerprint)
+		{
+			std::cerr << _filename << " host contract fingerprint is "
+				<< fingerprint << '\n';
+			require(false, "host parameter IDs/order/names/ranges/defaults changed");
+		}
 	}
 }
 
 int main()
 {
 	verify("parameterDescriptions_md.json", md::MachineModel::Machinedrum,
-		26, md::automation::machinedrum::TrackCount, 416);
+		26, md::automation::machinedrum::TrackCount, 416, 6612241820543455307ull);
 	verify("parameterDescriptions_mm.json", md::MachineModel::Monomachine,
-		58, md::automation::monomachine::TrackCount, 348);
+		58, md::automation::monomachine::TrackCount, 348, 15680169437425968391ull);
 	std::cout << "mdAutomationParameterTest: PASS\n";
 	return 0;
 }

--- a/source/elektron/md/mdJucePlugin/mdAutomationRobustnessTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationRobustnessTest.cpp
@@ -1,191 +1,22 @@
-#include "mdController.h"
-#include "mdPluginProcessor.h"
+#include "mdAutomationTestSupport.h"
 
-#include "mdLib/mdautomation.h"
-#include "mdLib/mddevice.h"
 #include "mdLib/mdsysexautomation.h"
 #include "synthLib/midiTypes.h"
 
 #include "juce_events/juce_events.h"
 
-#include <algorithm>
-#include <atomic>
-#include <chrono>
-#include <cstdint>
+#include <cmath>
 #include <cstring>
 #include <exception>
 #include <iostream>
 #include <map>
-#include <memory>
 #include <random>
-#include <stdexcept>
 #include <string>
-#include <thread>
 #include <vector>
 
 namespace
 {
-	constexpr int g_blockSize = 128;
-
-	void require(const bool _condition, const std::string& _message)
-	{
-		if(_condition)
-			return;
-		throw std::runtime_error(_message);
-	}
-
-	const char* modelName(const md::MachineModel _model)
-	{
-		return _model == md::MachineModel::Monomachine ? "MM" : "MD";
-	}
-
-	struct MidiTelemetry
-	{
-		uint64_t consumed = 0;
-		size_t overflows = 0;
-		uint64_t contentionDrops = 0;
-		uint64_t capacityDrops = 0;
-	};
-
-	class StoppedPlayHead final : public juce::AudioPlayHead
-	{
-	public:
-		juce::Optional<PositionInfo> getPosition() const override
-		{
-			PositionInfo result;
-			result.setIsPlaying(false);
-			result.setIsRecording(false);
-			result.setBpm(120.0);
-			result.setPpqPosition(0.0);
-			return result;
-		}
-	};
-
-	class Harness
-	{
-	public:
-		explicit Harness(const md::MachineModel _model)
-			: model(_model)
-			, processor(_model,
-				mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig{}, false)
-			, audioProcessor(static_cast<juce::AudioProcessor&>(processor))
-			, controller(dynamic_cast<mdJucePlugin::Controller&>(
-				processor.getController()))
-			, audio(2, g_blockSize)
-		{
-			audioProcessor.setPlayHead(&playHead);
-		}
-
-		~Harness()
-		{
-			if(prepared)
-				audioProcessor.releaseResources();
-		}
-
-		bool hasLocalFirmware()
-		{
-			return processor.getPlugin().withDeviceLocked(
-				[](synthLib::Device* const _device)
-				{
-					return dynamic_cast<md::Device*>(_device) != nullptr;
-				});
-		}
-
-		void prepare()
-		{
-			if(prepared)
-				return;
-			audioProcessor.prepareToPlay(48000.0, g_blockSize);
-			prepared = true;
-		}
-
-		void process(const int _blocks)
-		{
-			require(prepared, "attempted to process an unprepared instance");
-			for(int block = 0; block < _blocks; ++block)
-			{
-				audio.clear();
-				midi.clear();
-				audioProcessor.processBlock(audio, midi);
-				controller.processPendingMidiMessages();
-			}
-		}
-
-		bool synchronize(const int _maximumBlocks = 3000)
-		{
-			for(int block = 0; block < _maximumBlocks; ++block)
-			{
-				process(1);
-				if(controller.isAutomationSynchronized())
-					return true;
-			}
-			return false;
-		}
-
-		MidiTelemetry telemetry()
-		{
-			MidiTelemetry result;
-			result.contentionDrops =
-				controller.getRealtimeMidiIngressContentionDropCount();
-			result.capacityDrops =
-				controller.getRealtimeMidiIngressCapacityDropCount();
-			processor.getPlugin().withDeviceLocked(
-				[&result](synthLib::Device* const _device)
-				{
-					if(const auto* const device = dynamic_cast<md::Device*>(_device))
-					{
-						result.consumed = device->getHardware().midiRxConsumedCount();
-						result.overflows = device->getHardware().midiRxOverflowCount();
-					}
-				});
-			return result;
-		}
-
-		const md::MachineModel model;
-		StoppedPlayHead playHead;
-		mdJucePlugin::AudioPluginAudioProcessor processor;
-		juce::AudioProcessor& audioProcessor;
-		mdJucePlugin::Controller& controller;
-
-	private:
-		juce::AudioBuffer<float> audio;
-		juce::MidiBuffer midi;
-		bool prepared = false;
-	};
-
-	std::vector<pluginLib::Parameter*> parameters(Harness& _harness,
-		const bool _includeMutes = true)
-	{
-		std::vector<pluginLib::Parameter*> result;
-		const auto mutePage = _harness.model == md::MachineModel::Monomachine
-			? md::automation::monomachine::Mute
-			: md::automation::machinedrum::Mute;
-		for(auto* const audioParameter : _harness.audioProcessor.getParameters())
-		{
-			auto* const parameter = dynamic_cast<pluginLib::Parameter*>(audioParameter);
-			if(parameter && (_includeMutes
-				|| parameter->getDescription().page != mutePage))
-				result.push_back(parameter);
-		}
-		return result;
-	}
-
-	void hostWrite(pluginLib::Parameter& _parameter, const int _value)
-	{
-		_parameter.setValue(_parameter.getNormalisableRange().convertTo0to1(
-			static_cast<float>(_value)));
-	}
-
-	uint64_t appendDigest(uint64_t _digest,
-		const md::automation::ControlChange& _message)
-	{
-		for(const auto byte : _message)
-		{
-			_digest ^= byte;
-			_digest *= 1099511628211ull;
-		}
-		return _digest;
-	}
+	using namespace mdAutomationTest;
 
 	class ParameterListener final : public juce::AudioProcessorParameter::Listener
 	{
@@ -238,9 +69,15 @@ namespace
 		for(const auto& [parameter, value] : expected)
 			require(parameter->getUnnormalizedValue() == value,
 				"pre-boot queue lost its newest value");
-		_harness.process(96);
+		_harness.process(512);
 		require(_harness.telemetry().overflows == 0,
 			"pre-boot queue overflowed firmware MIDI RX");
+		for(const auto& [parameter, value] : expected)
+		{
+			if(parameter->getDescription().name == "Level")
+				require(parameter->getUnnormalizedValue() == value,
+					"late startup dump overwrote a flushed pre-boot host value");
+		}
 	}
 
 	void verifyExternalNotifications(Harness& _harness)
@@ -514,63 +351,7 @@ namespace
 			"randomized lifecycle overflowed firmware MIDI RX");
 	}
 
-	void verifyFirmwareSoak(Harness& _harness, const size_t _writeCount)
-	{
-		auto allParameters = parameters(_harness, false);
-		std::vector<int> expected(allParameters.size(), -1);
-		std::mt19937 random(0x534f414bu + static_cast<unsigned>(_harness.model));
-		const auto beforeCount =
-			_harness.controller.getTransmittedAutomationChangeCount();
-		const auto beforeMidi = _harness.telemetry();
-		for(size_t write = 0; write < _writeCount; ++write)
-		{
-			const auto index = static_cast<size_t>(random() % allParameters.size());
-			const auto value = static_cast<int>(random() & 0x7f);
-			hostWrite(*allParameters[index], value);
-			expected[index] = value;
-			if((write & 7) == 7)
-				_harness.process(4);
-		}
-		// Firmware echoes and parameter normalization arrive asynchronously. Require
-		// the final Level values to remain correct across a sustained drain window,
-		// rather than sampling the cache at one scheduler-dependent instant.
-		auto levelsMatch = [&]()
-		{
-			for(size_t index = 0; index < allParameters.size(); ++index)
-			{
-				if(expected[index] >= 0
-					&& allParameters[index]->getDescription().name == "Level"
-					&& allParameters[index]->getUnnormalizedValue() != expected[index])
-					return false;
-			}
-			return true;
-		};
-		size_t stableBlocks = 0;
-		for(size_t block = 0; block < 3000 && stableBlocks < 128; ++block)
-		{
-			_harness.process(1);
-			stableBlocks = levelsMatch() ? stableBlocks + 1 : 0;
-		}
-		require(stableBlocks == 128,
-			"soak final Level values did not settle after firmware echoes");
-		const auto afterMidi = _harness.telemetry();
-		const auto afterCount =
-			_harness.controller.getTransmittedAutomationChangeCount();
-		if(afterCount != beforeCount + _writeCount)
-			throw std::runtime_error("soak transmitted "
-				+ std::to_string(afterCount - beforeCount) + " of "
-				+ std::to_string(_writeCount) + " explicit host writes");
-		require(afterMidi.consumed >= beforeMidi.consumed + _writeCount * 3,
-			"firmware did not consume the complete soak stream");
-		require(afterMidi.overflows == beforeMidi.overflows,
-			"soak overflowed firmware MIDI RX");
-		require(afterMidi.contentionDrops == beforeMidi.contentionDrops,
-			"soak dropped firmware output on controller lock contention");
-		require(afterMidi.capacityDrops == beforeMidi.capacityDrops,
-			"soak dropped firmware output at controller queue capacity");
-	}
-
-	void verifyModel(const md::MachineModel _model, const size_t _soakWrites)
+	void verifyModel(const md::MachineModel _model)
 	{
 		Harness harness(_model);
 		if(!harness.hasLocalFirmware())
@@ -583,100 +364,10 @@ namespace
 		verifyExternalNotifications(harness);
 		verifyStateContract(harness);
 		verifyRandomizedLifecycle(harness);
-		verifyFirmwareSoak(harness, _soakWrites);
 		std::cout << "mdAutomationRobustnessTest: " << modelName(_model)
-			<< " PASS (" << _soakWrites << " soak writes)\n";
+			<< " PASS\n";
 	}
 
-	void verifyConcurrentIsolation(const size_t _writeCount)
-	{
-		Harness mdHarness(md::MachineModel::Machinedrum);
-		Harness mmHarness(md::MachineModel::Monomachine);
-		if(!mdHarness.hasLocalFirmware() || !mmHarness.hasLocalFirmware())
-		{
-			std::cout << "mdAutomationRobustnessTest: SKIP multi-instance"
-				" (firmware unavailable)\n";
-			return;
-		}
-		mdHarness.prepare();
-		mmHarness.prepare();
-		std::atomic<bool> start{false};
-		std::exception_ptr mdError;
-		std::exception_ptr mmError;
-		auto run = [&start, _writeCount](Harness& _harness, std::exception_ptr& _error,
-			const uint32_t _seed)
-		{
-			try
-			{
-				while(!start.load(std::memory_order_acquire))
-					std::this_thread::yield();
-				require(_harness.synchronize(),
-					"concurrent instance failed to synchronize");
-				auto allParameters = parameters(_harness, false);
-				allParameters.erase(std::remove_if(allParameters.begin(),
-					allParameters.end(), [](const pluginLib::Parameter* const _parameter)
-					{
-						return _parameter->getDescription().name != "Level";
-					}), allParameters.end());
-				require(!allParameters.empty(),
-					"concurrent instance has no stable Level parameters");
-				std::mt19937 random(_seed);
-				const auto before =
-					_harness.controller.getTransmittedAutomationChangeCount();
-				auto expectedDigest =
-					_harness.controller.getTransmittedAutomationDigest();
-				for(size_t write = 0; write < _writeCount; ++write)
-				{
-					const auto index = static_cast<size_t>(random() % allParameters.size());
-					const auto value = static_cast<int>(random() & 0x7f);
-					const auto& description = allParameters[index]->getDescription();
-					const auto encoded = md::automation::encodeParameterChange(
-						_harness.model,
-						{description.page, allParameters[index]->getPart(),
-							description.index, static_cast<uint8_t>(value)},
-						_harness.controller.getAutomationBaseChannel());
-					require(encoded.has_value(),
-						"concurrent expected automation change did not encode");
-					expectedDigest = appendDigest(expectedDigest, *encoded);
-					hostWrite(*allParameters[index], value);
-					if((write & 7) == 7)
-						_harness.process(4);
-				}
-				_harness.process(192);
-				require(_harness.controller.getTransmittedAutomationChangeCount()
-					== before + _writeCount,
-					"concurrent instance lost or gained automation writes");
-				require(_harness.controller.getTransmittedAutomationDigest()
-					== expectedDigest,
-					std::string("concurrent ") + modelName(_harness.model)
-					+ " automation message sequence was contaminated");
-				const auto snapshot =
-					_harness.controller.createAutomationSnapshot();
-				require(snapshot.size() == 6
-					+ _harness.audioProcessor.getParameters().size() * 4,
-					std::string("concurrent ") + modelName(_harness.model)
-					+ " snapshot shape was contaminated");
-				require(_harness.telemetry().overflows == 0,
-					"concurrent instance overflowed firmware MIDI RX");
-			}
-			catch(...)
-			{
-				_error = std::current_exception();
-			}
-		};
-
-		std::thread mdThread(run, std::ref(mdHarness), std::ref(mdError), 0x4d444d44u);
-		std::thread mmThread(run, std::ref(mmHarness), std::ref(mmError), 0x4d4d4d4du);
-		start.store(true, std::memory_order_release);
-		mdThread.join();
-		mmThread.join();
-		if(mdError)
-			std::rethrow_exception(mdError);
-		if(mmError)
-			std::rethrow_exception(mmError);
-		std::cout << "mdAutomationRobustnessTest: concurrent MD/MM PASS ("
-			<< _writeCount << " writes per instance)\n";
-	}
 }
 
 int main(const int _argc, const char* const* _argv)
@@ -684,12 +375,8 @@ int main(const int _argc, const char* const* _argv)
 	juce::ScopedJuceInitialiser_GUI juce;
 	try
 	{
-		size_t soakWrites = 8192;
-		size_t multiWrites = 2048;
 		bool mdOnly = false;
 		bool mmOnly = false;
-		bool noMulti = false;
-		bool multiOnly = false;
 		for(int argument = 1; argument < _argc; ++argument)
 		{
 			const std::string value(_argv[argument]);
@@ -697,24 +384,11 @@ int main(const int _argc, const char* const* _argv)
 				mdOnly = true;
 			else if(value == "--mm")
 				mmOnly = true;
-			else if(value == "--no-multi")
-				noMulti = true;
-			else if(value == "--multi-only")
-				multiOnly = true;
-			else if(value.rfind("--soak-writes=", 0) == 0)
-				soakWrites = static_cast<size_t>(std::stoul(value.substr(14)));
-			else if(value.rfind("--multi-writes=", 0) == 0)
-				multiWrites = static_cast<size_t>(std::stoul(value.substr(15)));
 		}
-		if(!multiOnly)
-		{
-			if(!mmOnly)
-				verifyModel(md::MachineModel::Machinedrum, soakWrites);
-			if(!mdOnly)
-				verifyModel(md::MachineModel::Monomachine, soakWrites);
-		}
-		if(!noMulti && !mdOnly && !mmOnly)
-			verifyConcurrentIsolation(multiWrites);
+		if(!mmOnly)
+			verifyModel(md::MachineModel::Machinedrum);
+		if(!mdOnly)
+			verifyModel(md::MachineModel::Monomachine);
 		return 0;
 	}
 	catch(const std::exception& error)

--- a/source/elektron/md/mdJucePlugin/mdAutomationRobustnessTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationRobustnessTest.cpp
@@ -1,0 +1,725 @@
+#include "mdController.h"
+#include "mdPluginProcessor.h"
+
+#include "mdLib/mdautomation.h"
+#include "mdLib/mddevice.h"
+#include "mdLib/mdsysexautomation.h"
+#include "synthLib/midiTypes.h"
+
+#include "juce_events/juce_events.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+	constexpr int g_blockSize = 128;
+
+	void require(const bool _condition, const std::string& _message)
+	{
+		if(_condition)
+			return;
+		throw std::runtime_error(_message);
+	}
+
+	const char* modelName(const md::MachineModel _model)
+	{
+		return _model == md::MachineModel::Monomachine ? "MM" : "MD";
+	}
+
+	struct MidiTelemetry
+	{
+		uint64_t consumed = 0;
+		size_t overflows = 0;
+		uint64_t contentionDrops = 0;
+		uint64_t capacityDrops = 0;
+	};
+
+	class StoppedPlayHead final : public juce::AudioPlayHead
+	{
+	public:
+		juce::Optional<PositionInfo> getPosition() const override
+		{
+			PositionInfo result;
+			result.setIsPlaying(false);
+			result.setIsRecording(false);
+			result.setBpm(120.0);
+			result.setPpqPosition(0.0);
+			return result;
+		}
+	};
+
+	class Harness
+	{
+	public:
+		explicit Harness(const md::MachineModel _model)
+			: model(_model)
+			, processor(_model,
+				mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig{}, false)
+			, audioProcessor(static_cast<juce::AudioProcessor&>(processor))
+			, controller(dynamic_cast<mdJucePlugin::Controller&>(
+				processor.getController()))
+			, audio(2, g_blockSize)
+		{
+			audioProcessor.setPlayHead(&playHead);
+		}
+
+		~Harness()
+		{
+			if(prepared)
+				audioProcessor.releaseResources();
+		}
+
+		bool hasLocalFirmware()
+		{
+			return processor.getPlugin().withDeviceLocked(
+				[](synthLib::Device* const _device)
+				{
+					return dynamic_cast<md::Device*>(_device) != nullptr;
+				});
+		}
+
+		void prepare()
+		{
+			if(prepared)
+				return;
+			audioProcessor.prepareToPlay(48000.0, g_blockSize);
+			prepared = true;
+		}
+
+		void process(const int _blocks)
+		{
+			require(prepared, "attempted to process an unprepared instance");
+			for(int block = 0; block < _blocks; ++block)
+			{
+				audio.clear();
+				midi.clear();
+				audioProcessor.processBlock(audio, midi);
+				controller.processPendingMidiMessages();
+			}
+		}
+
+		bool synchronize(const int _maximumBlocks = 3000)
+		{
+			for(int block = 0; block < _maximumBlocks; ++block)
+			{
+				process(1);
+				if(controller.isAutomationSynchronized())
+					return true;
+			}
+			return false;
+		}
+
+		MidiTelemetry telemetry()
+		{
+			MidiTelemetry result;
+			result.contentionDrops =
+				controller.getRealtimeMidiIngressContentionDropCount();
+			result.capacityDrops =
+				controller.getRealtimeMidiIngressCapacityDropCount();
+			processor.getPlugin().withDeviceLocked(
+				[&result](synthLib::Device* const _device)
+				{
+					if(const auto* const device = dynamic_cast<md::Device*>(_device))
+					{
+						result.consumed = device->getHardware().midiRxConsumedCount();
+						result.overflows = device->getHardware().midiRxOverflowCount();
+					}
+				});
+			return result;
+		}
+
+		const md::MachineModel model;
+		StoppedPlayHead playHead;
+		mdJucePlugin::AudioPluginAudioProcessor processor;
+		juce::AudioProcessor& audioProcessor;
+		mdJucePlugin::Controller& controller;
+
+	private:
+		juce::AudioBuffer<float> audio;
+		juce::MidiBuffer midi;
+		bool prepared = false;
+	};
+
+	std::vector<pluginLib::Parameter*> parameters(Harness& _harness,
+		const bool _includeMutes = true)
+	{
+		std::vector<pluginLib::Parameter*> result;
+		const auto mutePage = _harness.model == md::MachineModel::Monomachine
+			? md::automation::monomachine::Mute
+			: md::automation::machinedrum::Mute;
+		for(auto* const audioParameter : _harness.audioProcessor.getParameters())
+		{
+			auto* const parameter = dynamic_cast<pluginLib::Parameter*>(audioParameter);
+			if(parameter && (_includeMutes
+				|| parameter->getDescription().page != mutePage))
+				result.push_back(parameter);
+		}
+		return result;
+	}
+
+	void hostWrite(pluginLib::Parameter& _parameter, const int _value)
+	{
+		_parameter.setValue(_parameter.getNormalisableRange().convertTo0to1(
+			static_cast<float>(_value)));
+	}
+
+	uint64_t appendDigest(uint64_t _digest,
+		const md::automation::ControlChange& _message)
+	{
+		for(const auto byte : _message)
+		{
+			_digest ^= byte;
+			_digest *= 1099511628211ull;
+		}
+		return _digest;
+	}
+
+	class ParameterListener final : public juce::AudioProcessorParameter::Listener
+	{
+	public:
+		void parameterValueChanged(int, const float _newValue) override
+		{
+			lastValue = _newValue;
+			++valueChanges;
+		}
+
+		void parameterGestureChanged(int, bool) override {}
+
+		int valueChanges = 0;
+		float lastValue = -1.0f;
+	};
+
+	class ProcessorListener final : public juce::AudioProcessorListener
+	{
+	public:
+		void audioProcessorParameterChanged(juce::AudioProcessor*, int, float) override {}
+		void audioProcessorChanged(juce::AudioProcessor*,
+			const ChangeDetails& _details) override
+		{
+			if(_details.programChanged)
+				++programChanges;
+		}
+		int programChanges = 0;
+	};
+
+	void verifyQueuedPreBootWrites(Harness& _harness)
+	{
+		auto allParameters = parameters(_harness, false);
+		require(allParameters.size() >= 32, "too few automation parameters");
+		std::mt19937 random(0x4d444157u + static_cast<unsigned>(_harness.model));
+		std::map<pluginLib::Parameter*, int> expected;
+		for(int write = 0; write < 512; ++write)
+		{
+			auto* const parameter = allParameters[random() % 32];
+			const auto value = static_cast<int>(random() & 0x7f);
+			hostWrite(*parameter, value);
+			expected[parameter] = value;
+		}
+		require(_harness.controller.getTransmittedAutomationChangeCount() == 0,
+			"automation escaped before firmware synchronization");
+
+		_harness.prepare();
+		require(_harness.synchronize(), "pre-boot write synchronization timed out");
+		require(_harness.controller.getTransmittedAutomationChangeCount()
+			== expected.size(), "pre-boot queue did not coalesce by address");
+		for(const auto& [parameter, value] : expected)
+			require(parameter->getUnnormalizedValue() == value,
+				"pre-boot queue lost its newest value");
+		_harness.process(96);
+		require(_harness.telemetry().overflows == 0,
+			"pre-boot queue overflowed firmware MIDI RX");
+	}
+
+	void verifyExternalNotifications(Harness& _harness)
+	{
+		auto& controller = _harness.controller;
+		auto& probe = *parameters(_harness, false).front();
+		const auto& description = probe.getDescription();
+		const auto oldValue = probe.getUnnormalizedValue();
+		const auto newValue = (oldValue + 53) & 0x7f;
+		const md::automation::ParameterChange change{
+			description.page, probe.getPart(), description.index,
+			static_cast<uint8_t>(newValue)};
+		const auto encoded = md::automation::encodeParameterChange(_harness.model,
+			change, controller.getAutomationBaseChannel());
+		require(encoded.has_value(), "external notification probe did not encode");
+
+		ParameterListener parameterListener;
+		probe.addListener(&parameterListener);
+		const synthLib::SMidiEvent event(synthLib::MidiEventSource::Physical,
+			(*encoded)[0], (*encoded)[1], (*encoded)[2]);
+		require(controller.parseControllerMessage(event),
+			"external CC was not recognized");
+		require(probe.getUnnormalizedValue() == newValue,
+			"external CC did not update the DAW parameter cache");
+		require(probe.getChangeOrigin() == pluginLib::Parameter::Origin::Midi,
+			"external CC was assigned the wrong origin");
+		require(parameterListener.valueChanges == 1,
+			"external changed CC did not notify the host exactly once");
+		require(std::abs(parameterListener.lastValue - probe.getValue()) < 0.0001f,
+			"external CC host notification carried the wrong value");
+		require(controller.parseControllerMessage(event),
+			"repeated external CC was not recognized");
+		require(parameterListener.valueChanges == 1,
+			"repeated unchanged external CC redundantly notified the host");
+		probe.removeListener(&parameterListener);
+
+		const synthLib::SMidiEvent unmapped(synthLib::MidiEventSource::Physical,
+			(*encoded)[0], 0x7f, 1);
+		require(!controller.parseControllerMessage(unmapped),
+			"unmapped external CC was incorrectly consumed");
+
+		ProcessorListener processorListener;
+		_harness.audioProcessor.addListener(&processorListener);
+		const auto snapshot = controller.createAutomationSnapshot();
+		require(snapshot.size() >= 6, "could not observe current Kit for refresh test");
+		const auto currentKit = snapshot[3];
+
+		const synthLib::SMidiEvent deviceProgramChange(synthLib::MidiEventSource::Device,
+			static_cast<uint8_t>(0xc0 | controller.getAutomationBaseChannel()),
+			currentKit, 0);
+		controller.parseMidiMessage(deviceProgramChange);
+		require(controller.isAutomationSynchronized(),
+			"outgoing firmware Program Change invalidated the Kit snapshot");
+
+		const synthLib::SMidiEvent programChange(synthLib::MidiEventSource::Physical,
+			static_cast<uint8_t>(0xc0 | controller.getAutomationBaseChannel()),
+			currentKit, 0);
+		controller.parseMidiMessage(programChange);
+		require(!controller.isAutomationSynchronized(),
+			"Program Change did not invalidate the Kit snapshot");
+		require(_harness.synchronize(), "Program Change refresh timed out");
+		require(processorListener.programChanges > 0,
+			"Program Change refresh did not tell the host to rescan parameters");
+
+		for(const auto status : {
+			md::automation::sysex::StatusParameter::Kit,
+			md::automation::sysex::StatusParameter::Pattern})
+		{
+			const pluginLib::SysEx setStatus{
+				0xf0, 0x00, 0x20, 0x3c,
+				static_cast<uint8_t>(_harness.model == md::MachineModel::Monomachine
+					? 0x03 : 0x02),
+				0x00, 0x71, static_cast<uint8_t>(status), currentKit, 0xf7};
+			controller.parseSysexMessage(setStatus, synthLib::MidiEventSource::Physical);
+			require(!controller.isAutomationSynchronized(),
+				"external SET STATUS did not invalidate the Kit snapshot");
+			require(_harness.synchronize(), "external SET STATUS refresh timed out");
+		}
+		_harness.audioProcessor.removeListener(&processorListener);
+	}
+
+	std::vector<uint8_t> withoutAutomationChunk(const std::vector<uint8_t>& _state)
+	{
+		std::vector<uint8_t> result;
+		size_t position = 0;
+		bool removed = false;
+		while(position < _state.size())
+		{
+			require(_state.size() - position >= 12, "malformed saved chunk header");
+			uint32_t length = 0;
+			std::memcpy(&length, _state.data() + position + 8, sizeof(length));
+			const auto chunkSize = static_cast<size_t>(12) + length;
+			require(chunkSize <= _state.size() - position,
+				"malformed saved chunk length");
+			const auto isAutomation = std::memcmp(
+				_state.data() + position, "AUTO", 4) == 0;
+			if(isAutomation)
+				removed = true;
+			else
+				result.insert(result.end(), _state.begin() + position,
+					_state.begin() + position + chunkSize);
+			position += chunkSize;
+		}
+		require(removed, "saved custom state did not contain AUTO chunk");
+		return result;
+	}
+
+	void verifyStateContract(Harness& _harness)
+	{
+		auto& controller = _harness.controller;
+		const auto baseline = controller.createAutomationSnapshot();
+		require(!baseline.empty(), "automation snapshot was empty");
+		require(controller.createAutomationSnapshot() == baseline,
+			"unchanged automation snapshots were not deterministic");
+
+		auto expectInvalid = [&](std::vector<uint8_t> _snapshot,
+			const std::string& _description)
+		{
+			require(!controller.restoreAutomationSnapshot(_snapshot),
+				"accepted invalid snapshot: " + _description);
+			require(controller.createAutomationSnapshot() == baseline,
+				"invalid snapshot mutated live state: " + _description);
+		};
+
+		expectInvalid({}, "empty");
+		for(const auto length : {size_t{1}, size_t{5}, size_t{6},
+			baseline.size() - 1})
+			expectInvalid(std::vector<uint8_t>(baseline.begin(),
+				baseline.begin() + length), "truncated");
+		auto invalid = baseline;
+		invalid.push_back(0);
+		expectInvalid(invalid, "trailing byte");
+		invalid = baseline;
+		invalid[0] = 2;
+		expectInvalid(invalid, "future version");
+		invalid = baseline;
+		invalid[1] ^= 1;
+		expectInvalid(invalid, "wrong model");
+		invalid = baseline;
+		invalid[2] = 16;
+		expectInvalid(invalid, "invalid MIDI base");
+		invalid = baseline;
+		invalid[3] = _harness.model == md::MachineModel::Monomachine ? 128 : 64;
+		expectInvalid(invalid, "invalid Kit");
+		invalid = baseline;
+		invalid[4] = invalid[5] = 0;
+		expectInvalid(invalid, "wrong parameter count");
+		invalid = baseline;
+		invalid[6] = 0xff;
+		expectInvalid(invalid, "unknown address");
+		invalid = baseline;
+		invalid[10] = invalid[6];
+		invalid[11] = invalid[7];
+		invalid[12] = invalid[8];
+		expectInvalid(invalid, "duplicate address");
+		invalid = baseline;
+		invalid[9] = 0xff;
+		expectInvalid(invalid, "out-of-range value");
+
+		require(controller.restoreAutomationSnapshot(baseline),
+			"valid snapshot was rejected");
+		require(controller.createAutomationSnapshot().empty(),
+			"restoring a snapshot did not require firmware resynchronization");
+		require(_harness.synchronize(), "valid snapshot replay timed out");
+		require(controller.createAutomationSnapshot() == baseline,
+			"snapshot round trip changed persisted automation state");
+
+		std::vector<uint8_t> customState;
+		_harness.processor.saveCustomData(customState);
+		const auto legacyState = withoutAutomationChunk(customState);
+		require(_harness.processor.loadCustomData(legacyState),
+			"legacy custom state without AUTO was rejected");
+		controller.onStateLoaded();
+		require(_harness.synchronize(),
+			"legacy state without AUTO did not resynchronize from firmware");
+		require(!controller.createAutomationSnapshot().empty(),
+			"legacy state did not reconstruct an automation snapshot");
+
+		juce::MemoryBlock fullState;
+		_harness.audioProcessor.getStateInformation(fullState);
+		require(fullState.getSize() > 64, "full plugin state was unexpectedly small");
+		for(const auto length : {size_t{1}, size_t{8}, fullState.getSize() / 2,
+			fullState.getSize() - 1})
+		{
+			try
+			{
+				_harness.audioProcessor.setStateInformation(fullState.getData(),
+					static_cast<int>(length));
+			}
+			catch(...)
+			{
+				require(false, "truncated plugin state escaped an exception");
+			}
+		}
+		_harness.audioProcessor.setStateInformation(fullState.getData(),
+			static_cast<int>(fullState.getSize()));
+		require(_harness.synchronize(), "full plugin state recovery timed out");
+	}
+
+	void verifyRandomizedLifecycle(Harness& _harness)
+	{
+		auto allParameters = parameters(_harness, false);
+		std::mt19937 random(0x4c494645u + static_cast<unsigned>(_harness.model));
+		auto saved = _harness.controller.createAutomationSnapshot();
+		require(!saved.empty(), "lifecycle test could not save initial state");
+		const auto before = _harness.telemetry();
+		for(int operation = 0; operation < 384; ++operation)
+		{
+			switch(random() % 7)
+			{
+			case 0:
+			case 1:
+			{
+				auto& parameter = *allParameters[random() % allParameters.size()];
+				hostWrite(parameter, static_cast<int>(random() & 0x7f));
+				break;
+			}
+			case 2:
+				_harness.controller.requestAutomationState();
+				break;
+			case 3:
+				if(_harness.controller.isAutomationSynchronized())
+				{
+					const auto candidate =
+						_harness.controller.createAutomationSnapshot();
+					if(!candidate.empty())
+						saved = candidate;
+				}
+				break;
+			case 4:
+				if(operation % 47 == 0)
+					require(_harness.controller.restoreAutomationSnapshot(saved),
+						"randomized lifecycle rejected a saved snapshot");
+				break;
+			case 5:
+				if(_harness.controller.getAutomationBaseChannel() < 16)
+				{
+					auto& parameter = *allParameters[random() % allParameters.size()];
+					const auto& description = parameter.getDescription();
+					const md::automation::ParameterChange change{
+						description.page, parameter.getPart(), description.index,
+						static_cast<uint8_t>(random() & 0x7f)};
+					if(const auto encoded = md::automation::encodeParameterChange(
+						_harness.model, change,
+						_harness.controller.getAutomationBaseChannel()))
+						_harness.controller.parseControllerMessage({
+							synthLib::MidiEventSource::Physical,
+							(*encoded)[0], (*encoded)[1], (*encoded)[2]});
+				}
+				break;
+			case 6:
+			{
+				auto malformed = saved;
+				malformed.resize(random() % 6);
+				require(!_harness.controller.restoreAutomationSnapshot(malformed),
+					"randomized lifecycle accepted malformed state");
+				break;
+			}
+			}
+			_harness.process(static_cast<int>(1 + random() % 4));
+			if((operation & 15) == 15)
+				require(_harness.synchronize(),
+					"randomized lifecycle synchronization timed out");
+		}
+		require(_harness.synchronize(), "final randomized lifecycle sync timed out");
+		_harness.process(128);
+		const auto after = _harness.telemetry();
+		require(after.consumed > before.consumed,
+			"randomized lifecycle produced no firmware MIDI traffic");
+		require(after.overflows == before.overflows,
+			"randomized lifecycle overflowed firmware MIDI RX");
+	}
+
+	void verifyFirmwareSoak(Harness& _harness, const size_t _writeCount)
+	{
+		auto allParameters = parameters(_harness, false);
+		std::vector<int> expected(allParameters.size(), -1);
+		std::mt19937 random(0x534f414bu + static_cast<unsigned>(_harness.model));
+		const auto beforeCount =
+			_harness.controller.getTransmittedAutomationChangeCount();
+		const auto beforeMidi = _harness.telemetry();
+		for(size_t write = 0; write < _writeCount; ++write)
+		{
+			const auto index = static_cast<size_t>(random() % allParameters.size());
+			const auto value = static_cast<int>(random() & 0x7f);
+			hostWrite(*allParameters[index], value);
+			expected[index] = value;
+			if((write & 7) == 7)
+				_harness.process(4);
+		}
+		// Firmware echoes and parameter normalization arrive asynchronously. Require
+		// the final Level values to remain correct across a sustained drain window,
+		// rather than sampling the cache at one scheduler-dependent instant.
+		auto levelsMatch = [&]()
+		{
+			for(size_t index = 0; index < allParameters.size(); ++index)
+			{
+				if(expected[index] >= 0
+					&& allParameters[index]->getDescription().name == "Level"
+					&& allParameters[index]->getUnnormalizedValue() != expected[index])
+					return false;
+			}
+			return true;
+		};
+		size_t stableBlocks = 0;
+		for(size_t block = 0; block < 3000 && stableBlocks < 128; ++block)
+		{
+			_harness.process(1);
+			stableBlocks = levelsMatch() ? stableBlocks + 1 : 0;
+		}
+		require(stableBlocks == 128,
+			"soak final Level values did not settle after firmware echoes");
+		const auto afterMidi = _harness.telemetry();
+		const auto afterCount =
+			_harness.controller.getTransmittedAutomationChangeCount();
+		if(afterCount != beforeCount + _writeCount)
+			throw std::runtime_error("soak transmitted "
+				+ std::to_string(afterCount - beforeCount) + " of "
+				+ std::to_string(_writeCount) + " explicit host writes");
+		require(afterMidi.consumed >= beforeMidi.consumed + _writeCount * 3,
+			"firmware did not consume the complete soak stream");
+		require(afterMidi.overflows == beforeMidi.overflows,
+			"soak overflowed firmware MIDI RX");
+		require(afterMidi.contentionDrops == beforeMidi.contentionDrops,
+			"soak dropped firmware output on controller lock contention");
+		require(afterMidi.capacityDrops == beforeMidi.capacityDrops,
+			"soak dropped firmware output at controller queue capacity");
+	}
+
+	void verifyModel(const md::MachineModel _model, const size_t _soakWrites)
+	{
+		Harness harness(_model);
+		if(!harness.hasLocalFirmware())
+		{
+			std::cout << "mdAutomationRobustnessTest: SKIP " << modelName(_model)
+				<< " (firmware unavailable)\n";
+			return;
+		}
+		verifyQueuedPreBootWrites(harness);
+		verifyExternalNotifications(harness);
+		verifyStateContract(harness);
+		verifyRandomizedLifecycle(harness);
+		verifyFirmwareSoak(harness, _soakWrites);
+		std::cout << "mdAutomationRobustnessTest: " << modelName(_model)
+			<< " PASS (" << _soakWrites << " soak writes)\n";
+	}
+
+	void verifyConcurrentIsolation(const size_t _writeCount)
+	{
+		Harness mdHarness(md::MachineModel::Machinedrum);
+		Harness mmHarness(md::MachineModel::Monomachine);
+		if(!mdHarness.hasLocalFirmware() || !mmHarness.hasLocalFirmware())
+		{
+			std::cout << "mdAutomationRobustnessTest: SKIP multi-instance"
+				" (firmware unavailable)\n";
+			return;
+		}
+		mdHarness.prepare();
+		mmHarness.prepare();
+		std::atomic<bool> start{false};
+		std::exception_ptr mdError;
+		std::exception_ptr mmError;
+		auto run = [&start, _writeCount](Harness& _harness, std::exception_ptr& _error,
+			const uint32_t _seed)
+		{
+			try
+			{
+				while(!start.load(std::memory_order_acquire))
+					std::this_thread::yield();
+				require(_harness.synchronize(),
+					"concurrent instance failed to synchronize");
+				auto allParameters = parameters(_harness, false);
+				allParameters.erase(std::remove_if(allParameters.begin(),
+					allParameters.end(), [](const pluginLib::Parameter* const _parameter)
+					{
+						return _parameter->getDescription().name != "Level";
+					}), allParameters.end());
+				require(!allParameters.empty(),
+					"concurrent instance has no stable Level parameters");
+				std::mt19937 random(_seed);
+				const auto before =
+					_harness.controller.getTransmittedAutomationChangeCount();
+				auto expectedDigest =
+					_harness.controller.getTransmittedAutomationDigest();
+				for(size_t write = 0; write < _writeCount; ++write)
+				{
+					const auto index = static_cast<size_t>(random() % allParameters.size());
+					const auto value = static_cast<int>(random() & 0x7f);
+					const auto& description = allParameters[index]->getDescription();
+					const auto encoded = md::automation::encodeParameterChange(
+						_harness.model,
+						{description.page, allParameters[index]->getPart(),
+							description.index, static_cast<uint8_t>(value)},
+						_harness.controller.getAutomationBaseChannel());
+					require(encoded.has_value(),
+						"concurrent expected automation change did not encode");
+					expectedDigest = appendDigest(expectedDigest, *encoded);
+					hostWrite(*allParameters[index], value);
+					if((write & 7) == 7)
+						_harness.process(4);
+				}
+				_harness.process(192);
+				require(_harness.controller.getTransmittedAutomationChangeCount()
+					== before + _writeCount,
+					"concurrent instance lost or gained automation writes");
+				require(_harness.controller.getTransmittedAutomationDigest()
+					== expectedDigest,
+					std::string("concurrent ") + modelName(_harness.model)
+					+ " automation message sequence was contaminated");
+				const auto snapshot =
+					_harness.controller.createAutomationSnapshot();
+				require(snapshot.size() == 6
+					+ _harness.audioProcessor.getParameters().size() * 4,
+					std::string("concurrent ") + modelName(_harness.model)
+					+ " snapshot shape was contaminated");
+				require(_harness.telemetry().overflows == 0,
+					"concurrent instance overflowed firmware MIDI RX");
+			}
+			catch(...)
+			{
+				_error = std::current_exception();
+			}
+		};
+
+		std::thread mdThread(run, std::ref(mdHarness), std::ref(mdError), 0x4d444d44u);
+		std::thread mmThread(run, std::ref(mmHarness), std::ref(mmError), 0x4d4d4d4du);
+		start.store(true, std::memory_order_release);
+		mdThread.join();
+		mmThread.join();
+		if(mdError)
+			std::rethrow_exception(mdError);
+		if(mmError)
+			std::rethrow_exception(mmError);
+		std::cout << "mdAutomationRobustnessTest: concurrent MD/MM PASS ("
+			<< _writeCount << " writes per instance)\n";
+	}
+}
+
+int main(const int _argc, const char* const* _argv)
+{
+	juce::ScopedJuceInitialiser_GUI juce;
+	try
+	{
+		size_t soakWrites = 8192;
+		size_t multiWrites = 2048;
+		bool mdOnly = false;
+		bool mmOnly = false;
+		bool noMulti = false;
+		bool multiOnly = false;
+		for(int argument = 1; argument < _argc; ++argument)
+		{
+			const std::string value(_argv[argument]);
+			if(value == "--md")
+				mdOnly = true;
+			else if(value == "--mm")
+				mmOnly = true;
+			else if(value == "--no-multi")
+				noMulti = true;
+			else if(value == "--multi-only")
+				multiOnly = true;
+			else if(value.rfind("--soak-writes=", 0) == 0)
+				soakWrites = static_cast<size_t>(std::stoul(value.substr(14)));
+			else if(value.rfind("--multi-writes=", 0) == 0)
+				multiWrites = static_cast<size_t>(std::stoul(value.substr(15)));
+		}
+		if(!multiOnly)
+		{
+			if(!mmOnly)
+				verifyModel(md::MachineModel::Machinedrum, soakWrites);
+			if(!mdOnly)
+				verifyModel(md::MachineModel::Monomachine, soakWrites);
+		}
+		if(!noMulti && !mdOnly && !mmOnly)
+			verifyConcurrentIsolation(multiWrites);
+		return 0;
+	}
+	catch(const std::exception& error)
+	{
+		std::cerr << "mdAutomationRobustnessTest: " << error.what() << '\n';
+		return 1;
+	}
+}

--- a/source/elektron/md/mdJucePlugin/mdAutomationSoakTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationSoakTest.cpp
@@ -1,0 +1,268 @@
+#include "mdAutomationTestSupport.h"
+
+#include <algorithm>
+#include <atomic>
+#include <exception>
+#include <iostream>
+#include <random>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+	using namespace mdAutomationTest;
+
+	uint64_t appendDigest(uint64_t _digest,
+		const md::automation::ControlChange& _message)
+	{
+		for(const auto byte : _message)
+		{
+			_digest ^= byte;
+			_digest *= 1099511628211ull;
+		}
+		return _digest;
+	}
+
+	void verifyFirmwareSoak(Harness& _harness, const size_t _writeCount)
+	{
+		auto allParameters = parameters(_harness, false);
+		std::vector<int> expected(allParameters.size(), -1);
+		std::mt19937 random(0x534f414bu + static_cast<unsigned>(_harness.model));
+		const auto beforeCount =
+			_harness.controller.getTransmittedAutomationChangeCount();
+		const auto beforeMidi = _harness.telemetry();
+		for(size_t write = 0; write < _writeCount; ++write)
+		{
+			const auto index = static_cast<size_t>(random() % allParameters.size());
+			const auto value = static_cast<int>(random() & 0x7f);
+			hostWrite(*allParameters[index], value);
+			expected[index] = value;
+			if((write & 7) == 7)
+				_harness.process(4);
+		}
+
+		// Firmware echoes and parameter normalization arrive asynchronously. Require
+		// the final Level values to remain correct across a sustained drain window,
+		// rather than sampling the cache at one scheduler-dependent instant.
+		auto levelsMatch = [&]()
+		{
+			for(size_t index = 0; index < allParameters.size(); ++index)
+			{
+				if(expected[index] >= 0
+					&& allParameters[index]->getDescription().name == "Level"
+					&& allParameters[index]->getUnnormalizedValue() != expected[index])
+					return false;
+			}
+			return true;
+		};
+		size_t stableBlocks = 0;
+		for(size_t block = 0; block < 3000 && stableBlocks < 128; ++block)
+		{
+			_harness.process(1);
+			stableBlocks = levelsMatch() ? stableBlocks + 1 : 0;
+		}
+		if(stableBlocks != 128)
+		{
+			for(size_t index = 0; index < allParameters.size(); ++index)
+			{
+				if(expected[index] >= 0
+					&& allParameters[index]->getDescription().name == "Level"
+					&& allParameters[index]->getUnnormalizedValue() != expected[index])
+					throw std::runtime_error("soak final Level did not settle for track "
+						+ std::to_string(allParameters[index]->getPart() + 1)
+						+ ": expected " + std::to_string(expected[index])
+						+ ", observed " + std::to_string(
+							allParameters[index]->getUnnormalizedValue()));
+			}
+			throw std::runtime_error(
+				"soak final Level values did not remain stable");
+		}
+
+		const auto afterMidi = _harness.telemetry();
+		const auto afterCount =
+			_harness.controller.getTransmittedAutomationChangeCount();
+		if(afterCount != beforeCount + _writeCount)
+			throw std::runtime_error("soak transmitted "
+				+ std::to_string(afterCount - beforeCount) + " of "
+				+ std::to_string(_writeCount) + " explicit host writes");
+		require(afterMidi.consumed >= beforeMidi.consumed + _writeCount * 3,
+			"firmware did not consume the complete soak stream");
+		require(afterMidi.overflows == beforeMidi.overflows,
+			"soak overflowed firmware MIDI RX");
+		require(afterMidi.contentionDrops == beforeMidi.contentionDrops,
+			"soak dropped firmware output on controller lock contention");
+		require(afterMidi.capacityDrops == beforeMidi.capacityDrops,
+			"soak dropped firmware output at controller queue capacity");
+	}
+
+	void verifyModel(const md::MachineModel _model, const size_t _writeCount)
+	{
+		Harness harness(_model);
+		if(!harness.hasLocalFirmware())
+		{
+			std::cout << "mdAutomationSoakTest: SKIP " << modelName(_model)
+				<< " (firmware unavailable)\n";
+			return;
+		}
+		harness.prepare();
+		require(harness.synchronize(), "soak firmware synchronization timed out");
+		// Synchronization completes once the authoritative dumps are applied, while
+		// unrelated startup MIDI can still be in flight. Establish a quiet baseline
+		// so this steady-state test does not depend on another suite draining it.
+		harness.process(256);
+		verifyFirmwareSoak(harness, _writeCount);
+		std::cout << "mdAutomationSoakTest: " << modelName(_model)
+			<< " PASS (" << _writeCount << " writes)\n";
+	}
+
+	void verifyConcurrentIsolation(const size_t _writeCount)
+	{
+		Harness mdHarness(md::MachineModel::Machinedrum);
+		Harness mmHarness(md::MachineModel::Monomachine);
+		if(!mdHarness.hasLocalFirmware() || !mmHarness.hasLocalFirmware())
+		{
+			std::cout << "mdAutomationSoakTest: SKIP multi-instance"
+				" (firmware unavailable)\n";
+			return;
+		}
+		mdHarness.prepare();
+		mmHarness.prepare();
+		std::atomic<bool> start{false};
+		std::exception_ptr mdError;
+		std::exception_ptr mmError;
+		auto run = [&start, _writeCount](Harness& _harness,
+			std::exception_ptr& _error, const uint32_t _seed)
+		{
+			try
+			{
+				while(!start.load(std::memory_order_acquire))
+					std::this_thread::yield();
+				require(_harness.synchronize(),
+					"concurrent instance failed to synchronize");
+				auto allParameters = parameters(_harness, false);
+				allParameters.erase(std::remove_if(allParameters.begin(),
+					allParameters.end(), [](const pluginLib::Parameter* const _parameter)
+					{
+						return _parameter->getDescription().name != "Level";
+					}), allParameters.end());
+				require(!allParameters.empty(),
+					"concurrent instance has no stable Level parameters");
+
+				std::mt19937 random(_seed);
+				const auto beforeCount =
+					_harness.controller.getTransmittedAutomationChangeCount();
+				const auto beforeMidi = _harness.telemetry();
+				auto expectedDigest =
+					_harness.controller.getTransmittedAutomationDigest();
+				for(size_t write = 0; write < _writeCount; ++write)
+				{
+					const auto index =
+						static_cast<size_t>(random() % allParameters.size());
+					const auto value = static_cast<int>(random() & 0x7f);
+					const auto& description = allParameters[index]->getDescription();
+					const auto encoded = md::automation::encodeParameterChange(
+						_harness.model,
+						{description.page, allParameters[index]->getPart(),
+							description.index, static_cast<uint8_t>(value)},
+						_harness.controller.getAutomationBaseChannel());
+					require(encoded.has_value(),
+						"concurrent expected automation change did not encode");
+					expectedDigest = appendDigest(expectedDigest, *encoded);
+					hostWrite(*allParameters[index], value);
+					if((write & 7) == 7)
+						_harness.process(4);
+				}
+				_harness.process(192);
+
+				require(_harness.controller.getTransmittedAutomationChangeCount()
+					== beforeCount + _writeCount,
+					"concurrent instance lost or gained automation writes");
+				require(_harness.controller.getTransmittedAutomationDigest()
+					== expectedDigest,
+					std::string("concurrent ") + modelName(_harness.model)
+					+ " automation message sequence was contaminated");
+				const auto snapshot =
+					_harness.controller.createAutomationSnapshot();
+				require(snapshot.size() == 6
+					+ _harness.audioProcessor.getParameters().size() * 4,
+					std::string("concurrent ") + modelName(_harness.model)
+					+ " snapshot shape was contaminated");
+				const auto afterMidi = _harness.telemetry();
+				require(afterMidi.overflows == beforeMidi.overflows,
+					"concurrent instance overflowed firmware MIDI RX");
+				require(afterMidi.contentionDrops == beforeMidi.contentionDrops,
+					"concurrent instance dropped firmware output on contention");
+				require(afterMidi.capacityDrops == beforeMidi.capacityDrops,
+					"concurrent instance dropped firmware output at capacity");
+			}
+			catch(...)
+			{
+				_error = std::current_exception();
+			}
+		};
+
+		std::thread mdThread(run, std::ref(mdHarness), std::ref(mdError),
+			0x4d444d44u);
+		std::thread mmThread(run, std::ref(mmHarness), std::ref(mmError),
+			0x4d4d4d4du);
+		start.store(true, std::memory_order_release);
+		mdThread.join();
+		mmThread.join();
+		if(mdError)
+			std::rethrow_exception(mdError);
+		if(mmError)
+			std::rethrow_exception(mmError);
+		std::cout << "mdAutomationSoakTest: concurrent MD/MM PASS ("
+			<< _writeCount << " writes per instance)\n";
+	}
+}
+
+int main(const int _argc, const char* const* _argv)
+{
+	juce::ScopedJuceInitialiser_GUI juce;
+	try
+	{
+		size_t soakWrites = 256;
+		size_t multiWrites = 128;
+		bool mdOnly = false;
+		bool mmOnly = false;
+		bool noMulti = false;
+		bool multiOnly = false;
+		for(int argument = 1; argument < _argc; ++argument)
+		{
+			const std::string value(_argv[argument]);
+			if(value == "--md")
+				mdOnly = true;
+			else if(value == "--mm")
+				mmOnly = true;
+			else if(value == "--no-multi")
+				noMulti = true;
+			else if(value == "--multi-only")
+				multiOnly = true;
+			else if(value.rfind("--soak-writes=", 0) == 0)
+				soakWrites = static_cast<size_t>(std::stoul(value.substr(14)));
+			else if(value.rfind("--multi-writes=", 0) == 0)
+				multiWrites = static_cast<size_t>(std::stoul(value.substr(15)));
+			else
+				require(false, "unknown argument: " + value);
+		}
+		require(soakWrites > 0 && multiWrites > 0,
+			"write counts must be positive");
+		if(!multiOnly)
+		{
+			if(!mmOnly)
+				verifyModel(md::MachineModel::Machinedrum, soakWrites);
+			if(!mdOnly)
+				verifyModel(md::MachineModel::Monomachine, soakWrites);
+		}
+		if(!noMulti && !mdOnly && !mmOnly)
+			verifyConcurrentIsolation(multiWrites);
+		return 0;
+	}
+	catch(const std::exception& error)
+	{
+		std::cerr << "mdAutomationSoakTest: " << error.what() << '\n';
+		return 1;
+	}
+}

--- a/source/elektron/md/mdJucePlugin/mdAutomationTestSupport.h
+++ b/source/elektron/md/mdJucePlugin/mdAutomationTestSupport.h
@@ -1,0 +1,171 @@
+#pragma once
+
+#include "mdController.h"
+#include "mdPluginProcessor.h"
+
+#include "mdLib/mdautomation.h"
+#include "mdLib/mddevice.h"
+
+#include "juce_events/juce_events.h"
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace mdAutomationTest
+{
+	constexpr int BlockSize = 128;
+
+	inline void require(const bool _condition, const std::string& _message)
+	{
+		if(_condition)
+			return;
+		throw std::runtime_error(_message);
+	}
+
+	inline const char* modelName(const md::MachineModel _model)
+	{
+		return _model == md::MachineModel::Monomachine ? "MM" : "MD";
+	}
+
+	struct MidiTelemetry
+	{
+		uint64_t consumed = 0;
+		size_t overflows = 0;
+		uint64_t contentionDrops = 0;
+		uint64_t capacityDrops = 0;
+	};
+
+	class StoppedPlayHead final : public juce::AudioPlayHead
+	{
+	public:
+		juce::Optional<PositionInfo> getPosition() const override
+		{
+			PositionInfo result;
+			result.setIsPlaying(false);
+			result.setIsRecording(false);
+			result.setBpm(120.0);
+			result.setPpqPosition(0.0);
+			return result;
+		}
+	};
+
+	class Harness
+	{
+	public:
+		explicit Harness(const md::MachineModel _model)
+			: model(_model)
+			, processor(_model,
+				mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig{}, false)
+			, audioProcessor(static_cast<juce::AudioProcessor&>(processor))
+			, controller(dynamic_cast<mdJucePlugin::Controller&>(
+				processor.getController()))
+			, audio(2, BlockSize)
+		{
+			audioProcessor.setPlayHead(&playHead);
+		}
+
+		~Harness()
+		{
+			if(prepared)
+				audioProcessor.releaseResources();
+		}
+
+		bool hasLocalFirmware()
+		{
+			return processor.getPlugin().withDeviceLocked(
+				[](synthLib::Device* const _device)
+				{
+					return dynamic_cast<md::Device*>(_device) != nullptr;
+				});
+		}
+
+		void prepare()
+		{
+			if(prepared)
+				return;
+			audioProcessor.prepareToPlay(48000.0, BlockSize);
+			prepared = true;
+		}
+
+		void process(const int _blocks)
+		{
+			require(prepared, "attempted to process an unprepared instance");
+			for(int block = 0; block < _blocks; ++block)
+			{
+				audio.clear();
+				midi.clear();
+				audioProcessor.processBlock(audio, midi);
+				controller.processPendingMidiMessages();
+			}
+		}
+
+		bool synchronize(const int _maximumBlocks = 3000)
+		{
+			for(int block = 0; block < _maximumBlocks; ++block)
+			{
+				process(1);
+				if(controller.isAutomationSynchronized())
+					return true;
+			}
+			return false;
+		}
+
+		MidiTelemetry telemetry()
+		{
+			MidiTelemetry result;
+			result.contentionDrops =
+				controller.getRealtimeMidiIngressContentionDropCount();
+			result.capacityDrops =
+				controller.getRealtimeMidiIngressCapacityDropCount();
+			processor.getPlugin().withDeviceLocked(
+				[&result](synthLib::Device* const _device)
+				{
+					if(const auto* const device = dynamic_cast<md::Device*>(_device))
+					{
+						result.consumed =
+							device->getHardware().midiRxConsumedCount();
+						result.overflows =
+							device->getHardware().midiRxOverflowCount();
+					}
+				});
+			return result;
+		}
+
+		const md::MachineModel model;
+		StoppedPlayHead playHead;
+		mdJucePlugin::AudioPluginAudioProcessor processor;
+		juce::AudioProcessor& audioProcessor;
+		mdJucePlugin::Controller& controller;
+
+	private:
+		juce::AudioBuffer<float> audio;
+		juce::MidiBuffer midi;
+		bool prepared = false;
+	};
+
+	inline std::vector<pluginLib::Parameter*> parameters(Harness& _harness,
+		const bool _includeMutes = true)
+	{
+		std::vector<pluginLib::Parameter*> result;
+		const auto mutePage = _harness.model == md::MachineModel::Monomachine
+			? md::automation::monomachine::Mute
+			: md::automation::machinedrum::Mute;
+		for(auto* const audioParameter : _harness.audioProcessor.getParameters())
+		{
+			auto* const parameter =
+				dynamic_cast<pluginLib::Parameter*>(audioParameter);
+			if(parameter && (_includeMutes
+				|| parameter->getDescription().page != mutePage))
+				result.push_back(parameter);
+		}
+		return result;
+	}
+
+	inline void hostWrite(pluginLib::Parameter& _parameter, const int _value)
+	{
+		_parameter.setValue(_parameter.getNormalisableRange().convertTo0to1(
+			static_cast<float>(_value)));
+	}
+}

--- a/source/elektron/md/mdJucePlugin/mdController.cpp
+++ b/source/elektron/md/mdJucePlugin/mdController.cpp
@@ -13,6 +13,8 @@ namespace mdJucePlugin
 {
 	namespace
 	{
+		constexpr uint64_t g_dumpRequestRetryMs = 2000;
+
 		class AutomationParameter final : public pluginLib::Parameter
 		{
 		public:
@@ -162,6 +164,8 @@ namespace mdJucePlugin
 		m_haveKit.store(false, std::memory_order_release);
 		m_currentGlobal.store(0xff, std::memory_order_release);
 		m_currentKit.store(0xff, std::memory_order_release);
+		m_globalDumpRequestMs.store(0, std::memory_order_release);
+		m_kitDumpRequestMs.store(0, std::memory_order_release);
 		sendMissingSynchronizationRequests();
 	}
 
@@ -169,6 +173,7 @@ namespace mdJucePlugin
 	{
 		m_automationReady.store(false, std::memory_order_release);
 		m_haveKit.store(false, std::memory_order_release);
+		m_kitDumpRequestMs.store(0, std::memory_order_release);
 		sendMissingSynchronizationRequests();
 	}
 
@@ -181,6 +186,11 @@ namespace mdJucePlugin
 	void Controller::sendMissingSynchronizationRequests()
 	{
 		m_lastSynchronizationRequestMs.store(milliseconds(), std::memory_order_release);
+		// Do not accumulate status requests in the plug-in MIDI queue while the
+		// firmware DSPs are still booting. Once consumed, those duplicates can yield
+		// late Kit dumps that overwrite host writes after synchronization completed.
+		if(!firmwareReadyForAutomation())
+			return;
 		if(!m_haveGlobal.load(std::memory_order_acquire))
 			sendSysEx(toPluginSysex(md::automation::sysex::statusRequest(m_model,
 				md::automation::sysex::StatusParameter::Global)));
@@ -338,13 +348,21 @@ namespace mdJucePlugin
 			{
 				const auto previous = m_currentGlobal.exchange(status->value,
 					std::memory_order_acq_rel);
-				if(!m_haveGlobal.load(std::memory_order_acquire)
-					|| previous != status->value)
+				const auto changed = previous != status->value;
+				if(!m_haveGlobal.load(std::memory_order_acquire) || changed)
 				{
 					m_automationReady.store(false, std::memory_order_release);
 					m_haveGlobal.store(false, std::memory_order_release);
-					sendSysEx(toPluginSysex(md::automation::sysex::globalRequest(
-						m_model, status->value)));
+					const auto now = milliseconds();
+					const auto requested =
+						m_globalDumpRequestMs.load(std::memory_order_acquire);
+					if(changed || requested == 0
+						|| now - requested >= g_dumpRequestRetryMs)
+					{
+						m_globalDumpRequestMs.store(now, std::memory_order_release);
+						sendSysEx(toPluginSysex(md::automation::sysex::globalRequest(
+							m_model, status->value)));
+					}
 				}
 				return true;
 			}
@@ -352,13 +370,21 @@ namespace mdJucePlugin
 			{
 				const auto previous = m_currentKit.exchange(status->value,
 					std::memory_order_acq_rel);
-				if(!m_haveKit.load(std::memory_order_acquire)
-					|| previous != status->value)
+				const auto changed = previous != status->value;
+				if(!m_haveKit.load(std::memory_order_acquire) || changed)
 				{
 					m_automationReady.store(false, std::memory_order_release);
 					m_haveKit.store(false, std::memory_order_release);
-					sendSysEx(toPluginSysex(md::automation::sysex::kitRequest(
-						m_model, status->value)));
+					const auto now = milliseconds();
+					const auto requested =
+						m_kitDumpRequestMs.load(std::memory_order_acquire);
+					if(changed || requested == 0
+						|| now - requested >= g_dumpRequestRetryMs)
+					{
+						m_kitDumpRequestMs.store(now, std::memory_order_release);
+						sendSysEx(toPluginSysex(md::automation::sysex::kitRequest(
+							m_model, status->value)));
+					}
 				}
 				return true;
 			}
@@ -372,6 +398,7 @@ namespace mdJucePlugin
 		{
 			m_baseChannel.store(*channel, std::memory_order_release);
 			m_haveGlobal.store(true, std::memory_order_release);
+			m_globalDumpRequestMs.store(0, std::memory_order_release);
 			completeSynchronizationIfReady();
 			return true;
 		}
@@ -381,6 +408,7 @@ namespace mdJucePlugin
 		{
 			applyKitParameters(*parameters);
 			m_haveKit.store(true, std::memory_order_release);
+			m_kitDumpRequestMs.store(0, std::memory_order_release);
 			completeSynchronizationIfReady();
 			return true;
 		}
@@ -398,6 +426,7 @@ namespace mdJucePlugin
 				m_currentGlobal.store(_message[8], std::memory_order_release);
 				m_automationReady.store(false, std::memory_order_release);
 				m_haveGlobal.store(false, std::memory_order_release);
+				m_globalDumpRequestMs.store(milliseconds(), std::memory_order_release);
 				sendSysEx(toPluginSysex(md::automation::sysex::globalRequest(
 					m_model, _message[8])));
 			}

--- a/source/elektron/md/mdJucePlugin/mdController.cpp
+++ b/source/elektron/md/mdJucePlugin/mdController.cpp
@@ -160,6 +160,7 @@ namespace mdJucePlugin
 		m_automationReady.store(false, std::memory_order_release);
 		m_haveGlobal.store(false, std::memory_order_release);
 		m_haveKit.store(false, std::memory_order_release);
+		m_currentGlobal.store(0xff, std::memory_order_release);
 		m_currentKit.store(0xff, std::memory_order_release);
 		sendMissingSynchronizationRequests();
 	}
@@ -241,6 +242,19 @@ namespace mdJucePlugin
 		if(const auto message = md::automation::encodeParameterChange(
 			m_model, _change, getAutomationBaseChannel()))
 		{
+			auto observed = m_transmittedAutomationDigest.load(std::memory_order_relaxed);
+			for(;;)
+			{
+				auto desired = observed;
+				for(const auto byte : *message)
+				{
+					desired ^= byte;
+					desired *= 1099511628211ull;
+				}
+				if(m_transmittedAutomationDigest.compare_exchange_weak(observed,
+					desired, std::memory_order_release, std::memory_order_relaxed))
+					break;
+			}
 			m_transmittedAutomationChanges.fetch_add(1, std::memory_order_release);
 			sendMidiEvent((*message)[0], (*message)[1], (*message)[2]);
 		}
@@ -321,11 +335,19 @@ namespace mdJucePlugin
 			switch(status->parameter)
 			{
 			case md::automation::sysex::StatusParameter::Global:
-				m_automationReady.store(false, std::memory_order_release);
-				m_haveGlobal.store(false, std::memory_order_release);
-				sendSysEx(toPluginSysex(md::automation::sysex::globalRequest(
-					m_model, status->value)));
+			{
+				const auto previous = m_currentGlobal.exchange(status->value,
+					std::memory_order_acq_rel);
+				if(!m_haveGlobal.load(std::memory_order_acquire)
+					|| previous != status->value)
+				{
+					m_automationReady.store(false, std::memory_order_release);
+					m_haveGlobal.store(false, std::memory_order_release);
+					sendSysEx(toPluginSysex(md::automation::sysex::globalRequest(
+						m_model, status->value)));
+				}
 				return true;
+			}
 			case md::automation::sysex::StatusParameter::Kit:
 			{
 				const auto previous = m_currentKit.exchange(status->value,
@@ -373,6 +395,7 @@ namespace mdJucePlugin
 			if(_message[7] == static_cast<uint8_t>(
 				md::automation::sysex::StatusParameter::Global))
 			{
+				m_currentGlobal.store(_message[8], std::memory_order_release);
 				m_automationReady.store(false, std::memory_order_release);
 				m_haveGlobal.store(false, std::memory_order_release);
 				sendSysEx(toPluginSysex(md::automation::sysex::globalRequest(
@@ -409,7 +432,10 @@ namespace mdJucePlugin
 	bool Controller::parseMidiMessage(const synthLib::SMidiEvent& _event)
 	{
 		const auto handled = pluginLib::Controller::parseMidiMessage(_event);
-		if(_event.sysex.empty() && (_event.a & 0xf0) == 0xc0)
+		// Device-origin Program Change is outgoing firmware MIDI (for example from
+		// an MM MIDI machine), not an instruction selecting the plug-in's Kit.
+		if(_event.source != synthLib::MidiEventSource::Device
+			&& _event.sysex.empty() && (_event.a & 0xf0) == 0xc0)
 			requestKitState();
 		return handled;
 	}

--- a/source/elektron/md/mdJucePlugin/mdController.cpp
+++ b/source/elektron/md/mdJucePlugin/mdController.cpp
@@ -1,13 +1,416 @@
 #include "mdController.h"
 
 #include "mdPluginProcessor.h"
+#include "mdLib/mdautomation.h"
+#include "mdLib/mddevice.h"
+#include "mdLib/mdsysexautomation.h"
+
+#include <algorithm>
+#include <chrono>
+#include <set>
 
 namespace mdJucePlugin
 {
-	Controller::Controller(AudioPluginAudioProcessor& _p) : pluginLib::Controller(_p)
+	namespace
 	{
-		registerParams(_p);
+		class AutomationParameter final : public pluginLib::Parameter
+		{
+		public:
+			using pluginLib::Parameter::Parameter;
+
+		protected:
+			bool shouldSendRepeatedHostValues() const override { return true; }
+		};
+
+		pluginLib::SysEx toPluginSysex(
+			const md::automation::sysex::Message& _message)
+		{
+			return pluginLib::SysEx(_message.begin(), _message.end());
+		}
+	}
+
+	Controller::Controller(AudioPluginAudioProcessor& _p)
+		: pluginLib::Controller(_p, _p.getModel() == md::MachineModel::Monomachine
+			? "parameterDescriptions_mm.json" : "parameterDescriptions_md.json")
+		, m_model(_p.getModel())
+	{
+		registerParams(_p, [](const uint8_t _part, const bool _nonPartSensitive)
+		{
+			return _nonPartSensitive ? juce::String("Global")
+				: juce::String("Track ") + juce::String(_part + 1);
+		});
+
+		// Give mute (which is not part of a Kit dump) a defined initial cache value.
+		// The other values are replaced by the firmware snapshot below.
+		for(const auto& [address, parameters] : getExposedParameters())
+		{
+			(void)address;
+			for(auto* const parameter : parameters)
+				parameter->setValueFromSynth(parameter->getDefault(),
+					pluginLib::Parameter::Origin::PresetChange);
+		}
+
+		requestAutomationState();
 	}
 
 	Controller::~Controller() = default;
+
+	uint8_t Controller::getPartCount() const
+	{
+		return m_model == md::MachineModel::Monomachine
+			? md::automation::monomachine::TrackCount
+			: md::automation::machinedrum::TrackCount;
+	}
+
+	pluginLib::Parameter* Controller::createParameter(
+		pluginLib::Controller& _controller,
+		const pluginLib::Description& _description, const uint8_t _part,
+		const int _uid, const pluginLib::Parameter::PartFormatter& _formatter)
+	{
+		return new AutomationParameter(_controller, _description, _part, _uid,
+			_formatter);
+	}
+
+	void Controller::onStateLoaded()
+	{
+		requestAutomationState();
+	}
+
+	std::vector<uint8_t> Controller::createAutomationSnapshot() const
+	{
+		if(!m_haveGlobal.load(std::memory_order_acquire)
+			|| m_currentKit.load(std::memory_order_acquire) == 0xff)
+			return {};
+		std::vector<uint8_t> result;
+		result.reserve(6 + getExposedParameters().size() * 4);
+		result.push_back(1);
+		result.push_back(static_cast<uint8_t>(m_model));
+		result.push_back(getAutomationBaseChannel());
+		result.push_back(m_currentKit.load(std::memory_order_acquire));
+		const auto count = static_cast<uint16_t>(getExposedParameters().size());
+		result.push_back(static_cast<uint8_t>(count >> 8));
+		result.push_back(static_cast<uint8_t>(count & 0xff));
+		for(const auto& [address, parameters] : getExposedParameters())
+		{
+			if(parameters.empty())
+				continue;
+			result.push_back(address.page);
+			result.push_back(address.partNum);
+			result.push_back(address.paramNum);
+			result.push_back(static_cast<uint8_t>(std::clamp(
+				parameters.front()->getUnnormalizedValue(), 0, 127)));
+		}
+		return result;
+	}
+
+	bool Controller::restoreAutomationSnapshot(
+		const std::vector<uint8_t>& _snapshot)
+	{
+		if(_snapshot.size() < 6 || _snapshot[0] != 1
+			|| _snapshot[1] != static_cast<uint8_t>(m_model))
+			return false;
+		const auto count = static_cast<size_t>((_snapshot[4] << 8) | _snapshot[5]);
+		const auto kitCount = m_model == md::MachineModel::Monomachine ? 128 : 64;
+		if(_snapshot.size() != 6 + count * 4
+			|| count != getExposedParameters().size()
+			|| !(_snapshot[2] < 16 || _snapshot[2] == 0x7f)
+			|| _snapshot[3] >= kitCount)
+			return false;
+		std::set<Address> addresses;
+		for(size_t position = 6; position < _snapshot.size(); position += 4)
+		{
+			const Address address{_snapshot[position], _snapshot[position + 1],
+				_snapshot[position + 2]};
+			if(_snapshot[position + 3] > 127 || !addresses.insert(address).second
+				|| findSynthParam(address.track, address.page, address.index).empty())
+				return false;
+		}
+
+		m_automationReady.store(false, std::memory_order_release);
+		m_baseChannel.store(_snapshot[2], std::memory_order_release);
+		m_currentKit.store(_snapshot[3], std::memory_order_release);
+		std::map<Address, pluginLib::ParamValue> restored;
+		for(size_t position = 6; position < _snapshot.size(); position += 4)
+		{
+			const Address address{_snapshot[position], _snapshot[position + 1],
+				_snapshot[position + 2]};
+			const auto& parameters = findSynthParam(_snapshot[position + 1],
+				_snapshot[position], _snapshot[position + 2]);
+			if(parameters.empty())
+				return false;
+			for(auto* const parameter : parameters)
+				parameter->setValueFromSynth(_snapshot[position + 3],
+					pluginLib::Parameter::Origin::PresetChange);
+			restored[address] = _snapshot[position + 3];
+		}
+		{
+			const std::lock_guard lock(m_pendingMutex);
+			for(const auto& [address, value] : restored)
+				m_pendingChanges[address] = value;
+		}
+		m_haveGlobal.store(false, std::memory_order_release);
+		m_haveKit.store(false, std::memory_order_release);
+		getProcessor().updateHostDisplay(
+			juce::AudioProcessorListener::ChangeDetails().withProgramChanged(true));
+		return true;
+	}
+
+	void Controller::requestAutomationState()
+	{
+		m_automationReady.store(false, std::memory_order_release);
+		m_haveGlobal.store(false, std::memory_order_release);
+		m_haveKit.store(false, std::memory_order_release);
+		m_currentKit.store(0xff, std::memory_order_release);
+		sendMissingSynchronizationRequests();
+	}
+
+	void Controller::requestKitState()
+	{
+		m_automationReady.store(false, std::memory_order_release);
+		m_haveKit.store(false, std::memory_order_release);
+		sendMissingSynchronizationRequests();
+	}
+
+	uint64_t Controller::milliseconds()
+	{
+		return std::chrono::duration_cast<std::chrono::milliseconds>(
+			std::chrono::steady_clock::now().time_since_epoch()).count();
+	}
+
+	void Controller::sendMissingSynchronizationRequests()
+	{
+		m_lastSynchronizationRequestMs.store(milliseconds(), std::memory_order_release);
+		if(!m_haveGlobal.load(std::memory_order_acquire))
+			sendSysEx(toPluginSysex(md::automation::sysex::statusRequest(m_model,
+				md::automation::sysex::StatusParameter::Global)));
+		if(!m_haveKit.load(std::memory_order_acquire))
+			sendSysEx(toPluginSysex(md::automation::sysex::statusRequest(m_model,
+				md::automation::sysex::StatusParameter::Kit)));
+	}
+
+	void Controller::onControllerTimer()
+	{
+		completeSynchronizationIfReady();
+		const auto now = milliseconds();
+		if(m_automationReady.load(std::memory_order_acquire))
+		{
+			// Firmware Global is authoritative for the MIDI channel, and a front-panel
+			// kit selection bypasses the controller. Poll their tiny status messages;
+			// only a changed kit number causes the much larger Kit dump.
+			if(now - m_lastStatePollMs.load(std::memory_order_acquire) < 5000)
+				return;
+			m_lastStatePollMs.store(now, std::memory_order_release);
+			sendSysEx(toPluginSysex(md::automation::sysex::statusRequest(m_model,
+				md::automation::sysex::StatusParameter::Global)));
+			sendSysEx(toPluginSysex(md::automation::sysex::statusRequest(m_model,
+				md::automation::sysex::StatusParameter::Kit)));
+			return;
+		}
+		if(now - m_lastSynchronizationRequestMs.load(std::memory_order_acquire) < 500)
+			return;
+		sendMissingSynchronizationRequests();
+	}
+
+	void Controller::sendParameterChange(const pluginLib::Parameter& _parameter,
+		const pluginLib::ParamValue _value, pluginLib::Parameter::Origin)
+	{
+		const auto& description = _parameter.getDescription();
+		const md::automation::ParameterChange change{
+			description.page,
+			_parameter.getPart(),
+			description.index,
+			static_cast<uint8_t>(std::clamp<pluginLib::ParamValue>(_value, 0, 127))
+		};
+		if(!m_automationReady.load(std::memory_order_acquire)
+			|| getAutomationBaseChannel() == 0x7f)
+		{
+			const std::lock_guard lock(m_pendingMutex);
+			if(!m_automationReady.load(std::memory_order_relaxed)
+				|| getAutomationBaseChannel() == 0x7f)
+			{
+				m_pendingChanges[{change.page, change.track, change.index}] = _value;
+				return;
+			}
+		}
+		transmitParameterChange(change);
+	}
+
+	void Controller::transmitParameterChange(
+		const md::automation::ParameterChange& _change)
+	{
+		if(const auto message = md::automation::encodeParameterChange(
+			m_model, _change, getAutomationBaseChannel()))
+		{
+			m_transmittedAutomationChanges.fetch_add(1, std::memory_order_release);
+			sendMidiEvent((*message)[0], (*message)[1], (*message)[2]);
+		}
+	}
+
+	void Controller::applyKitParameters(
+		const std::vector<md::automation::ParameterChange>& _changes)
+	{
+		for(const auto& change : _changes)
+		{
+			const auto& parameters = findSynthParam(change.track, change.page,
+				change.index);
+			for(auto* const parameter : parameters)
+				parameter->setValueFromSynth(change.value,
+					pluginLib::Parameter::Origin::PresetChange);
+		}
+		getProcessor().updateHostDisplay(
+			juce::AudioProcessorListener::ChangeDetails().withProgramChanged(true));
+	}
+
+	void Controller::completeSynchronizationIfReady()
+	{
+		if(!m_haveGlobal.load(std::memory_order_acquire)
+			|| !m_haveKit.load(std::memory_order_acquire)
+			|| !firmwareReadyForAutomation())
+			return;
+
+		// Writes can arrive on the host audio thread while a dump is being applied.
+		// Keep draining until no such write remains, then publish the lock-free ready
+		// state. This preserves the newest host value over the older firmware snapshot.
+		for(;;)
+		{
+			std::map<Address, pluginLib::ParamValue> pending;
+			{
+				const std::lock_guard lock(m_pendingMutex);
+				if(m_pendingChanges.empty())
+				{
+					m_lastStatePollMs.store(milliseconds(), std::memory_order_release);
+					m_automationReady.store(true, std::memory_order_release);
+					return;
+				}
+				pending.swap(m_pendingChanges);
+			}
+
+			for(const auto& [address, value] : pending)
+			{
+				const auto clamped = static_cast<uint8_t>(
+					std::clamp<pluginLib::ParamValue>(value, 0, 127));
+				const auto& parameters = findSynthParam(address.track, address.page,
+					address.index);
+				for(auto* const parameter : parameters)
+					parameter->setValueFromSynth(clamped,
+						pluginLib::Parameter::Origin::HostAutomation);
+				transmitParameterChange({address.page, address.track, address.index,
+					clamped});
+			}
+		}
+	}
+
+	bool Controller::firmwareReadyForAutomation() const
+	{
+		bool ready = true;
+		getProcessor().getPlugin().withDeviceLocked(
+			[&ready](synthLib::Device* const _device)
+			{
+				if(const auto* const device = dynamic_cast<md::Device*>(_device))
+					ready = device->getHardware().isAudioReady();
+			});
+		return ready;
+	}
+
+	bool Controller::parseSysexMessage(const pluginLib::SysEx& _message,
+		synthLib::MidiEventSource)
+	{
+		if(const auto status = md::automation::sysex::parseStatusResponse(
+			m_model, _message))
+		{
+			switch(status->parameter)
+			{
+			case md::automation::sysex::StatusParameter::Global:
+				m_automationReady.store(false, std::memory_order_release);
+				m_haveGlobal.store(false, std::memory_order_release);
+				sendSysEx(toPluginSysex(md::automation::sysex::globalRequest(
+					m_model, status->value)));
+				return true;
+			case md::automation::sysex::StatusParameter::Kit:
+			{
+				const auto previous = m_currentKit.exchange(status->value,
+					std::memory_order_acq_rel);
+				if(!m_haveKit.load(std::memory_order_acquire)
+					|| previous != status->value)
+				{
+					m_automationReady.store(false, std::memory_order_release);
+					m_haveKit.store(false, std::memory_order_release);
+					sendSysEx(toPluginSysex(md::automation::sysex::kitRequest(
+						m_model, status->value)));
+				}
+				return true;
+			}
+			case md::automation::sysex::StatusParameter::Pattern:
+				return true;
+			}
+		}
+
+		if(const auto channel = md::automation::sysex::parseBaseChannel(
+			m_model, _message))
+		{
+			m_baseChannel.store(*channel, std::memory_order_release);
+			m_haveGlobal.store(true, std::memory_order_release);
+			completeSynchronizationIfReady();
+			return true;
+		}
+
+		if(const auto parameters = md::automation::sysex::parseKitParameters(
+			m_model, _message))
+		{
+			applyKitParameters(*parameters);
+			m_haveKit.store(true, std::memory_order_release);
+			completeSynchronizationIfReady();
+			return true;
+		}
+
+		// External SET STATUS messages can change the active Global, selected Kit,
+		// or Pattern without going through the controller. Refresh after the firmware
+		// consumes the same queued MIDI event.
+		if(_message.size() == 10 && _message[0] == 0xf0
+			&& _message[4] == (m_model == md::MachineModel::Monomachine ? 0x03 : 0x02)
+			&& _message[6] == 0x71)
+		{
+			if(_message[7] == static_cast<uint8_t>(
+				md::automation::sysex::StatusParameter::Global))
+			{
+				m_automationReady.store(false, std::memory_order_release);
+				m_haveGlobal.store(false, std::memory_order_release);
+				sendSysEx(toPluginSysex(md::automation::sysex::globalRequest(
+					m_model, _message[8])));
+			}
+			else if(_message[7] == static_cast<uint8_t>(
+				md::automation::sysex::StatusParameter::Kit)
+				|| _message[7] == static_cast<uint8_t>(
+					md::automation::sysex::StatusParameter::Pattern))
+			{
+				requestKitState();
+			}
+		}
+		return false;
+	}
+
+	bool Controller::parseControllerMessage(const synthLib::SMidiEvent& _event)
+	{
+		const auto change = md::automation::decodeParameterChange(m_model,
+			{_event.a, _event.b, _event.c}, getAutomationBaseChannel());
+		if(!change)
+			return false;
+
+		const auto& parameters = findSynthParam(change->track, change->page,
+			change->index);
+		if(parameters.empty())
+			return false;
+		const auto origin = midiEventSourceToParameterOrigin(_event.source);
+		for(auto* const parameter : parameters)
+			parameter->setValueFromSynth(change->value, origin);
+		return true;
+	}
+
+	bool Controller::parseMidiMessage(const synthLib::SMidiEvent& _event)
+	{
+		const auto handled = pluginLib::Controller::parseMidiMessage(_event);
+		if(_event.sysex.empty() && (_event.a & 0xf0) == 0xc0)
+			requestKitState();
+		return handled;
+	}
 }

--- a/source/elektron/md/mdJucePlugin/mdController.h
+++ b/source/elektron/md/mdJucePlugin/mdController.h
@@ -50,6 +50,10 @@ namespace mdJucePlugin
 		{
 			return m_transmittedAutomationChanges.load(std::memory_order_acquire);
 		}
+		uint64_t getTransmittedAutomationDigest() const
+		{
+			return m_transmittedAutomationDigest.load(std::memory_order_acquire);
+		}
 		void requestAutomationState();
 		std::vector<uint8_t> createAutomationSnapshot() const;
 		bool restoreAutomationSnapshot(const std::vector<uint8_t>& _snapshot);
@@ -89,6 +93,8 @@ namespace mdJucePlugin
 		std::atomic<uint64_t> m_lastSynchronizationRequestMs{0};
 		std::atomic<uint64_t> m_lastStatePollMs{0};
 		std::atomic<uint64_t> m_transmittedAutomationChanges{0};
+		std::atomic<uint64_t> m_transmittedAutomationDigest{14695981039346656037ull};
+		std::atomic<uint8_t> m_currentGlobal{0xff};
 		std::atomic<uint8_t> m_currentKit{0xff};
 		std::mutex m_pendingMutex;
 		std::map<Address, pluginLib::ParamValue> m_pendingChanges;

--- a/source/elektron/md/mdJucePlugin/mdController.h
+++ b/source/elektron/md/mdJucePlugin/mdController.h
@@ -1,6 +1,12 @@
 #pragma once
 
 #include "jucePluginLib/controller.h"
+#include "mdLib/mdautomation.h"
+#include "mdLib/mdtypes.h"
+
+#include <atomic>
+#include <map>
+#include <mutex>
 
 namespace mdJucePlugin
 {
@@ -12,17 +18,80 @@ namespace mdJucePlugin
 		explicit Controller(AudioPluginAudioProcessor& _p);
 		~Controller() override;
 
-		// The Machinedrum front panel is driven directly (LCD framebuffer + panel events),
-		// not through the parameter/sysex system, so these are minimal no-ops for now.
-		void onStateLoaded() override {}
+		void onStateLoaded() override;
 
-		uint8_t getPartCount() const override { return 1; }
+		uint8_t getPartCount() const override;
 
-		bool parseSysexMessage(const pluginLib::SysEx&, synthLib::MidiEventSource) override { return false; }
+		bool parseSysexMessage(const pluginLib::SysEx&,
+			synthLib::MidiEventSource) override;
+		bool parseControllerMessage(const synthLib::SMidiEvent& _event) override;
+		bool parseMidiMessage(const synthLib::SMidiEvent& _event) override;
 
-		void sendParameterChange(const pluginLib::Parameter& _parameter, pluginLib::ParamValue _value, pluginLib::Parameter::Origin _origin) override {}
+		void sendParameterChange(const pluginLib::Parameter& _parameter,
+			pluginLib::ParamValue _value, pluginLib::Parameter::Origin _origin) override;
+
+		bool isAutomationSynchronized() const
+		{
+			return m_automationReady.load(std::memory_order_acquire);
+		}
+		uint8_t getAutomationBaseChannel() const
+		{
+			return m_baseChannel.load(std::memory_order_acquire);
+		}
+		bool hasAutomationGlobalSnapshot() const
+		{
+			return m_haveGlobal.load(std::memory_order_acquire);
+		}
+		bool hasAutomationKitSnapshot() const
+		{
+			return m_haveKit.load(std::memory_order_acquire);
+		}
+		uint64_t getTransmittedAutomationChangeCount() const
+		{
+			return m_transmittedAutomationChanges.load(std::memory_order_acquire);
+		}
+		void requestAutomationState();
+		std::vector<uint8_t> createAutomationSnapshot() const;
+		bool restoreAutomationSnapshot(const std::vector<uint8_t>& _snapshot);
 
 	private:
+		struct Address
+		{
+			uint8_t page;
+			uint8_t track;
+			uint8_t index;
+
+			bool operator<(const Address& _other) const
+			{
+				if(page != _other.page) return page < _other.page;
+				if(track != _other.track) return track < _other.track;
+				return index < _other.index;
+			}
+		};
+
+		pluginLib::Parameter* createParameter(pluginLib::Controller& _controller,
+			const pluginLib::Description& _description, uint8_t _part, int _uid,
+			const pluginLib::Parameter::PartFormatter& _formatter) override;
+		void requestKitState();
+		void transmitParameterChange(const md::automation::ParameterChange& _change);
+		void completeSynchronizationIfReady();
+		bool firmwareReadyForAutomation() const;
+		void applyKitParameters(const std::vector<md::automation::ParameterChange>& _changes);
+		void onControllerTimer() override;
+		void sendMissingSynchronizationRequests();
+		static uint64_t milliseconds();
+
+		const md::MachineModel m_model;
+		std::atomic<uint8_t> m_baseChannel{0x7f};
+		std::atomic<bool> m_haveGlobal{false};
+		std::atomic<bool> m_haveKit{false};
+		std::atomic<bool> m_automationReady{false};
+		std::atomic<uint64_t> m_lastSynchronizationRequestMs{0};
+		std::atomic<uint64_t> m_lastStatePollMs{0};
+		std::atomic<uint64_t> m_transmittedAutomationChanges{0};
+		std::atomic<uint8_t> m_currentKit{0xff};
+		std::mutex m_pendingMutex;
+		std::map<Address, pluginLib::ParamValue> m_pendingChanges;
 		JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Controller)
 	};
 }

--- a/source/elektron/md/mdJucePlugin/mdController.h
+++ b/source/elektron/md/mdJucePlugin/mdController.h
@@ -92,6 +92,8 @@ namespace mdJucePlugin
 		std::atomic<bool> m_automationReady{false};
 		std::atomic<uint64_t> m_lastSynchronizationRequestMs{0};
 		std::atomic<uint64_t> m_lastStatePollMs{0};
+		std::atomic<uint64_t> m_globalDumpRequestMs{0};
+		std::atomic<uint64_t> m_kitDumpRequestMs{0};
 		std::atomic<uint64_t> m_transmittedAutomationChanges{0};
 		std::atomic<uint64_t> m_transmittedAutomationDigest{14695981039346656037ull};
 		std::atomic<uint8_t> m_currentGlobal{0xff};

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
@@ -14,6 +14,8 @@
 
 #include "synthLib/deviceException.h"
 
+#include "baseLib/binarystream.h"
+
 #include <utility>
 
 namespace
@@ -67,6 +69,30 @@ namespace
 
 namespace mdJucePlugin
 {
+	void AudioPluginAudioProcessor::saveChunkData(baseLib::BinaryStream& _stream)
+	{
+		jucePluginEditorLib::Processor::saveChunkData(_stream);
+		const auto& controller = dynamic_cast<const Controller&>(getController());
+		const auto snapshot = controller.createAutomationSnapshot();
+		if(!snapshot.empty())
+		{
+			baseLib::ChunkWriter chunk(_stream, "AUTO", 1);
+			_stream.write(snapshot);
+		}
+	}
+
+	void AudioPluginAudioProcessor::loadChunkData(baseLib::ChunkReader& _reader)
+	{
+		jucePluginEditorLib::Processor::loadChunkData(_reader);
+		_reader.add("AUTO", 1, [this](baseLib::BinaryStream& _stream, uint32_t)
+		{
+			std::vector<uint8_t> snapshot;
+			_stream.read(snapshot);
+			auto& controller = dynamic_cast<Controller&>(getController());
+			(void)controller.restoreAutomationSnapshot(snapshot);
+		});
+	}
+
 	AudioPluginAudioProcessor::AudioPluginAudioProcessor()
 		: AudioPluginAudioProcessor(g_defaultModel)
 	{

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
@@ -35,6 +35,8 @@ namespace mdJucePlugin
 		void getRemoteDeviceParams(synthLib::DeviceCreateParams& _params) const override;
 
 	    pluginLib::Controller* createController() override;
+		void saveChunkData(baseLib::BinaryStream& _stream) override;
+		void loadChunkData(baseLib::ChunkReader& _reader) override;
 
 	private:
 		AudioPluginAudioProcessor(md::MachineModel _model,

--- a/source/elektron/md/mdJucePlugin/parameterDescriptions_md.json
+++ b/source/elektron/md/mdJucePlugin/parameterDescriptions_md.json
@@ -3,20 +3,47 @@
 	{
 		"isPublic":true,
 		"isBipolar":false,
-		"toText":"unsignedZero",
+		"toText":{"format":"%d"},
 		"name":"",
 		"class":"",
 		"min":0,
 		"max":127,
 		"isBool":false,
-		"isDiscrete":false,
+		"isDiscrete":true,
 		"page":0,
 		"step":0
 	},
-	"valuelists":
-	{
-	},
+	"valuelists":{"offOn":["Off", "On"]},
 	"parameterdescriptions":
 	[
+		{"page":0, "index":0, "name":"MachineParameter1", "displayName":"Machine Parameter 1"},
+		{"page":0, "index":1, "name":"MachineParameter2", "displayName":"Machine Parameter 2"},
+		{"page":0, "index":2, "name":"MachineParameter3", "displayName":"Machine Parameter 3"},
+		{"page":0, "index":3, "name":"MachineParameter4", "displayName":"Machine Parameter 4"},
+		{"page":0, "index":4, "name":"MachineParameter5", "displayName":"Machine Parameter 5"},
+		{"page":0, "index":5, "name":"MachineParameter6", "displayName":"Machine Parameter 6"},
+		{"page":0, "index":6, "name":"MachineParameter7", "displayName":"Machine Parameter 7"},
+		{"page":0, "index":7, "name":"MachineParameter8", "displayName":"Machine Parameter 8"},
+
+		{"page":1, "index":0, "name":"AMDepth", "displayName":"AM Depth"},
+		{"page":1, "index":1, "name":"AMRate", "displayName":"AM Rate"},
+		{"page":1, "index":2, "name":"EQFrequency", "displayName":"EQ Frequency"},
+		{"page":1, "index":3, "name":"EQGain", "displayName":"EQ Gain"},
+		{"page":1, "index":4, "name":"FilterBase", "displayName":"Filter Base Frequency"},
+		{"page":1, "index":5, "name":"FilterWidth", "displayName":"Filter Width"},
+		{"page":1, "index":6, "name":"FilterQ", "displayName":"Filter Q"},
+		{"page":1, "index":7, "name":"SampleRateReduction", "displayName":"Sample Rate Reduction"},
+
+		{"page":2, "index":0, "name":"Distortion", "displayName":"Distortion"},
+		{"page":2, "index":1, "name":"Volume", "displayName":"Volume"},
+		{"page":2, "index":2, "name":"Pan", "displayName":"Pan"},
+		{"page":2, "index":3, "name":"DelaySend", "displayName":"Delay Send"},
+		{"page":2, "index":4, "name":"ReverbSend", "displayName":"Reverb Send"},
+		{"page":2, "index":5, "name":"LFOSpeed", "displayName":"LFO Speed"},
+		{"page":2, "index":6, "name":"LFOAmount", "displayName":"LFO Amount"},
+		{"page":2, "index":7, "name":"LFOShape", "displayName":"LFO Shape"},
+
+		{"page":3, "index":0, "name":"Level", "displayName":"Level"},
+		{"page":4, "index":0, "name":"Mute", "displayName":"Mute", "min":0, "max":1, "isBool":true, "toText":"offOn"}
 	]
 }

--- a/source/elektron/md/mdJucePlugin/parameterDescriptions_mm.json
+++ b/source/elektron/md/mdJucePlugin/parameterDescriptions_mm.json
@@ -1,0 +1,85 @@
+{
+	"parameterdescriptiondefaults":
+	{
+		"isPublic":true,
+		"isBipolar":false,
+		"toText":{"format":"%d"},
+		"name":"",
+		"class":"",
+		"min":0,
+		"max":127,
+		"isBool":false,
+		"isDiscrete":true,
+		"page":0,
+		"step":0
+	},
+	"valuelists":{"offOn":["Off", "On"]},
+	"parameterdescriptions":
+	[
+		{"page":0, "index":0, "name":"SynthesisA", "displayName":"Synthesis A"},
+		{"page":0, "index":1, "name":"SynthesisB", "displayName":"Synthesis B"},
+		{"page":0, "index":2, "name":"SynthesisC", "displayName":"Synthesis C"},
+		{"page":0, "index":3, "name":"SynthesisD", "displayName":"Synthesis D"},
+		{"page":0, "index":4, "name":"SynthesisE", "displayName":"Synthesis E"},
+		{"page":0, "index":5, "name":"SynthesisF", "displayName":"Synthesis F"},
+		{"page":0, "index":6, "name":"SynthesisG", "displayName":"Synthesis G"},
+		{"page":0, "index":7, "name":"SynthesisH", "displayName":"Synthesis H"},
+
+		{"page":1, "index":0, "name":"AmpAttack", "displayName":"Amp Attack"},
+		{"page":1, "index":1, "name":"AmpHold", "displayName":"Amp Hold"},
+		{"page":1, "index":2, "name":"AmpDecay", "displayName":"Amp Decay"},
+		{"page":1, "index":3, "name":"AmpRelease", "displayName":"Amp Release"},
+		{"page":1, "index":4, "name":"AmpDistortion", "displayName":"Amp Distortion"},
+		{"page":1, "index":5, "name":"AmpVolume", "displayName":"Amp Volume"},
+		{"page":1, "index":6, "name":"AmpPan", "displayName":"Amp Pan"},
+		{"page":1, "index":7, "name":"AmpPortamento", "displayName":"Amp Portamento"},
+
+		{"page":2, "index":0, "name":"FilterBase", "displayName":"Filter Base"},
+		{"page":2, "index":1, "name":"FilterWidth", "displayName":"Filter Width"},
+		{"page":2, "index":2, "name":"FilterHighpassQ", "displayName":"Filter Highpass Q"},
+		{"page":2, "index":3, "name":"FilterLowpassQ", "displayName":"Filter Lowpass Q"},
+		{"page":2, "index":4, "name":"FilterAttack", "displayName":"Filter Attack"},
+		{"page":2, "index":5, "name":"FilterDecay", "displayName":"Filter Decay"},
+		{"page":2, "index":6, "name":"FilterBaseOffset", "displayName":"Filter Base Offset"},
+		{"page":2, "index":7, "name":"FilterWidthOffset", "displayName":"Filter Width Offset"},
+
+		{"page":3, "index":0, "name":"EffectsEqFrequency", "displayName":"Effects EQ Frequency"},
+		{"page":3, "index":1, "name":"EffectsEqGain", "displayName":"Effects EQ Gain"},
+		{"page":3, "index":2, "name":"EffectsSampleRate", "displayName":"Effects Sample Rate Reduction"},
+		{"page":3, "index":3, "name":"EffectsDelayTime", "displayName":"Effects Delay Time"},
+		{"page":3, "index":4, "name":"EffectsDelaySend", "displayName":"Effects Delay Send"},
+		{"page":3, "index":5, "name":"EffectsDelayFeedback", "displayName":"Effects Delay Feedback"},
+		{"page":3, "index":6, "name":"EffectsDelayBase", "displayName":"Effects Delay Base"},
+		{"page":3, "index":7, "name":"EffectsDelayWidth", "displayName":"Effects Delay Width"},
+
+		{"page":4, "index":0, "name":"Lfo1Page", "displayName":"LFO 1 Page"},
+		{"page":4, "index":1, "name":"Lfo1Destination", "displayName":"LFO 1 Destination"},
+		{"page":4, "index":2, "name":"Lfo1Trigger", "displayName":"LFO 1 Trigger"},
+		{"page":4, "index":3, "name":"Lfo1Waveform", "displayName":"LFO 1 Waveform"},
+		{"page":4, "index":4, "name":"Lfo1Multiplier", "displayName":"LFO 1 Multiplier"},
+		{"page":4, "index":5, "name":"Lfo1Speed", "displayName":"LFO 1 Speed"},
+		{"page":4, "index":6, "name":"Lfo1Interlace", "displayName":"LFO 1 Interlace"},
+		{"page":4, "index":7, "name":"Lfo1Depth", "displayName":"LFO 1 Depth"},
+
+		{"page":5, "index":0, "name":"Lfo2Page", "displayName":"LFO 2 Page"},
+		{"page":5, "index":1, "name":"Lfo2Destination", "displayName":"LFO 2 Destination"},
+		{"page":5, "index":2, "name":"Lfo2Trigger", "displayName":"LFO 2 Trigger"},
+		{"page":5, "index":3, "name":"Lfo2Waveform", "displayName":"LFO 2 Waveform"},
+		{"page":5, "index":4, "name":"Lfo2Multiplier", "displayName":"LFO 2 Multiplier"},
+		{"page":5, "index":5, "name":"Lfo2Speed", "displayName":"LFO 2 Speed"},
+		{"page":5, "index":6, "name":"Lfo2Interlace", "displayName":"LFO 2 Interlace"},
+		{"page":5, "index":7, "name":"Lfo2Depth", "displayName":"LFO 2 Depth"},
+
+		{"page":6, "index":0, "name":"Lfo3Page", "displayName":"LFO 3 Page"},
+		{"page":6, "index":1, "name":"Lfo3Destination", "displayName":"LFO 3 Destination"},
+		{"page":6, "index":2, "name":"Lfo3Trigger", "displayName":"LFO 3 Trigger"},
+		{"page":6, "index":3, "name":"Lfo3Waveform", "displayName":"LFO 3 Waveform"},
+		{"page":6, "index":4, "name":"Lfo3Multiplier", "displayName":"LFO 3 Multiplier"},
+		{"page":6, "index":5, "name":"Lfo3Speed", "displayName":"LFO 3 Speed"},
+		{"page":6, "index":6, "name":"Lfo3Interlace", "displayName":"LFO 3 Interlace"},
+		{"page":6, "index":7, "name":"Lfo3Depth", "displayName":"LFO 3 Depth"},
+
+		{"page":7, "index":0, "name":"Level", "displayName":"Level"},
+		{"page":8, "index":0, "name":"Mute", "displayName":"Mute", "min":0, "max":1, "isBool":true, "toText":"offOn"}
+	]
+}

--- a/source/elektron/md/mdLib/CMakeLists.txt
+++ b/source/elektron/md/mdLib/CMakeLists.txt
@@ -5,6 +5,7 @@ project(mdLib)
 add_library(mdLib STATIC)
 
 set(SOURCES
+	mdautomation.cpp mdautomation.h
 	mddevice.cpp mddevice.h
 	mddsp.cpp mddsp.h
 	mdfrontpanel.cpp mdfrontpanel.h
@@ -12,6 +13,7 @@ set(SOURCES
 	mdmc.cpp mdmc.h
 	mdmemorymap.h
 	mdmidiprotocol.h
+	mdsysexautomation.cpp mdsysexautomation.h
 	mdmmwaveforms.h
 	mdrealtimemidiqueue.h
 	mdpanel.cpp mdpanel.h

--- a/source/elektron/md/mdLib/mdautomation.cpp
+++ b/source/elektron/md/mdLib/mdautomation.cpp
@@ -1,0 +1,147 @@
+#include "mdautomation.h"
+
+namespace md::automation
+{
+	namespace
+	{
+		constexpr uint8_t g_controlChange = 0xb0;
+
+		std::optional<uint8_t> mdController(const ParameterChange& _change)
+		{
+			if(_change.track >= machinedrum::TrackCount || _change.value > 127)
+				return std::nullopt;
+
+			const auto lane = static_cast<uint8_t>(_change.track & 3);
+			if(_change.page <= machinedrum::Routing && _change.index < 8)
+			{
+				constexpr std::array<uint8_t, 4> bases{16, 40, 72, 96};
+				return static_cast<uint8_t>(bases[lane] + _change.page * 8
+					+ _change.index);
+			}
+			if(_change.page == machinedrum::Level && _change.index == 0)
+				return static_cast<uint8_t>(8 + lane);
+			if(_change.page == machinedrum::Mute && _change.index == 0)
+				return static_cast<uint8_t>(12 + lane);
+			return std::nullopt;
+		}
+
+		std::optional<uint8_t> mmController(const ParameterChange& _change)
+		{
+			if(_change.track >= monomachine::TrackCount || _change.value > 127)
+				return std::nullopt;
+
+			constexpr std::array<uint8_t, 7> pageBases{48, 56, 72, 80, 88, 104, 112};
+			if(_change.page < pageBases.size() && _change.index < 8)
+				return static_cast<uint8_t>(pageBases[_change.page] + _change.index);
+			if(_change.page == monomachine::Level && _change.index == 0)
+				return 7;
+			if(_change.page == monomachine::Mute && _change.index == 0)
+				return 3;
+			return std::nullopt;
+		}
+	}
+
+	std::optional<ControlChange> encodeParameterChange(const MachineModel _model,
+		const ParameterChange& _change, const uint8_t _baseChannel)
+	{
+		const auto channelOffset = _model == MachineModel::Monomachine
+			? _change.track : static_cast<uint8_t>(_change.track >> 2);
+		if(static_cast<unsigned>(_baseChannel) + channelOffset > 15)
+			return std::nullopt;
+
+		const auto cc = _model == MachineModel::Monomachine
+			? mmController(_change) : mdController(_change);
+		if(!cc)
+			return std::nullopt;
+
+		return ControlChange{
+			static_cast<uint8_t>(g_controlChange | (_baseChannel + channelOffset)),
+			*cc,
+			_change.value
+		};
+	}
+
+	std::optional<ParameterChange> decodeParameterChange(const MachineModel _model,
+		const ControlChange& _message, const uint8_t _baseChannel)
+	{
+		if((_message[0] & 0xf0) != g_controlChange || _message[1] > 127
+			|| _message[2] > 127)
+			return std::nullopt;
+
+		const auto channel = static_cast<uint8_t>(_message[0] & 0x0f);
+		if(channel < _baseChannel)
+			return std::nullopt;
+		const auto channelOffset = static_cast<uint8_t>(channel - _baseChannel);
+
+		ParameterChange result;
+		result.value = _message[2];
+		const auto cc = _message[1];
+
+		if(_model == MachineModel::Machinedrum)
+		{
+			if(channelOffset >= 4)
+				return std::nullopt;
+
+			uint8_t lane = 0;
+			if(cc >= 8 && cc <= 11)
+			{
+				result.page = machinedrum::Level;
+				lane = static_cast<uint8_t>(cc - 8);
+			}
+			else if(cc >= 12 && cc <= 15)
+			{
+				result.page = machinedrum::Mute;
+				result.value = result.value > 0 ? 1 : 0;
+				lane = static_cast<uint8_t>(cc - 12);
+			}
+			else
+			{
+				constexpr std::array<uint8_t, 4> bases{16, 40, 72, 96};
+				bool found = false;
+				for(uint8_t candidate = 0; candidate < bases.size(); ++candidate)
+				{
+					if(cc < bases[candidate] || cc >= bases[candidate] + 24)
+						continue;
+					const auto offset = static_cast<uint8_t>(cc - bases[candidate]);
+					result.page = static_cast<uint8_t>(offset / 8);
+					result.index = static_cast<uint8_t>(offset & 7);
+					lane = candidate;
+					found = true;
+					break;
+				}
+				if(!found)
+					return std::nullopt;
+			}
+			result.track = static_cast<uint8_t>(channelOffset * 4 + lane);
+			return result;
+		}
+
+		if(channelOffset >= monomachine::TrackCount)
+			return std::nullopt;
+		result.track = channelOffset;
+		if(cc == 7)
+			result.page = monomachine::Level;
+		else if(cc == 3)
+		{
+			result.page = monomachine::Mute;
+			result.value = result.value > 0 ? 1 : 0;
+		}
+		else
+		{
+			constexpr std::array<uint8_t, 7> pageBases{48, 56, 72, 80, 88, 104, 112};
+			bool found = false;
+			for(uint8_t page = 0; page < pageBases.size(); ++page)
+			{
+				if(cc < pageBases[page] || cc >= pageBases[page] + 8)
+					continue;
+				result.page = page;
+				result.index = static_cast<uint8_t>(cc - pageBases[page]);
+				found = true;
+				break;
+			}
+			if(!found)
+				return std::nullopt;
+		}
+		return result;
+	}
+}

--- a/source/elektron/md/mdLib/mdautomation.h
+++ b/source/elektron/md/mdLib/mdautomation.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+
+#include "mdtypes.h"
+
+namespace md::automation
+{
+	// Stable host-parameter pages. The page numbers are part of the JUCE
+	// parameter IDs, so append new pages rather than renumbering these.
+	namespace machinedrum
+	{
+		constexpr uint8_t Synthesis = 0;
+		constexpr uint8_t Effects = 1;
+		constexpr uint8_t Routing = 2;
+		constexpr uint8_t Level = 3;
+		constexpr uint8_t Mute = 4;
+		constexpr uint8_t TrackCount = 16;
+	}
+
+	namespace monomachine
+	{
+		constexpr uint8_t Synthesis = 0;
+		constexpr uint8_t Amplification = 1;
+		constexpr uint8_t Filter = 2;
+		constexpr uint8_t Effects = 3;
+		constexpr uint8_t Lfo1 = 4;
+		constexpr uint8_t Lfo2 = 5;
+		constexpr uint8_t Lfo3 = 6;
+		constexpr uint8_t Level = 7;
+		constexpr uint8_t Mute = 8;
+		constexpr uint8_t TrackCount = 6;
+	}
+
+	struct ParameterChange
+	{
+		uint8_t page = 0;
+		uint8_t track = 0;
+		uint8_t index = 0;
+		uint8_t value = 0;
+
+		constexpr bool operator==(const ParameterChange& _other) const
+		{
+			return page == _other.page && track == _other.track
+				&& index == _other.index && value == _other.value;
+		}
+	};
+
+	using ControlChange = std::array<uint8_t, 3>;
+
+	// baseChannel is zero-based. MD consumes four consecutive channels and MM
+	// consumes six, matching the public Elektron MIDI implementations.
+	std::optional<ControlChange> encodeParameterChange(MachineModel _model,
+		const ParameterChange& _change, uint8_t _baseChannel);
+
+	std::optional<ParameterChange> decodeParameterChange(MachineModel _model,
+		const ControlChange& _message, uint8_t _baseChannel);
+}

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -60,6 +60,10 @@ namespace md
 		bool isValid() const;
 		MachineModel getModel() const { return m_model; }
 		bool isMonomachine() const { return m_model == MachineModel::Monomachine; }
+		bool isAudioReady() const
+		{
+			return m_dspMixer.booted() && m_dspProducer.booted();
+		}
 		uint64_t firmwareFingerprint() const { return m_firmwareFingerprint; }
 		uint64_t hostAudioOverflowCount() const
 		{
@@ -71,6 +75,7 @@ namespace md
 		}
 		size_t queuedMidiRxBytes() const { return m_uc.queuedMidiRxBytes(); }
 		size_t midiRxOverflowCount() const { return m_uc.midiRxOverflowCount(); }
+		uint64_t midiRxConsumedCount() const { return m_uc.midiRxConsumedCount(); }
 
 		Microcontroller& getUC() { return m_uc; }
 		std::vector<uint8_t> copyPatchRam() const { return m_uc.copyPatchRam(); }

--- a/source/elektron/md/mdLib/mdmc.h
+++ b/source/elektron/md/mdLib/mdmc.h
@@ -115,6 +115,10 @@ namespace md
 		{
 			return m_sim.rxOverflowCount(Sim::g_uartMidi);
 		}
+		uint64_t midiRxConsumedCount() const
+		{
+			return m_sim.rxConsumedCount(Sim::g_uartMidi);
+		}
 
 		struct PatchByteUpdate
 		{

--- a/source/elektron/md/mdLib/mdsim.cpp
+++ b/source/elektron/md/mdLib/mdsim.cpp
@@ -231,6 +231,7 @@ namespace md
 
 		uint8_t b = 0;
 		rx.pop(b);
+		++m_uart[_uart].rxConsumed;
 
 		// Hardware: reading URB clears RxRDY; if the receiver still holds a byte it re-asserts
 		// immediately, so the ISR is re-entered until the FIFO is drained. Re-arm the edge here
@@ -319,6 +320,11 @@ namespace md
 	size_t Sim::rxOverflowCount(const unsigned _uart) const
 	{
 		return _uart < g_uartCount ? m_uart[_uart].rxOverflows : 0;
+	}
+
+	uint64_t Sim::rxConsumedCount(const unsigned _uart) const
+	{
+		return _uart < g_uartCount ? m_uart[_uart].rxConsumed : 0;
 	}
 
 	// -------------------------------------------------------------------------

--- a/source/elektron/md/mdLib/mdsim.h
+++ b/source/elektron/md/mdLib/mdsim.h
@@ -177,6 +177,7 @@ namespace md
 		size_t queuedRxBytes(unsigned _uart) const;
 		size_t availableRxBytes(unsigned _uart) const;
 		size_t rxOverflowCount(unsigned _uart) const;
+		uint64_t rxConsumedCount(unsigned _uart) const;
 
 		// --- Timers + interrupt controller (UM 14.4 / 8.3.2.3-8.3.2.5) ------------
 
@@ -268,6 +269,7 @@ namespace md
 			ByteQueue<g_uartRxCapacity> rx;	// bytes waiting to be read from URB
 			TransmitCallback    txCallback;
 			size_t rxOverflows = 0;
+			uint64_t rxConsumed = 0;
 		};
 
 		uint8_t computeParallelData() const;

--- a/source/elektron/md/mdLib/mdsysexautomation.cpp
+++ b/source/elektron/md/mdLib/mdsysexautomation.cpp
@@ -1,0 +1,211 @@
+#include "mdsysexautomation.h"
+
+#include <algorithm>
+
+namespace md::automation::sysex
+{
+	namespace
+	{
+		constexpr uint8_t g_globalDump = 0x50;
+		constexpr uint8_t g_globalRequest = 0x51;
+		constexpr uint8_t g_kitDump = 0x52;
+		constexpr uint8_t g_kitRequest = 0x53;
+		constexpr uint8_t g_statusRequest = 0x70;
+		constexpr uint8_t g_statusResponse = 0x72;
+
+		uint8_t product(const MachineModel _model)
+		{
+			return _model == MachineModel::Monomachine ? 0x03 : 0x02;
+		}
+
+		Message request(const MachineModel _model, const uint8_t _command,
+			const uint8_t _value)
+		{
+			return {0xf0, 0x00, 0x20, 0x3c, product(_model), 0x00,
+				_command, static_cast<uint8_t>(_value & 0x7f), 0xf7};
+		}
+
+		bool hasHeader(const MachineModel _model, const MessageView _message,
+			const uint8_t _command)
+		{
+			return _message.size() >= 8 && _message[0] == 0xf0
+				&& _message[1] == 0x00 && _message[2] == 0x20
+				&& _message[3] == 0x3c && _message[4] == product(_model)
+				&& _message[5] == 0x00 && _message[6] == _command
+				&& _message.back() == 0xf7;
+		}
+
+		bool validDump(const MachineModel _model, const MessageView _message,
+			const uint8_t _command)
+		{
+			if(_message.size() < 13 || !hasHeader(_model, _message, _command))
+				return false;
+			if(std::any_of(_message.begin() + 1, _message.end() - 1,
+				[](const uint8_t _value) { return _value > 0x7f; }))
+				return false;
+
+			const auto checksumPosition = _message.size() - 5;
+			uint32_t sum = 0;
+			for(size_t i = 9; i < checksumPosition; ++i)
+				sum += _message[i];
+			const auto checksum = static_cast<uint16_t>(
+				(_message[checksumPosition] << 7) | _message[checksumPosition + 1]);
+			if((sum & 0x3fff) != checksum)
+				return false;
+
+			const auto length = static_cast<uint16_t>(
+				(_message[checksumPosition + 2] << 7) | _message[checksumPosition + 3]);
+			return length == _message.size() - 10;
+		}
+
+		std::optional<std::vector<uint8_t>> decodeMonomachinePayload(
+			const MessageView _message)
+		{
+			const auto end = _message.size() - 5;
+			std::vector<uint8_t> rle;
+			rle.reserve(end - 10);
+			for(size_t position = 10; position < end;)
+			{
+				const auto highBits = _message[position++];
+				for(uint8_t bit = 0; bit < 7 && position < end; ++bit)
+				{
+					auto value = _message[position++];
+					if(highBits & (1u << (6u - bit)))
+						value |= 0x80;
+					rle.push_back(value);
+				}
+			}
+
+			std::vector<uint8_t> decoded;
+			for(size_t position = 0; position < rle.size(); ++position)
+			{
+				const auto value = rle[position];
+				if((value & 0x80) == 0)
+				{
+					decoded.push_back(value);
+					continue;
+				}
+
+				const auto count = static_cast<size_t>(value & 0x7f);
+				if(count == 0 || ++position >= rle.size())
+					return std::nullopt;
+				if(decoded.size() + count > 4096)
+					return std::nullopt;
+				decoded.insert(decoded.end(), count, rle[position]);
+			}
+			return decoded;
+		}
+	}
+
+	Message statusRequest(const MachineModel _model,
+		const StatusParameter _parameter)
+	{
+		return request(_model, g_statusRequest, static_cast<uint8_t>(_parameter));
+	}
+
+	Message globalRequest(const MachineModel _model, const uint8_t _slot)
+	{
+		return request(_model, g_globalRequest, _slot);
+	}
+
+	Message kitRequest(const MachineModel _model, const uint8_t _slot)
+	{
+		return request(_model, g_kitRequest, _slot);
+	}
+
+	std::optional<StatusResponse> parseStatusResponse(const MachineModel _model,
+		const MessageView _message)
+	{
+		if(_message.size() != 10 || !hasHeader(_model, _message, g_statusResponse))
+			return std::nullopt;
+		const auto parameter = _message[7];
+		if(parameter != static_cast<uint8_t>(StatusParameter::Global)
+			&& parameter != static_cast<uint8_t>(StatusParameter::Kit)
+			&& parameter != static_cast<uint8_t>(StatusParameter::Pattern))
+			return std::nullopt;
+		return StatusResponse{static_cast<StatusParameter>(parameter), _message[8]};
+	}
+
+	std::optional<uint8_t> parseBaseChannel(const MachineModel _model,
+		const MessageView _message)
+	{
+		if(!validDump(_model, _message, g_globalDump))
+			return std::nullopt;
+
+		uint8_t channel = 0;
+		if(_model == MachineModel::Machinedrum)
+		{
+			constexpr size_t baseChannelPosition = 0xad;
+			if(_message.size() <= baseChannelPosition)
+				return std::nullopt;
+			channel = _message[baseChannelPosition];
+		}
+		else
+		{
+			const auto decoded = decodeMonomachinePayload(_message);
+			if(!decoded || decoded->size() < 2)
+				return std::nullopt;
+			channel = (*decoded)[1];
+		}
+
+		return channel < 16 || channel == 0x7f
+			? std::optional<uint8_t>(channel) : std::nullopt;
+	}
+
+	std::optional<std::vector<ParameterChange>> parseKitParameters(
+		const MachineModel _model, const MessageView _message)
+	{
+		if(!validDump(_model, _message, g_kitDump))
+			return std::nullopt;
+
+		std::vector<ParameterChange> result;
+		if(_model == MachineModel::Machinedrum)
+		{
+			constexpr size_t parameterPosition = 0x1a;
+			constexpr size_t levelPosition = 0x19a;
+			if(_message.size() <= levelPosition + machinedrum::TrackCount)
+				return std::nullopt;
+			result.reserve(machinedrum::TrackCount * 25);
+			for(uint8_t track = 0; track < machinedrum::TrackCount; ++track)
+			{
+				for(uint8_t page = machinedrum::Synthesis;
+					page <= machinedrum::Routing; ++page)
+				{
+					for(uint8_t index = 0; index < 8; ++index)
+					{
+						const auto offset = parameterPosition + track * 24 + page * 8 + index;
+						result.push_back({page, track, index, _message[offset]});
+					}
+				}
+				result.push_back({machinedrum::Level, track, 0,
+					_message[levelPosition + track]});
+			}
+			return result;
+		}
+
+		const auto decoded = decodeMonomachinePayload(_message);
+		constexpr size_t levelPosition = 0x0b;
+		constexpr size_t parameterPosition = 0x11;
+		constexpr size_t parameterStride = 72;
+		if(!decoded || decoded->size() < parameterPosition
+			+ monomachine::TrackCount * parameterStride)
+			return std::nullopt;
+		result.reserve(monomachine::TrackCount * 57);
+		for(uint8_t track = 0; track < monomachine::TrackCount; ++track)
+		{
+			for(uint8_t page = monomachine::Synthesis;
+				page <= monomachine::Lfo3; ++page)
+			{
+				for(uint8_t index = 0; index < 8; ++index)
+				{
+					const auto offset = parameterPosition + track * parameterStride
+						+ page * 8 + index;
+					result.push_back({page, track, index, (*decoded)[offset]});
+				}
+			}
+			result.push_back({monomachine::Level, track, 0,
+				(*decoded)[levelPosition + track]});
+		}
+		return result;
+	}
+}

--- a/source/elektron/md/mdLib/mdsysexautomation.h
+++ b/source/elektron/md/mdLib/mdsysexautomation.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "mdautomation.h"
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace md::automation::sysex
+{
+	using Message = std::vector<uint8_t>;
+	class MessageView
+	{
+	public:
+		template<typename Allocator>
+		MessageView(const std::vector<uint8_t, Allocator>& _message)
+			: m_data(_message.data()), m_size(_message.size()) {}
+
+		const uint8_t* begin() const { return m_data; }
+		const uint8_t* end() const { return m_data + m_size; }
+		const uint8_t& operator[](size_t _index) const { return m_data[_index]; }
+		const uint8_t& back() const { return m_data[m_size - 1]; }
+		size_t size() const { return m_size; }
+
+	private:
+		const uint8_t* m_data;
+		size_t m_size;
+	};
+
+	enum class StatusParameter : uint8_t
+	{
+		Global = 0x01,
+		Kit = 0x02,
+		Pattern = 0x04
+	};
+
+	struct StatusResponse
+	{
+		StatusParameter parameter;
+		uint8_t value;
+	};
+
+	Message statusRequest(MachineModel _model, StatusParameter _parameter);
+	Message globalRequest(MachineModel _model, uint8_t _slot);
+	Message kitRequest(MachineModel _model, uint8_t _slot);
+
+	std::optional<StatusResponse> parseStatusResponse(MachineModel _model,
+		MessageView _message);
+	std::optional<uint8_t> parseBaseChannel(MachineModel _model,
+		MessageView _message);
+	std::optional<std::vector<ParameterChange>> parseKitParameters(
+		MachineModel _model, MessageView _message);
+}

--- a/source/elektron/md/mdLibTest/CMakeLists.txt
+++ b/source/elektron/md/mdLibTest/CMakeLists.txt
@@ -7,3 +7,9 @@ add_test(NAME mdLibTests COMMAND mdLibTest)
 set_tests_properties(mdLibTests PROPERTIES LABELS "UnitTest")
 
 set_property(TARGET mdLibTest PROPERTY FOLDER "Elektron")
+
+add_executable(mdAutomationMidiTest automationMidiTest.cpp)
+target_link_libraries(mdAutomationMidiTest PRIVATE mdLib)
+add_test(NAME mdAutomationMidiTest COMMAND mdAutomationMidiTest)
+set_tests_properties(mdAutomationMidiTest PROPERTIES LABELS "UnitTest")
+set_property(TARGET mdAutomationMidiTest PROPERTY FOLDER "Elektron")

--- a/source/elektron/md/mdLibTest/automationMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/automationMidiTest.cpp
@@ -1,5 +1,6 @@
 #include "mdLib/mdautomation.h"
 #include "mdLib/mdsysexautomation.h"
+#include "synthLib/midiBufferParser.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -226,6 +227,44 @@ namespace
 			"accepted status response for the wrong product");
 	}
 
+	void testMidiRunningStatus()
+	{
+		synthLib::MidiBufferParser parser(synthLib::MidiEventSource::Device);
+		std::vector<synthLib::SMidiEvent> events;
+		parser.write(std::vector<uint8_t>{
+			0xb2, 16, 1, 17, 2, 18, 3,
+			0xf8,
+			19, 4,
+			0xf1, 0x05,
+			20, 6,
+			0x92, 60, 100, 61, 101});
+		parser.getEvents(events);
+		require(events.size() == 8, "wrong MIDI running-status event count");
+		require(events[0].a == 0xb2 && events[0].b == 16 && events[0].c == 1,
+			"wrong first running-status CC");
+		require(events[1].a == 0xb2 && events[1].b == 17 && events[1].c == 2,
+			"running-status CC lost retained status");
+		require(events[2].a == 0xb2 && events[2].b == 18 && events[2].c == 3,
+			"wrong third running-status CC");
+		require(events[3].a == 0xf8,
+			"realtime byte was not emitted independently");
+		require(events[4].a == 0xb2 && events[4].b == 19 && events[4].c == 4,
+			"realtime byte incorrectly cancelled running status");
+		require(events[5].a == 0xf1 && events[5].b == 0x05,
+			"System Common message was parsed incorrectly");
+		require(events[6].a == 0x92 && events[6].b == 60 && events[6].c == 100,
+			"orphan data after System Common was not discarded");
+		require(events[7].a == 0x92 && events[7].b == 61 && events[7].c == 101,
+			"note-on running status was parsed incorrectly");
+
+		parser.write(std::vector<uint8_t>{0xb0, 7});
+		parser.discardPartialMessage();
+		parser.write(std::vector<uint8_t>{100, 101});
+		events.clear();
+		parser.getEvents(events);
+		require(events.empty(), "discontinuity retained unsafe running status");
+	}
+
 	void testMachinedrumDumps()
 	{
 		using namespace md::automation;
@@ -340,6 +379,7 @@ int main(const int _argc, const char* const* _argv)
 	testMachinedrum();
 	testMonomachine();
 	testSysexRequestsAndStatus();
+	testMidiRunningStatus();
 	testMachinedrumDumps();
 	testMonomachineDumps();
 	if(_argc > 1)

--- a/source/elektron/md/mdLibTest/automationMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/automationMidiTest.cpp
@@ -1,0 +1,351 @@
+#include "mdLib/mdautomation.h"
+#include "mdLib/mdsysexautomation.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <vector>
+
+namespace
+{
+	void require(const bool _condition, const char* const _message)
+	{
+		if(_condition)
+			return;
+		std::cerr << "automationMidiTest: " << _message << '\n';
+		std::exit(1);
+	}
+
+	void expectMessage(const md::MachineModel _model,
+		const md::automation::ParameterChange& _change, const uint8_t _baseChannel,
+		const md::automation::ControlChange& _expected)
+	{
+		const auto encoded = md::automation::encodeParameterChange(_model, _change,
+			_baseChannel);
+		require(encoded.has_value(), "valid parameter did not encode");
+		require(*encoded == _expected, "parameter encoded to the wrong CC");
+		const auto decoded = md::automation::decodeParameterChange(_model, *encoded,
+			_baseChannel);
+		require(decoded.has_value(), "encoded CC did not decode");
+		require(*decoded == _change, "CC round trip changed its parameter address");
+	}
+
+	void expectRoundTrip(const md::MachineModel _model,
+		const md::automation::ParameterChange& _change, const uint8_t _baseChannel)
+	{
+		const auto encoded = md::automation::encodeParameterChange(_model, _change,
+			_baseChannel);
+		require(encoded.has_value(), "valid parameter did not encode");
+		const auto decoded = md::automation::decodeParameterChange(_model, *encoded,
+			_baseChannel);
+		require(decoded.has_value(), "encoded CC did not decode");
+		require(*decoded == _change, "CC round trip changed its parameter address");
+	}
+
+	void testMachinedrum()
+	{
+		using namespace md::automation;
+		expectMessage(md::MachineModel::Machinedrum,
+			{machinedrum::Synthesis, 0, 0, 23}, 0, {0xb0, 16, 23});
+		expectMessage(md::MachineModel::Machinedrum,
+			{machinedrum::Effects, 0, 0, 31}, 0, {0xb0, 24, 31});
+		expectMessage(md::MachineModel::Machinedrum,
+			{machinedrum::Routing, 3, 7, 127}, 0, {0xb0, 119, 127});
+		expectMessage(md::MachineModel::Machinedrum,
+			{machinedrum::Synthesis, 4, 0, 64}, 0, {0xb1, 16, 64});
+		expectMessage(md::MachineModel::Machinedrum,
+			{machinedrum::Level, 15, 0, 99}, 0, {0xb3, 11, 99});
+		expectMessage(md::MachineModel::Machinedrum,
+			{machinedrum::Mute, 9, 0, 1}, 4, {0xb6, 13, 1});
+
+		for(uint8_t track = 0; track < machinedrum::TrackCount; ++track)
+		{
+			for(uint8_t page = machinedrum::Synthesis;
+				page <= machinedrum::Routing; ++page)
+			{
+				for(uint8_t index = 0; index < 8; ++index)
+					expectRoundTrip(md::MachineModel::Machinedrum,
+						{page, track, index, static_cast<uint8_t>(track + index)}, 0);
+			}
+
+			for(const auto page : {machinedrum::Level, machinedrum::Mute})
+			{
+				const ParameterChange change{page, track, 0,
+					static_cast<uint8_t>(page == machinedrum::Mute ? 1 : track)};
+				expectRoundTrip(md::MachineModel::Machinedrum, change, 0);
+			}
+		}
+
+		require(!encodeParameterChange(md::MachineModel::Machinedrum,
+			{machinedrum::Synthesis, 16, 0, 0}, 0), "accepted MD track 17");
+		require(!encodeParameterChange(md::MachineModel::Machinedrum,
+			{machinedrum::Synthesis, 15, 0, 0}, 13), "accepted overflowing MD channel span");
+	}
+
+	void testMonomachine()
+	{
+		using namespace md::automation;
+		expectMessage(md::MachineModel::Monomachine,
+			{monomachine::Synthesis, 0, 0, 12}, 0, {0xb0, 48, 12});
+		expectMessage(md::MachineModel::Monomachine,
+			{monomachine::Amplification, 0, 0, 12}, 0, {0xb0, 56, 12});
+		expectMessage(md::MachineModel::Monomachine,
+			{monomachine::Filter, 0, 0, 12}, 0, {0xb0, 72, 12});
+		expectMessage(md::MachineModel::Monomachine,
+			{monomachine::Effects, 0, 3, 12}, 0, {0xb0, 83, 12});
+		expectMessage(md::MachineModel::Monomachine,
+			{monomachine::Effects, 0, 4, 12}, 0, {0xb0, 84, 12});
+		expectMessage(md::MachineModel::Monomachine,
+			{monomachine::Lfo1, 0, 0, 12}, 0, {0xb0, 88, 12});
+		expectMessage(md::MachineModel::Monomachine,
+			{monomachine::Lfo2, 0, 0, 12}, 0, {0xb0, 104, 12});
+		expectMessage(md::MachineModel::Monomachine,
+			{monomachine::Lfo3, 5, 7, 126}, 2, {0xb7, 119, 126});
+		expectMessage(md::MachineModel::Monomachine,
+			{monomachine::Level, 2, 0, 77}, 0, {0xb2, 7, 77});
+		expectMessage(md::MachineModel::Monomachine,
+			{monomachine::Mute, 4, 0, 1}, 0, {0xb4, 3, 1});
+
+		for(uint8_t track = 0; track < monomachine::TrackCount; ++track)
+		{
+			for(uint8_t page = monomachine::Synthesis;
+				page <= monomachine::Lfo3; ++page)
+			{
+				for(uint8_t index = 0; index < 8; ++index)
+				{
+					const ParameterChange change{page, track, index,
+						static_cast<uint8_t>(page * 8 + index)};
+					expectRoundTrip(md::MachineModel::Monomachine, change, 0);
+				}
+			}
+
+			for(const auto page : {monomachine::Level, monomachine::Mute})
+			{
+				const ParameterChange change{page, track, 0,
+					static_cast<uint8_t>(page == monomachine::Mute ? 1 : track)};
+				expectRoundTrip(md::MachineModel::Monomachine, change, 0);
+			}
+		}
+
+		require(!encodeParameterChange(md::MachineModel::Monomachine,
+			{monomachine::Synthesis, 6, 0, 0}, 0), "accepted MM track 7");
+		require(!encodeParameterChange(md::MachineModel::Monomachine,
+			{monomachine::Synthesis, 5, 0, 0}, 11), "accepted overflowing MM channel span");
+	}
+
+	void finishDump(md::automation::sysex::Message& _message)
+	{
+		uint32_t checksum = 0;
+		for(size_t i = 9; i < _message.size(); ++i)
+			checksum += _message[i];
+		checksum &= 0x3fff;
+		const auto finalSize = _message.size() + 5;
+		const auto length = static_cast<uint16_t>(finalSize - 10);
+		_message.push_back(static_cast<uint8_t>(checksum >> 7));
+		_message.push_back(static_cast<uint8_t>(checksum & 0x7f));
+		_message.push_back(static_cast<uint8_t>(length >> 7));
+		_message.push_back(static_cast<uint8_t>(length & 0x7f));
+		_message.push_back(0xf7);
+	}
+
+	std::vector<uint8_t> rleEncode(const std::vector<uint8_t>& _decoded)
+	{
+		std::vector<uint8_t> result;
+		for(size_t position = 0; position < _decoded.size();)
+		{
+			const auto value = _decoded[position];
+			size_t count = 1;
+			while(position + count < _decoded.size()
+				&& _decoded[position + count] == value && count < 127)
+				++count;
+			if(value >= 0x80 || count > 1)
+			{
+				result.push_back(static_cast<uint8_t>(0x80 | count));
+				result.push_back(value);
+			}
+			else
+				result.push_back(value);
+			position += count;
+		}
+		return result;
+	}
+
+	std::vector<uint8_t> pack7Bit(const std::vector<uint8_t>& _decoded)
+	{
+		std::vector<uint8_t> result;
+		for(size_t position = 0; position < _decoded.size();)
+		{
+			const auto headerPosition = result.size();
+			result.push_back(0);
+			for(uint8_t bit = 0; bit < 7 && position < _decoded.size(); ++bit)
+			{
+				const auto value = _decoded[position++];
+				if(value & 0x80)
+					result[headerPosition] |= static_cast<uint8_t>(1u << (6u - bit));
+				result.push_back(static_cast<uint8_t>(value & 0x7f));
+			}
+		}
+		return result;
+	}
+
+	md::automation::sysex::Message makeMmDump(const uint8_t _command,
+		const std::vector<uint8_t>& _decoded)
+	{
+		md::automation::sysex::Message result{
+			0xf0, 0x00, 0x20, 0x3c, 0x03, 0x00, _command, 0x02, 0x01, 0x00};
+		const auto rle = rleEncode(_decoded);
+		const auto packed = pack7Bit(rle);
+		result.insert(result.end(), packed.begin(), packed.end());
+		finishDump(result);
+		return result;
+	}
+
+	void testSysexRequestsAndStatus()
+	{
+		using namespace md::automation::sysex;
+		require(statusRequest(md::MachineModel::Machinedrum,
+			StatusParameter::Global)
+			== Message({0xf0, 0x00, 0x20, 0x3c, 0x02, 0x00, 0x70, 0x01, 0xf7}),
+			"wrong MD status request");
+		require(globalRequest(md::MachineModel::Monomachine, 7)
+			== Message({0xf0, 0x00, 0x20, 0x3c, 0x03, 0x00, 0x51, 0x07, 0xf7}),
+			"wrong MM global request");
+		require(kitRequest(md::MachineModel::Machinedrum, 63)
+			== Message({0xf0, 0x00, 0x20, 0x3c, 0x02, 0x00, 0x53, 0x3f, 0xf7}),
+			"wrong MD kit request");
+
+		const Message response{0xf0, 0x00, 0x20, 0x3c, 0x03, 0x00,
+			0x72, 0x02, 0x37, 0xf7};
+		const auto parsed = parseStatusResponse(md::MachineModel::Monomachine,
+			response);
+		require(parsed && parsed->parameter == StatusParameter::Kit
+			&& parsed->value == 0x37, "could not parse status response");
+		require(!parseStatusResponse(md::MachineModel::Machinedrum, response),
+			"accepted status response for the wrong product");
+	}
+
+	void testMachinedrumDumps()
+	{
+		using namespace md::automation;
+		using namespace md::automation::sysex;
+		Message global{0xf0, 0x00, 0x20, 0x3c, 0x02, 0x00,
+			0x50, 0x05, 0x01, 0x00};
+		global.resize(0xb0, 0);
+		global[0xad] = 11;
+		finishDump(global);
+		require(parseBaseChannel(md::MachineModel::Machinedrum, global) == 11,
+			"wrong MD base channel");
+		global[0xad] = 0x7f;
+		global.resize(global.size() - 5);
+		finishDump(global);
+		require(parseBaseChannel(md::MachineModel::Machinedrum, global) == 0x7f,
+			"MD MIDI NONE should be a valid persisted setting");
+
+		Message kit{0xf0, 0x00, 0x20, 0x3c, 0x02, 0x00,
+			0x52, 0x04, 0x01, 0x00};
+		kit.resize(1228, 0);
+		for(uint8_t track = 0; track < machinedrum::TrackCount; ++track)
+		{
+			for(uint8_t parameter = 0; parameter < 24; ++parameter)
+				kit[0x1a + track * 24 + parameter]
+					= static_cast<uint8_t>((track * 24 + parameter) & 0x7f);
+			kit[0x19a + track] = static_cast<uint8_t>(100 + track);
+		}
+		finishDump(kit);
+		const auto values = parseKitParameters(md::MachineModel::Machinedrum, kit);
+		require(values && values->size() == 400, "wrong MD Kit parameter count");
+		require((*values)[0] == ParameterChange{machinedrum::Synthesis, 0, 0, 0},
+			"wrong first MD Kit parameter");
+		require((*values)[399] == ParameterChange{machinedrum::Level, 15, 0, 115},
+			"wrong last MD Kit parameter");
+		kit[100] ^= 1;
+		require(!parseKitParameters(md::MachineModel::Machinedrum, kit),
+			"accepted corrupt MD Kit checksum");
+	}
+
+	void testMonomachineDumps()
+	{
+		using namespace md::automation;
+		using namespace md::automation::sysex;
+		std::vector<uint8_t> globalData(260, 0);
+		globalData[0] = 0x91;
+		globalData[1] = 5;
+		auto global = makeMmDump(0x50, globalData);
+		require(parseBaseChannel(md::MachineModel::Monomachine, global) == 5,
+			"wrong MM base channel or broken 7-bit/RLE decode");
+
+		std::vector<uint8_t> kitData(698, 0);
+		for(uint8_t track = 0; track < monomachine::TrackCount; ++track)
+		{
+			kitData[0x0b + track] = static_cast<uint8_t>(90 + track);
+			for(uint8_t parameter = 0; parameter < 56; ++parameter)
+				kitData[0x11 + track * 72 + parameter]
+					= static_cast<uint8_t>((track * 56 + parameter) & 0x7f);
+		}
+		kitData.back() = 0xe5;
+		auto kit = makeMmDump(0x52, kitData);
+		const auto values = parseKitParameters(md::MachineModel::Monomachine, kit);
+		require(values && values->size() == 342, "wrong MM Kit parameter count");
+		require((*values)[0] == ParameterChange{monomachine::Synthesis, 0, 0, 0},
+			"wrong first MM Kit parameter");
+		require((*values)[341] == ParameterChange{monomachine::Level, 5, 0, 95},
+			"wrong last MM Kit parameter");
+		kit[12] ^= 1;
+		require(!parseKitParameters(md::MachineModel::Monomachine, kit),
+			"accepted corrupt MM Kit checksum");
+	}
+
+	void testBackupFile(const char* const _path, const md::MachineModel _model)
+	{
+		std::ifstream file(_path, std::ios::binary);
+		require(file.good(), "could not open optional SysEx backup");
+		const std::vector<uint8_t> bytes(std::istreambuf_iterator<char>(file), {});
+		size_t globalCount = 0;
+		size_t kitCount = 0;
+		for(size_t begin = 0; begin < bytes.size();)
+		{
+			begin = static_cast<size_t>(std::find(bytes.begin() + begin, bytes.end(),
+				0xf0) - bytes.begin());
+			if(begin == bytes.size())
+				break;
+			const auto endIterator = std::find(bytes.begin() + begin, bytes.end(), 0xf7);
+			if(endIterator == bytes.end())
+				break;
+			const auto end = static_cast<size_t>(endIterator - bytes.begin());
+			const md::automation::sysex::Message message(bytes.begin() + begin,
+				bytes.begin() + end + 1);
+			if(message.size() > 6 && message[6] == 0x50)
+			{
+				require(md::automation::sysex::parseBaseChannel(_model, message)
+					.has_value(), "could not parse real Global dump");
+				++globalCount;
+			}
+			else if(message.size() > 6 && message[6] == 0x52)
+			{
+				require(md::automation::sysex::parseKitParameters(_model, message)
+					.has_value(), "could not parse real Kit dump");
+				++kitCount;
+			}
+			begin = end + 1;
+		}
+		require(globalCount > 0, "real backup contained no Global dumps");
+		require(kitCount > 0, "real backup contained no Kit dumps");
+	}
+}
+
+int main(const int _argc, const char* const* _argv)
+{
+	testMachinedrum();
+	testMonomachine();
+	testSysexRequestsAndStatus();
+	testMachinedrumDumps();
+	testMonomachineDumps();
+	if(_argc > 1)
+		testBackupFile(_argv[1], md::MachineModel::Machinedrum);
+	if(_argc > 2)
+		testBackupFile(_argv[2], md::MachineModel::Monomachine);
+	std::cout << "automationMidiTest: PASS\n";
+	return 0;
+}

--- a/source/jucePluginLib/controller.cpp
+++ b/source/jucePluginLib/controller.cpp
@@ -301,6 +301,7 @@ namespace pluginLib
 	void Controller::timerCallback()
 	{
 		processMidiMessages();
+		onControllerTimer();
 	}
 
 	bool Controller::sendSysEx(const std::string& _packetName) const

--- a/source/jucePluginLib/controller.h
+++ b/source/jucePluginLib/controller.h
@@ -87,6 +87,15 @@ namespace pluginLib
 		// MIDI routes are unaffected.
 		bool tryEnqueueRealtimeMidiMessage(const synthLib::SMidiEvent& _event);
 
+		// Drains queued controller-facing MIDI immediately. Normal plugin operation
+		// uses the message-thread timer; headless renderers and integration tests may
+		// call this from their controlling (non-audio) thread between process blocks.
+		void processPendingMidiMessages()
+		{
+			processMidiMessages();
+			onControllerTimer();
+		}
+
 		uint64_t getRealtimeMidiIngressContentionDropCount() const
 		{
 			return m_realtimeMidiIngressContentionDrops.load(std::memory_order_relaxed);
@@ -153,6 +162,7 @@ namespace pluginLib
 		void applyPatchParameters(const MidiPacket::ParamValues& _params, uint8_t _part) const;
 
 		virtual bool isDerivedParameter(Parameter& _derived, Parameter& _base) const { return true; }
+		virtual void onControllerTimer() {}
 
         struct ParamIndex
         {

--- a/source/jucePluginLib/parameter.cpp
+++ b/source/jucePluginLib/parameter.cpp
@@ -253,7 +253,21 @@ namespace pluginLib
 		if(m_notifyingHost)
 			return;
 
-		setUnnormalizedValue(juce::roundToInt(convertFrom0to1(_newValue)), Origin::HostAutomation);
+		const auto value = clampValue(juce::roundToInt(convertFrom0to1(_newValue)));
+		if(shouldSendRepeatedHostValues())
+		{
+			if(m_rateLimit)
+				sendParameterChangeDelayed(value, Origin::HostAutomation);
+			else
+				sendParameterChangeNow(value, Origin::HostAutomation);
+			// Publish the cache first so the Value listener does not emit a duplicate.
+			// MIDI-backed parameters must forward every explicit host write, including
+			// first, changed, repeated, and default/zero values.
+			m_lastValue = value;
+			setUnnormalizedValue(value, Origin::HostAutomation);
+			return;
+		}
+		setUnnormalizedValue(value, Origin::HostAutomation);
 	}
 
     void Parameter::setUnnormalizedValue(const int _newValue, const Origin _origin)

--- a/source/jucePluginLib/parameter.h
+++ b/source/jucePluginLib/parameter.h
@@ -98,6 +98,12 @@ namespace pluginLib
 
 		static bool requiresGesture(Origin _origin);
 
+	protected:
+		// Some MIDI-backed devices cannot be initialized from a local patch object.
+		// Their host writes remain meaningful even when equal to the cached/default
+		// value, including an explicit first write of zero.
+		virtual bool shouldSendRepeatedHostValues() const { return false; }
+
 	private:
 
 		struct ScopedChangeGesture

--- a/source/jucePluginLib/processor.cpp
+++ b/source/jucePluginLib/processor.cpp
@@ -870,11 +870,11 @@ namespace pluginLib
 		state.resize(_sizeInBytes);
 		memcpy(state.data(), _data, _sizeInBytes);
 
-		PluginStream ss(state);
-
-		if (ss.checkString(g_saveMagic))
+		try
 		{
-			try
+			PluginStream ss(state);
+
+			if (ss.checkString(g_saveMagic))
 			{
 				const std::string magic = ss.readString();
 
@@ -907,15 +907,15 @@ namespace pluginLib
 					}
 				}
 			}
-			catch (std::range_error& e)
+			else
 			{
-				LOG("Failed to read state: " << e.what());
-				return;
+				getPlugin().setState(state);
 			}
 		}
-		else
+		catch (std::range_error& e)
 		{
-			getPlugin().setState(state);
+			LOG("Failed to read state: " << e.what());
+			return;
 		}
 
 		if (hasController())

--- a/source/synthLib/midiBufferParser.cpp
+++ b/source/synthLib/midiBufferParser.cpp
@@ -31,6 +31,7 @@ namespace synthLib
 		if(d == synthLib::M_STARTOFSYSEX)
 		{
 			m_pendingEventLen = 0;
+			m_runningStatus = 0;
 			flushSysex();
 			m_sysex = true;
 			m_sysexBuffer.push_back(d);
@@ -52,25 +53,50 @@ namespace synthLib
 			flushSysex();	// aborted sysex
 		}
 
-		// Any non-realtime status supersedes an incomplete short message. This is
-		// the MIDI resynchronisation boundary after a lost/truncated data byte.
+		// Any non-realtime status supersedes an incomplete short message. Channel
+		// voice statuses establish running status; System Common messages cancel it.
+		// Realtime messages returned above do not disturb either state.
 		if((d & 0x80) != 0)
+		{
 			m_pendingEventLen = 0;
+			m_runningStatus = d < 0xf0 ? d : 0;
+		}
 
 		if(m_pendingEventLen == 0)
 		{
-			m_pendingEvent.a = d;
-			m_pendingEvent.b = 0;
-			m_pendingEvent.c = 0;
+			if((d & 0x80) == 0)
+			{
+				// A data byte can begin the next running-status message. With no
+				// retained channel status it is an orphan and must not be emitted as
+				// a bogus one-byte MIDI message.
+				if(m_runningStatus == 0)
+					return;
+				m_pendingEvent.a = m_runningStatus;
+				m_pendingEvent.b = d;
+				m_pendingEvent.c = 0;
+				m_pendingEventLen = 2;
+			}
+			else
+			{
+				// F7 outside SysEx is an end marker without a message of its own.
+				if(d == synthLib::M_ENDOFSYSEX)
+					return;
+				m_pendingEvent.a = d;
+				m_pendingEvent.b = 0;
+				m_pendingEvent.c = 0;
+				m_pendingEventLen = 1;
+			}
 			m_pendingEvent.offset = 0;
 			m_pendingEvent.sysex.clear();
 		}
-		else if(m_pendingEventLen == 1)
-			m_pendingEvent.b = d;
-		else if(m_pendingEventLen == 2)
-			m_pendingEvent.c = d;
-
-		++m_pendingEventLen;
+		else
+		{
+			if(m_pendingEventLen == 1)
+				m_pendingEvent.b = d;
+			else if(m_pendingEventLen == 2)
+				m_pendingEvent.c = d;
+			++m_pendingEventLen;
+		}
 
 		if(lengthFromStatusByte(m_pendingEvent.a) == m_pendingEventLen)
 			flushEvent();
@@ -87,6 +113,7 @@ namespace synthLib
 	void MidiBufferParser::discardPartialMessage()
 	{
 		m_pendingEventLen = 0;
+		m_runningStatus = 0;
 		m_sysex = false;
 		m_sysexBuffer.clear();
 	}

--- a/source/synthLib/midiBufferParser.h
+++ b/source/synthLib/midiBufferParser.h
@@ -52,6 +52,7 @@ namespace synthLib
 		SysexBuffer m_sysexBuffer;
 		synthLib::SMidiEvent m_pendingEvent;
 		uint32_t m_pendingEventLen = 0;
+		uint8_t m_runningStatus = 0;
 		bool m_sysex = false;
 	};
 }


### PR DESCRIPTION
## Summary

- expose 416 Machinedrum and 348 Monomachine synthesis parameters to DAW hosts
- translate host automation through the documented Elektron MIDI CC protocol into the real emulated firmware
- synchronize host parameters from firmware CC, Global, Kit, Program Change, and SET STATUS activity
- persist an automation snapshot and replay restored values into firmware after synchronization
- preserve explicit zero and repeated host writes, including writes queued before DSP startup
- add strict SysEx parsing, MIDI running-status support, parameter-identity contracts, and firmware-backed robustness coverage
- keep routine integration testing short while retaining an opt-in full firmware soak

## Stack

This PR is intentionally based on `feature/md-mm-shift-trig-hold` and therefore depends on #2. Its own commit range is only:

- `926c53b2` Add MD and MM DAW automation
- `ef8fd66c` Harden MD and MM automation synchronization
- `702fbc15` Split automation test tiers and prevent late dumps

After #2 merges, this PR can be retargeted to `release/md-mm-public-alpha-20260826` without bringing the Shift/trig commits into this review.

## Validation

- exhaustive MD/MM CC mapping and synthetic SysEx corruption tests
- real Machinedrum and Monomachine backup-dump parsing
- stable host parameter counts and full identity fingerprints
- official-firmware synchronization, explicit-write, UART-consumption, and state-replay tests for both models
- deterministic randomized boot/lifecycle/save/restore/external-MIDI campaign
- malformed, truncated, future-version, wrong-model, duplicate-address, and legacy state coverage
- exact external CC host-notification count, value, and origin
- 8,192 explicit firmware-backed automation writes on each model, with exact transmit counts, complete UART consumption, settled final values, and no overflow or controller-ingress drops
- concurrent MD/MM isolation with 2,048 writes per instance and exact independent message digests
- regression coverage for duplicate startup dump requests arriving after synchronization and overwriting host writes
- existing mdLib, MIDI-learn, Shift-latch, and MD/MM VST3 host tests pass
- MD/MM VST3, AU, and CLAP targets build successfully

The default CTest suite registers a short 256-write/model and 128-write/instance
soak. Configure with `-DMD_AUTOMATION_REGISTER_FULL_SOAK_TEST=ON` to register the
full soak. Final full-soak output:

```text
mdAutomationSoakTest: MD PASS (8192 writes)
mdAutomationSoakTest: MM PASS (8192 writes)
mdAutomationSoakTest: concurrent MD/MM PASS (2048 writes per instance)
```

## Known limitations

- reliable firmware/front-panel-to-DAW mute feedback is unavailable in the published protocol; DAW-to-firmware mute automation works
- VST3 received runtime host validation; AU and CLAP received build/structural validation only
- a ThreadSanitizer build was attempted but could not link with the available disk space, so no sanitizer-clean claim is made
- final acceptance should still exercise automation recording, project reload, and front-panel interaction in representative DAWs
