### PR TITLE
Load official MD and MM updater SysEx files

### DIFF
--- a/doc/elektron_md_mm_sysex.md
+++ b/doc/elektron_md_mm_sysex.md
@@ -1,0 +1,34 @@
+# Machinedrum and Monomachine SysEx
+
+No firmware, factory NVRAM, SysEx backup, preset library, firmware-derived
+fixture, or private test capture is included or downloaded. Users must supply
+files they are entitled to use.
+
+## OS updater files
+
+The emulator accepts an official Machinedrum or Monomachine OS-update `.syx`
+directly. Put the update in the matching legacy data directory used by the
+current builds (`Machinedrum/roms` for Gearmulator MD or `Monomachine/roms` for
+Gearmulator MM), then restart the plug-in or Standalone application. No external
+`.bin` conversion is needed. A matching 8 MiB `.bin` dump remains supported and
+takes precedence when both are present.
+
+The SysEx is decoded into a private Gearmulator image in memory only. That image
+is not a hardware flash dump and must never be sent to a device.
+
+For Monomachine, the updater's factory-data section also supplies the initial
+storage image when no valid `nvram/mm-factory-live3-be.bin` is installed. An
+installed or restored NVRAM image still takes precedence. The official OS
+updater does not contain the separate MKII factory DigiPRO waveform bank, so
+those factory waveforms remain unavailable when booting from `.syx` alone.
+
+## Implementation boundary
+
+The OS-update reader implements the legacy SysEx packet framing plus the update
+container's compressed sections. Its transport decoder and aPLib variant are
+based on Marcel Bierling's MIT-licensed
+[`elektron-firmware-tool`](https://github.com/mischa85/elektron-firmware-tool);
+the required license text is shipped beside the implementation. Gearmulator
+adds a private in-memory image layout and direct initialization of the emulated
+ColdFire and DSP hardware. It does not reconstruct or export a hardware flash
+dump.

--- a/source/elektron/md/mdLib/CMakeLists.txt
+++ b/source/elektron/md/mdLib/CMakeLists.txt
@@ -9,6 +9,8 @@ set(SOURCES
 	mddevice.cpp mddevice.h
 	mddsp.cpp mddsp.h
 	mdfrontpanel.cpp mdfrontpanel.h
+	mdfirmwareupdate.cpp mdfirmwareupdate.h
+	elektron-firmware-tool.LICENSE
 	mdhardware.cpp mdhardware.h
 	mdmc.cpp mdmc.h
 	mdmemorymap.h

--- a/source/elektron/md/mdLib/CMakeLists.txt
+++ b/source/elektron/md/mdLib/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
 	mddevice.cpp mddevice.h
 	mddsp.cpp mddsp.h
 	mdfrontpanel.cpp mdfrontpanel.h
+	mdflash.cpp mdflash.h
 	mdfirmwareupdate.cpp mdfirmwareupdate.h
 	elektron-firmware-tool.LICENSE
 	mdhardware.cpp mdhardware.h

--- a/source/elektron/md/mdLib/elektron-firmware-tool.LICENSE
+++ b/source/elektron/md/mdLib/elektron-firmware-tool.LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Marcel Bierling
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/source/elektron/md/mdLib/mddsp.cpp
+++ b/source/elektron/md/mdLib/mddsp.cpp
@@ -1,5 +1,6 @@
 #include "mddsp.h"
 
+#include "mdfirmwareupdate.h"
 #include "mdhardware.h"
 
 #include "mc68k/hdi08.h"
@@ -172,6 +173,129 @@ namespace md
 		// There are no background DSP threads. Publish the completed boot state to
 		// the deterministic scheduler that owns all subsequent execution.
 		m_schedRunnable.store(true, std::memory_order_release);
+	}
+
+	bool Dsp::loadFirmwareUpdate(const std::vector<uint8_t>& _mainOs,
+		const std::vector<uint8_t>& _specific, const std::vector<uint8_t>& _common,
+		std::string& _error)
+	{
+		// The updater carries the same 133-word resident HI08 loader used by the
+		// first-stage ColdFire code. The main OS contains several related loader
+		// signatures; the bootstrap uses the final (DSP56303) instance. The payload
+		// itself always comes from the user's update file.
+		constexpr uint8_t signature[] =
+			{0xbd, 0xf4, 0x08, 0x23, 0x00, 0x3d, 0xf8, 0x03, 0x00};
+		const auto loader = std::find_end(_mainOs.begin(), _mainOs.end(),
+			std::begin(signature), std::end(signature));
+		constexpr size_t loaderWords = 133;
+		if(loader == _mainOs.end()
+			|| static_cast<size_t>(_mainOs.end() - loader) < loaderWords * 3)
+		{
+			_error = "main OS has no supported DSP resident loader";
+			return false;
+		}
+		auto le24 = [](const uint8_t* const _p)
+		{
+			return static_cast<uint32_t>(_p[0])
+				| (static_cast<uint32_t>(_p[1]) << 8)
+				| (static_cast<uint32_t>(_p[2]) << 16);
+		};
+		if(m_boot.hdiWriteTX(loaderWords) || m_boot.hdiWriteTX(0x100))
+		{
+			_error = "DSP resident loader entered an invalid boot state";
+			return false;
+		}
+		for(size_t i = 0; i < loaderWords; ++i)
+		{
+			const bool finished = m_boot.hdiWriteTX(le24(&*loader + i * 3));
+			if(finished != (i + 1 == loaderWords))
+			{
+				_error = "DSP resident loader has an invalid length";
+				return false;
+			}
+		}
+		onDspBootFinished();
+		// Let the resident loader finish relocating itself to external SRAM and
+		// reach its first host-receive instruction before presenting command data.
+		// The ColdFire does this naturally while polling TXDE after the boot upload.
+		constexpr uint32_t receiveEntry = 0x14ffcb;
+		const uint64_t readyStop = m_dsp.getCycles() + 5'000'000;
+		while(m_dsp.getPC().toWord() != receiveEntry && m_dsp.getCycles() < readyStop)
+			m_dsp.exec();
+		if(m_dsp.getPC().toWord() != receiveEntry)
+		{
+			_error = "DSP resident loader did not reach its receive loop";
+			return false;
+		}
+		size_t sentWords = 0;
+		auto send = [this, &_error, &sentWords](const uint32_t _word)
+		{
+			const uint64_t stop = m_dsp.getCycles() + 1'000'000;
+			while(hdi08().hasRXData() && m_dsp.getCycles() < stop)
+				m_dsp.exec();
+			if(hdi08().hasRXData())
+			{
+				_error = "DSP resident loader stopped accepting data after word "
+					+ std::to_string(sentWords);
+				return false;
+			}
+			hdi08().writeRX(&_word, 1);
+			const uint64_t settleStop = m_dsp.getCycles() + 512;
+			while(m_dsp.getCycles() < settleStop)
+				m_dsp.exec();
+			++sentWords;
+			return true;
+		};
+		auto sendCommand = [this, &send, &_error](const uint32_t _command)
+		{
+			if(!send(_command))
+				return false;
+			const uint64_t stop = m_dsp.getCycles() + 1'000'000;
+			while(!hdi08().hasTX() && m_dsp.getCycles() < stop)
+				m_dsp.exec();
+			if(!hdi08().hasTX() || hdi08().readTX() != _command)
+			{
+				_error = "DSP resident loader did not acknowledge a memory command";
+				return false;
+			}
+			return true;
+		};
+		auto stream = [&send, &sendCommand, &le24, &_error](
+			const std::vector<uint8_t>& _section, const bool _executeTail)
+		{
+			if(_section.size() < 12 || _section.size() % 3)
+			{
+				_error = "DSP section is not a 24-bit command stream";
+				return false;
+			}
+			const size_t wordCount = _section.size() / 3;
+			size_t cursor = 2;
+			while(cursor < wordCount)
+			{
+				const uint32_t command = le24(_section.data() + cursor * 3);
+				if(command == 3)
+				{
+					if(cursor + 2 != wordCount)
+						return false;
+					return !_executeTail || (sendCommand(command)
+						&& send(le24(_section.data() + (cursor + 1) * 3)));
+				}
+				if(command > 2 || cursor + 3 > wordCount)
+					return false;
+				const uint32_t count = le24(_section.data() + (cursor + 2) * 3);
+				if(count > wordCount - cursor - 3 || !sendCommand(command)
+					|| !send(le24(_section.data() + (cursor + 1) * 3)) || !send(count))
+					return false;
+				cursor += 3;
+				for(uint32_t i = 0; i < count; ++i, ++cursor)
+					if(!send(le24(_section.data() + cursor * 3)))
+						return false;
+			}
+			return false;
+		};
+		if(!stream(_specific, false) || !stream(_common, true))
+			return false;
+		return true;
 	}
 
 	namespace

--- a/source/elektron/md/mdLib/mddsp.cpp
+++ b/source/elektron/md/mdLib/mddsp.cpp
@@ -179,6 +179,44 @@ namespace md
 		const std::vector<uint8_t>& _specific, const std::vector<uint8_t>& _common,
 		std::string& _error)
 	{
+		if(_common.empty())
+		{
+			// Machinedrum supplies a complete memory image for each DSP. Applying
+			// its validated records directly is equivalent to the instrument's
+			// resident loader and avoids depending on a particular loader build.
+			struct WriteContext
+			{
+				Dsp& dsp;
+			};
+			WriteContext context{*this};
+			const auto write = [](void* const _context, const uint32_t _space,
+				const uint32_t _address, const uint32_t* const _words,
+				const size_t _count)
+			{
+				if(_space >= dsp56k::MemArea_COUNT)
+					return false;
+				auto& target = static_cast<WriteContext*>(_context)->dsp;
+				const auto area = static_cast<dsp56k::EMemArea>(_space);
+				if(_address > target.m_memory.size(area)
+					|| _count > target.m_memory.size(area) - _address)
+					return false;
+				for(size_t i = 0; i < _count; ++i)
+				{
+					target.m_memory.set(area, _address + static_cast<uint32_t>(i), _words[i]);
+					if(area == dsp56k::MemArea_P)
+						target.m_dsp.getJit().notifyProgramMemWrite(
+							_address + static_cast<uint32_t>(i));
+				}
+				return true;
+			};
+			uint32_t entry = 0;
+			if(!firmwareUpdate::visitDspCommands(_specific, write, &context, entry, _error))
+				return false;
+			m_dsp.setPC(entry);
+			onDspBootFinished();
+			return true;
+		}
+
 		// The updater carries the same 133-word resident HI08 loader used by the
 		// first-stage ColdFire code. The main OS contains several related loader
 		// signatures; the bootstrap uses the final (DSP56303) instance. The payload
@@ -224,7 +262,8 @@ namespace md
 			m_dsp.exec();
 		if(m_dsp.getPC().toWord() != receiveEntry)
 		{
-			_error = "DSP resident loader did not reach its receive loop";
+			_error = "DSP resident loader did not reach its receive loop (PC "
+				+ std::to_string(m_dsp.getPC().toWord()) + ")";
 			return false;
 		}
 		size_t sentWords = 0;
@@ -273,6 +312,14 @@ namespace md
 			while(cursor < wordCount)
 			{
 				const uint32_t command = le24(_section.data() + cursor * 3);
+				if(command == 4)
+				{
+					if(cursor != 2 || cursor + 2 > wordCount
+						|| le24(_section.data() + (cursor + 1) * 3) != 0)
+						return false;
+					cursor += 2;
+					continue;
+				}
 				if(command == 3)
 				{
 					if(cursor + 2 != wordCount)
@@ -293,7 +340,10 @@ namespace md
 			}
 			return false;
 		};
-		if(!stream(_specific, false) || !stream(_common, true))
+		// MM splits each DSP image into a device-specific prefix and a shared
+		// tail. MD instead supplies one complete command stream per DSP.
+		if(_common.empty() ? !stream(_specific, true)
+			: (!stream(_specific, false) || !stream(_common, true)))
 			return false;
 		return true;
 	}

--- a/source/elektron/md/mdLib/mddsp.h
+++ b/source/elektron/md/mdLib/mddsp.h
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <cstdint>
 #include <functional>
+#include <string>
 #include <vector>
 
 #include "dsp56kEmu/dsp.h"
@@ -55,6 +56,9 @@ namespace md
 
 		bool     booted() const { return m_schedRunnable.load(std::memory_order_acquire); }
 		void onDspBootFinished();
+		bool loadFirmwareUpdate(const std::vector<uint8_t>& _mainOs,
+			const std::vector<uint8_t>& _specific, const std::vector<uint8_t>& _common,
+			std::string& _error);
 
 		// Continuously drain this DSP's HOTX into the UC-facing HI08 receive queue, bounded so the
 		// queue never exceeds _maxUcWords. Returns the number of words moved. Safe to call from the

--- a/source/elektron/md/mdLib/mdfirmwareupdate.cpp
+++ b/source/elektron/md/mdLib/mdfirmwareupdate.cpp
@@ -1,0 +1,565 @@
+#include "mdfirmwareupdate.h"
+
+#include "mdtypes.h"
+
+#include <algorithm>
+#include <array>
+
+namespace md::firmwareUpdate
+{
+	namespace
+	{
+		// The pre-ELE transport and aPLib variant are based on the MIT-licensed
+		// elektron-firmware-tool project (Copyright 2026 Marcel Bierling). See
+		// elektron-firmware-tool.LICENSE. This implementation is deliberately limited
+		// to official MD/MM update files.
+		constexpr std::array<uint8_t, 8> g_magic{{'G','S','Y','X','R','O','M','1'}};
+		constexpr size_t g_magicOffset = 0x10;
+		constexpr size_t g_headerSize = 0x100;
+		constexpr size_t g_flashUpdateOffset = 0x4000;
+		constexpr size_t g_payloadOffset = 0x200000;
+		constexpr size_t g_tableOffset = 0x30;
+		constexpr size_t g_recordSize = 12;
+		constexpr uint32_t g_formatVersion = 1;
+		constexpr size_t g_sectionCount = 5;
+		constexpr uint8_t g_deviceMd = 0x02;
+		constexpr uint8_t g_deviceMm = 0x03;
+		constexpr size_t g_transportHeader = 14;
+		constexpr size_t g_sectionHeader = 8;
+		constexpr uint32_t g_aplibOffsetBias = 767;
+		constexpr uint32_t g_aplibReuseGamma = 2;
+		constexpr uint32_t g_aplibFarThreshold = 3328;
+
+		uint32_t readBe32(const uint8_t* const _p)
+		{
+			return (static_cast<uint32_t>(_p[0]) << 24)
+				| (static_cast<uint32_t>(_p[1]) << 16)
+				| (static_cast<uint32_t>(_p[2]) << 8) | _p[3];
+		}
+
+		void writeBe32(std::vector<uint8_t>& _data, const size_t _offset,
+			const uint32_t _value)
+		{
+			_data[_offset] = static_cast<uint8_t>(_value >> 24);
+			_data[_offset + 1] = static_cast<uint8_t>(_value >> 16);
+			_data[_offset + 2] = static_cast<uint8_t>(_value >> 8);
+			_data[_offset + 3] = static_cast<uint8_t>(_value);
+		}
+
+		uint32_t readLe24(const uint8_t* const _p)
+		{
+			return static_cast<uint32_t>(_p[0])
+				| (static_cast<uint32_t>(_p[1]) << 8)
+				| (static_cast<uint32_t>(_p[2]) << 16);
+		}
+
+		uint32_t decodeNibbles(const uint8_t* const _p)
+		{
+			uint32_t value = 0;
+			for(size_t i = 0; i < 6; ++i)
+				value = (value << 4) | _p[i];
+			return value;
+		}
+
+		uint8_t packetChecksum(const uint8_t _device, const uint8_t* const _nibbles,
+			const unsigned _payloadSum)
+		{
+			unsigned sum = _payloadSum;
+			// MD/MM use the non-Octatrack legacy checksum branch.
+			if(_device == g_deviceMd || _device == g_deviceMm)
+				sum += _nibbles[1] + (_nibbles[2] << 4) + _nibbles[3]
+					+ ((_nibbles[4] & 0x0c) << 4);
+			return static_cast<uint8_t>(sum);
+		}
+
+		bool decodeTransport(const std::vector<uint8_t>& _sysex,
+			std::vector<uint8_t>& _container, uint8_t& _device, std::string& _error)
+		{
+			_container.clear();
+			_device = 0;
+			bool sawData = false;
+			bool sawLength = false;
+			uint32_t declaredLength = 0;
+
+			for(size_t begin = 0; begin < _sysex.size();)
+			{
+				if(_sysex[begin] != 0xf0)
+				{
+					++begin;
+					continue;
+				}
+				const auto endIt = std::find(_sysex.begin() + static_cast<std::ptrdiff_t>(begin + 1),
+					_sysex.end(), uint8_t{0xf7});
+				if(endIt == _sysex.end())
+				{
+					_error = "unterminated SysEx message";
+					return false;
+				}
+				const size_t end = static_cast<size_t>(endIt - _sysex.begin());
+				const uint8_t* const body = _sysex.data() + begin + 1;
+				const size_t length = end - begin - 1;
+				begin = end + 1;
+
+				if(length < 6 || body[0] != 0x00 || body[1] != 0x20 || body[2] != 0x3c)
+					continue;
+				if(body[3] != g_deviceMd && body[3] != g_deviceMm)
+					continue;
+				if(_device && _device != body[3])
+				{
+					_error = "mixed Machinedrum and Monomachine SysEx messages";
+					return false;
+				}
+				_device = body[3];
+
+				if(body[5] == 0x7e && length > g_transportHeader)
+				{
+					for(size_t i = 6; i < g_transportHeader; ++i)
+					{
+						if(body[i] > 0x0f)
+						{
+							_error = "invalid legacy packet counter/checksum nibble";
+							return false;
+						}
+					}
+					const size_t encodedLength = length - g_transportHeader;
+					if(encodedLength % 3)
+					{
+						_error = "truncated 2+7+7 firmware packet";
+						return false;
+					}
+					const uint32_t counter = decodeNibbles(body + 8);
+					if(counter != 0x4000u + _container.size())
+					{
+						_error = "out-of-order or missing firmware packet";
+						return false;
+					}
+
+					std::vector<uint8_t> decoded;
+					decoded.reserve(encodedLength / 3 * 2);
+					for(size_t i = g_transportHeader; i < length; i += 3)
+					{
+						if(body[i] > 3 || body[i + 1] > 0x7f || body[i + 2] > 0x7f)
+						{
+							_error = "invalid 2+7+7 firmware payload";
+							return false;
+						}
+						const uint16_t word = static_cast<uint16_t>((body[i] & 3) << 14)
+							| static_cast<uint16_t>(body[i + 1] << 7) | body[i + 2];
+						decoded.push_back(static_cast<uint8_t>(word >> 8));
+						decoded.push_back(static_cast<uint8_t>(word));
+					}
+					unsigned sum = 0;
+					for(const auto byte : decoded)
+						sum += byte;
+					const uint8_t checksum = packetChecksum(_device, body + 8, sum);
+					if(body[6] != ((checksum >> 4) & 0x0f) || body[7] != (checksum & 0x0f))
+					{
+						_error = "firmware packet checksum mismatch";
+						return false;
+					}
+					_container.insert(_container.end(), decoded.begin(), decoded.end());
+					sawData = true;
+				}
+				else if(body[5] == 0x7f && length >= 12)
+				{
+					for(size_t i = 6; i < 12; ++i)
+					{
+						if(body[i] > 0x0f)
+						{
+							_error = "invalid firmware length marker";
+							return false;
+						}
+					}
+					declaredLength = decodeNibbles(body + 6);
+					sawLength = true;
+				}
+			}
+
+			if(!sawData || !_device)
+			{
+				_error = "not a Machinedrum or Monomachine OS update SysEx";
+				return false;
+			}
+			if(!sawLength || declaredLength > _container.size()
+				|| _container.size() - declaredLength > 1)
+			{
+				_error = "firmware length marker is missing or inconsistent";
+				return false;
+			}
+			_container.resize(declaredLength);
+			return true;
+		}
+
+		class BitReader
+		{
+		public:
+			BitReader(const uint8_t* const _begin, const uint8_t* const _end)
+				: m_current(_begin), m_end(_end) {}
+
+			bool bit(uint32_t& _value)
+			{
+				m_tag <<= 1;
+				if((m_tag & 0xff) == 0)
+				{
+					if(m_current == m_end)
+						return false;
+					const uint32_t byte = *m_current++;
+					m_tag = (byte << 1) | 1;
+					_value = (byte >> 7) & 1;
+				}
+				else
+					_value = (m_tag >> 8) & 1;
+				return true;
+			}
+
+			bool byte(uint32_t& _value)
+			{
+				if(m_current == m_end)
+					return false;
+				_value = *m_current++;
+				return true;
+			}
+
+			bool gamma(uint32_t& _value)
+			{
+				_value = 1;
+				for(;;)
+				{
+					uint32_t data = 0;
+					uint32_t last = 0;
+					if(!bit(data) || _value > 0x02000000u)
+						return false;
+					_value = (_value << 1) + data;
+					if(!bit(last))
+						return false;
+					if(last)
+						return true;
+				}
+			}
+
+		private:
+			const uint8_t* m_current;
+			const uint8_t* const m_end;
+			uint32_t m_tag = 0;
+		};
+
+		bool decompressSection(const uint8_t* const _source, const size_t _length,
+			const size_t _limit, std::vector<uint8_t>& _output, std::string& _error)
+		{
+			if(_length < g_sectionHeader)
+				return false;
+			BitReader bits(_source + g_sectionHeader, _source + _length);
+			_output.clear();
+			_output.reserve(std::min<size_t>(_limit, _length * 4));
+			uint32_t lastOffset = 1;
+			for(;;)
+			{
+				uint32_t literal = 0;
+				if(!bits.bit(literal))
+					break;
+				if(literal)
+				{
+					uint32_t value = 0;
+					if(!bits.byte(value) || _output.size() == _limit)
+						break;
+					_output.push_back(static_cast<uint8_t>(value));
+					continue;
+				}
+
+				uint32_t gamma = 0;
+				uint32_t offset = 0;
+				if(!bits.gamma(gamma))
+					break;
+				if(gamma == g_aplibReuseGamma)
+					offset = lastOffset;
+				else
+				{
+					uint32_t low = 0;
+					if(!bits.byte(low))
+						break;
+					const uint32_t rawOffset = (gamma << 8) + low;
+					if(rawOffset == g_aplibOffsetBias)
+						return !_output.empty();
+					if(rawOffset < g_aplibOffsetBias)
+						break;
+					offset = rawOffset - g_aplibOffsetBias;
+					lastOffset = offset;
+				}
+
+				uint32_t a = 0;
+				uint32_t b = 0;
+				if(!bits.bit(a) || !bits.bit(b))
+					break;
+				uint32_t length = 2 * a + b;
+				if(!length)
+				{
+					if(!bits.gamma(length))
+						break;
+					length += 2;
+				}
+				if(offset > g_aplibFarThreshold)
+					++length;
+				++length;
+				if(!offset || offset > _output.size() || length > _limit - _output.size())
+					break;
+				for(uint32_t i = 0; i < length; ++i)
+					_output.push_back(_output[_output.size() - offset]);
+			}
+			_error = "invalid or truncated aPLib firmware section";
+			return false;
+		}
+
+		bool unpackSections(const std::vector<uint8_t>& _container,
+			std::array<std::vector<uint8_t>, g_sectionCount>& _sections,
+			std::array<uint32_t, g_sectionCount>& _compressedOffsets, std::string& _error)
+		{
+			size_t offset = 0;
+			for(size_t section = 0; section < g_sectionCount; ++section)
+			{
+				bool found = false;
+				while(offset + g_sectionHeader <= _container.size())
+				{
+					const uint32_t compressedSize = readBe32(_container.data() + offset);
+					const size_t end = offset + g_sectionHeader + compressedSize;
+					if(compressedSize >= 16 && end <= _container.size())
+					{
+						uint32_t sum = 0;
+						for(size_t i = offset + g_sectionHeader; i < end; ++i)
+							sum += _container[i];
+						if(sum == readBe32(_container.data() + offset + 4))
+						{
+							const size_t limit = section == static_cast<size_t>(Section::MainOs)
+								|| section == static_cast<size_t>(Section::FactoryData)
+								? 0x100000u : 0x200000u;
+							if(!decompressSection(_container.data() + offset,
+								g_sectionHeader + compressedSize, limit, _sections[section], _error))
+								return false;
+							_compressedOffsets[section] = static_cast<uint32_t>(offset);
+							offset = end;
+							found = true;
+							break;
+						}
+					}
+					++offset;
+				}
+				if(!found)
+				{
+					_error = "missing or corrupt firmware section " + std::to_string(section);
+					return false;
+				}
+			}
+			if(_sections[0].empty() || _sections[0].size() > 0x100000
+				|| _sections[4].size() > 0x100000)
+			{
+				_error = "firmware payload does not fit the emulated memory map";
+				return false;
+			}
+			for(size_t i = 1; i <= 3; ++i)
+			{
+				if(_sections[i].empty() || _sections[i].size() % 3)
+				{
+					_error = "invalid 24-bit DSP firmware section";
+					return false;
+				}
+			}
+			uint32_t mixerEntry = 0;
+			uint32_t producerEntry = 0;
+			uint32_t commonEntry = 0;
+			if(!visitDspCommands(_sections[1], nullptr, nullptr, mixerEntry, _error)
+				|| !visitDspCommands(_sections[2], nullptr, nullptr, producerEntry, _error)
+				|| !visitDspCommands(_sections[3], nullptr, nullptr, commonEntry, _error))
+				return false;
+			if(mixerEntry != commonEntry || producerEntry != commonEntry)
+			{
+				_error = "DSP firmware sections disagree on their entry point";
+				return false;
+			}
+			return true;
+		}
+
+		bool locateRecord(const std::vector<uint8_t>& _rom, const Section _section,
+			uint32_t& _offset, uint32_t& _length)
+		{
+			if(!isConvertedRom(_rom))
+				return false;
+			const uint32_t wanted = static_cast<uint32_t>(_section);
+			for(size_t i = 0; i < g_sectionCount; ++i)
+			{
+				const size_t record = g_tableOffset + i * g_recordSize;
+				if(readBe32(_rom.data() + record) != wanted)
+					continue;
+				_offset = readBe32(_rom.data() + record + 4);
+				_length = readBe32(_rom.data() + record + 8);
+				return _offset >= g_headerSize && _offset <= _rom.size()
+					&& _length <= _rom.size() - _offset;
+			}
+			return false;
+		}
+	}
+
+	bool convertSysexToRom(const std::vector<uint8_t>& _sysex,
+		std::vector<uint8_t>& _rom, MachineModel& _model, std::string& _error)
+	{
+		_rom.clear();
+		_error.clear();
+		std::vector<uint8_t> container;
+		uint8_t device = 0;
+		if(!decodeTransport(_sysex, container, device, _error))
+			return false;
+		_model = device == g_deviceMm ? MachineModel::Monomachine : MachineModel::Machinedrum;
+
+		std::array<std::vector<uint8_t>, g_sectionCount> sections;
+		std::array<uint32_t, g_sectionCount> compressedOffsets{};
+		if(!unpackSections(container, sections, compressedOffsets, _error))
+			return false;
+
+		_rom.assign(g_romSize, 0xff);
+		// Reset directly into the already-decompressed main OS. Bytes 8..11 retain
+		// the existing model discriminator used by RomLoader.
+		writeBe32(_rom, 0, 0x00300000);
+		writeBe32(_rom, 4, 0x00200000);
+		writeBe32(_rom, 8, _model == MachineModel::Monomachine
+			? 0x00000248 : 0x6000047a);
+		std::copy(g_magic.begin(), g_magic.end(), _rom.begin() + g_magicOffset);
+		writeBe32(_rom, 0x18, g_formatVersion);
+		writeBe32(_rom, 0x1c, device);
+		writeBe32(_rom, 0x20, static_cast<uint32_t>(g_sectionCount));
+		writeBe32(_rom, 0x24, static_cast<uint32_t>(g_flashUpdateOffset)
+			+ compressedOffsets[static_cast<size_t>(Section::FactoryData)]);
+		// Official pre-ELE update containers are the byte-exact flash payload at
+		// 0x4000. Preserve that mapping for OS code which reads its own flash.
+		if(container.size() > g_payloadOffset - g_flashUpdateOffset)
+		{
+			_rom.clear();
+			_error = "firmware flash payload overlaps the Gearmulator section area";
+			return false;
+		}
+		std::copy(container.begin(), container.end(),
+			_rom.begin() + g_flashUpdateOffset);
+
+		size_t payloadOffset = g_payloadOffset;
+		for(size_t i = 0; i < g_sectionCount; ++i)
+		{
+			payloadOffset = (payloadOffset + 15) & ~size_t{15};
+			if(sections[i].size() > _rom.size() - payloadOffset)
+			{
+				_rom.clear();
+				_error = "decoded firmware does not fit the Gearmulator update image";
+				return false;
+			}
+			const size_t record = g_tableOffset + i * g_recordSize;
+			writeBe32(_rom, record, static_cast<uint32_t>(i));
+			writeBe32(_rom, record + 4, static_cast<uint32_t>(payloadOffset));
+			writeBe32(_rom, record + 8, static_cast<uint32_t>(sections[i].size()));
+			std::copy(sections[i].begin(), sections[i].end(), _rom.begin() + payloadOffset);
+			payloadOffset += sections[i].size();
+		}
+		return true;
+	}
+
+	bool isConvertedRom(const std::vector<uint8_t>& _rom)
+	{
+		return _rom.size() == g_romSize
+			&& std::equal(g_magic.begin(), g_magic.end(), _rom.begin() + g_magicOffset)
+			&& readBe32(_rom.data() + 0x18) == g_formatVersion
+			&& readBe32(_rom.data() + 0x20) == g_sectionCount;
+	}
+
+	bool model(const std::vector<uint8_t>& _rom, MachineModel& _model)
+	{
+		if(!isConvertedRom(_rom))
+			return false;
+		const uint32_t device = readBe32(_rom.data() + 0x1c);
+		if(device == g_deviceMd)
+			_model = MachineModel::Machinedrum;
+		else if(device == g_deviceMm)
+			_model = MachineModel::Monomachine;
+		else
+			return false;
+		return true;
+	}
+
+	bool factoryFlashAddress(const std::vector<uint8_t>& _rom, uint32_t& _address)
+	{
+		if(!isConvertedRom(_rom))
+			return false;
+		_address = readBe32(_rom.data() + 0x24);
+		return _address >= g_flashUpdateOffset && _address < g_payloadOffset;
+	}
+
+	bool readSection(const std::vector<uint8_t>& _rom, const Section _section,
+		std::vector<uint8_t>& _data)
+	{
+		uint32_t offset = 0;
+		uint32_t length = 0;
+		if(!locateRecord(_rom, _section, offset, length))
+			return false;
+		_data.assign(_rom.begin() + offset, _rom.begin() + offset + length);
+		return true;
+	}
+
+	bool visitDspCommands(const std::vector<uint8_t>& _section, const DspWrite _write,
+		void* const _context, uint32_t& _entry, std::string& _error)
+	{
+		if(_section.size() < 12 || _section.size() % 3)
+		{
+			_error = "DSP section is not a 24-bit command stream";
+			return false;
+		}
+		const size_t wordCount = _section.size() / 3;
+		if(readLe24(_section.data()) != 3)
+		{
+			_error = "DSP section has no execute descriptor";
+			return false;
+		}
+		_entry = readLe24(_section.data() + 3);
+		size_t cursor = 2;
+		while(cursor < wordCount)
+		{
+			const uint32_t command = readLe24(_section.data() + cursor * 3);
+			if(command == 3)
+			{
+				if(cursor + 2 != wordCount)
+				{
+					_error = "DSP execute command is not the final record";
+					return false;
+				}
+				const uint32_t tailEntry = readLe24(_section.data() + (cursor + 1) * 3);
+				if(tailEntry != _entry)
+				{
+					_error = "DSP execute descriptors disagree";
+					return false;
+				}
+				return true;
+			}
+			if(command > 2 || cursor + 3 > wordCount)
+			{
+				_error = "unknown or truncated DSP memory command";
+				return false;
+			}
+			const uint32_t address = readLe24(_section.data() + (cursor + 1) * 3);
+			const uint32_t count = readLe24(_section.data() + (cursor + 2) * 3);
+			cursor += 3;
+			if(count > wordCount - cursor)
+			{
+				_error = "truncated DSP memory record";
+				return false;
+			}
+			if(_write)
+			{
+				std::vector<uint32_t> words;
+				words.reserve(count);
+				for(uint32_t i = 0; i < count; ++i)
+					words.push_back(readLe24(_section.data() + (cursor + i) * 3));
+				if(!_write(_context, command, address, words.data(), words.size()))
+				{
+					_error = "DSP memory record is outside the emulated address space";
+					return false;
+				}
+			}
+			cursor += count;
+		}
+		_error = "DSP section has no final execute command";
+		return false;
+	}
+}

--- a/source/elektron/md/mdLib/mdfirmwareupdate.cpp
+++ b/source/elektron/md/mdLib/mdfirmwareupdate.cpp
@@ -309,7 +309,7 @@ namespace md::firmwareUpdate
 			return false;
 		}
 
-		bool unpackSections(const std::vector<uint8_t>& _container,
+		bool unpackSections(const std::vector<uint8_t>& _container, const uint8_t _device,
 			std::array<std::vector<uint8_t>, g_sectionCount>& _sections,
 			std::array<uint32_t, g_sectionCount>& _compressedOffsets, std::string& _error)
 		{
@@ -354,7 +354,8 @@ namespace md::firmwareUpdate
 				_error = "firmware payload does not fit the emulated memory map";
 				return false;
 			}
-			for(size_t i = 1; i <= 3; ++i)
+			const size_t dspSectionCount = _device == g_deviceMd ? 2 : 3;
+			for(size_t i = 1; i <= dspSectionCount; ++i)
 			{
 				if(_sections[i].empty() || _sections[i].size() % 3)
 				{
@@ -364,15 +365,42 @@ namespace md::firmwareUpdate
 			}
 			uint32_t mixerEntry = 0;
 			uint32_t producerEntry = 0;
-			uint32_t commonEntry = 0;
 			if(!visitDspCommands(_sections[1], nullptr, nullptr, mixerEntry, _error)
-				|| !visitDspCommands(_sections[2], nullptr, nullptr, producerEntry, _error)
-				|| !visitDspCommands(_sections[3], nullptr, nullptr, commonEntry, _error))
+				|| !visitDspCommands(_sections[2], nullptr, nullptr, producerEntry, _error))
 				return false;
-			if(mixerEntry != commonEntry || producerEntry != commonEntry)
+			if(mixerEntry != producerEntry)
 			{
 				_error = "DSP firmware sections disagree on their entry point";
 				return false;
+			}
+			if(_device == g_deviceMd)
+			{
+				// Machinedrum carries two complete DSP command streams followed by two
+				// data images. Normalize the private Gearmulator section table to the
+				// mixer/producer/shared shape used by the boot path. The physical
+				// updater order is producer first, mixer second; the untouched
+				// compressed third data image remains available in the flash copy.
+				if(_sections[3].empty() || _sections[3].size() > 0x100000)
+				{
+					_error = "invalid Machinedrum data section";
+					return false;
+				}
+				std::swap(_sections[1], _sections[2]);
+				// The first data section remains compressed in flash and is the
+				// handoff pointer. The second expands into battery-backed patch RAM.
+				_compressedOffsets[4] = _compressedOffsets[3];
+				_sections[3].clear();
+			}
+			else
+			{
+				uint32_t commonEntry = 0;
+				if(!visitDspCommands(_sections[3], nullptr, nullptr, commonEntry, _error))
+					return false;
+				if(mixerEntry != commonEntry)
+				{
+					_error = "DSP firmware sections disagree on their entry point";
+					return false;
+				}
 			}
 			return true;
 		}
@@ -410,7 +438,7 @@ namespace md::firmwareUpdate
 
 		std::array<std::vector<uint8_t>, g_sectionCount> sections;
 		std::array<uint32_t, g_sectionCount> compressedOffsets{};
-		if(!unpackSections(container, sections, compressedOffsets, _error))
+		if(!unpackSections(container, device, sections, compressedOffsets, _error))
 			return false;
 
 		_rom.assign(g_romSize, 0xff);
@@ -517,6 +545,20 @@ namespace md::firmwareUpdate
 		while(cursor < wordCount)
 		{
 			const uint32_t command = readLe24(_section.data() + cursor * 3);
+			if(command == 4)
+			{
+				// Legacy Machinedrum images place one zero-valued stream selector
+				// immediately after the leading execute descriptor. It is metadata
+				// for the ColdFire-side sender, not a DSP memory command.
+				if(cursor != 2 || cursor + 2 > wordCount
+					|| readLe24(_section.data() + (cursor + 1) * 3) != 0)
+				{
+					_error = "invalid DSP stream selector";
+					return false;
+				}
+				cursor += 2;
+				continue;
+			}
 			if(command == 3)
 			{
 				if(cursor + 2 != wordCount)

--- a/source/elektron/md/mdLib/mdfirmwareupdate.h
+++ b/source/elektron/md/mdLib/mdfirmwareupdate.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "mdtypes.h"
+
+namespace md::firmwareUpdate
+{
+	// Gearmulator's 8 MiB update image is a private, deterministic container for
+	// the payloads in an official Machinedrum/Monomachine OS SysEx file. It is not
+	// an Elektron flash dump and is not intended to be written to hardware.
+	enum class Section : uint32_t
+	{
+		MainOs = 0,
+		DspMixer = 1,
+		DspProducer = 2,
+		DspCommon = 3,
+		FactoryData = 4
+	};
+
+	bool convertSysexToRom(const std::vector<uint8_t>& _sysex,
+		std::vector<uint8_t>& _rom, MachineModel& _model, std::string& _error);
+
+	bool isConvertedRom(const std::vector<uint8_t>& _rom);
+	bool model(const std::vector<uint8_t>& _rom, MachineModel& _model);
+	bool factoryFlashAddress(const std::vector<uint8_t>& _rom, uint32_t& _address);
+	bool readSection(const std::vector<uint8_t>& _rom, Section _section,
+		std::vector<uint8_t>& _data);
+
+	// Validate and decode one little-endian 24-bit DSP command stream. Each
+	// callback receives a memory-space command (0=P, 1=X, 2=Y), destination,
+	// and its words. The leading and trailing execute descriptors are validated
+	// and returned through _entry rather than passed to the callback.
+	using DspWrite = bool(*)(void* _context, uint32_t _space, uint32_t _address,
+		const uint32_t* _words, size_t _count);
+	bool visitDspCommands(const std::vector<uint8_t>& _section, DspWrite _write,
+		void* _context, uint32_t& _entry, std::string& _error);
+}

--- a/source/elektron/md/mdLib/mdflash.cpp
+++ b/source/elektron/md/mdLib/mdflash.cpp
@@ -1,0 +1,91 @@
+#include "mdflash.h"
+
+namespace md
+{
+	namespace
+	{
+		constexpr uint32_t g_unlockAddress1 = 0x0000aaaa;
+		constexpr uint32_t g_unlockAddress2 = 0x00005554;
+		constexpr uint16_t g_unlockValue1 = 0xaaaa;
+		constexpr uint16_t g_unlockValue2 = 0x5555;
+		constexpr uint16_t g_identifyCommand = 0x9090;
+		constexpr uint16_t g_programCommand = 0xa0a0;
+		constexpr uint16_t g_eraseCommand = 0x8080;
+		constexpr uint16_t g_eraseSectorCommand = 0x3030;
+		constexpr uint16_t g_resetCommand = 0xf0f0;
+	}
+
+	std::optional<FlashCommandDecoder::Operation> FlashCommandDecoder::write16(
+		const uint32_t _offset, const uint16_t _value)
+	{
+		// Once Program has been armed, every 16-bit value is payload. In
+		// particular F0F0 is valid firmware data rather than a reset command.
+		if(_value == g_resetCommand && m_state != State::Program)
+		{
+			m_state = State::ReadArray;
+			return std::nullopt;
+		}
+
+		switch(m_state)
+		{
+		case State::ReadArray:
+		case State::Identify:
+			m_state = _offset == g_unlockAddress1 && _value == g_unlockValue1
+				? State::Unlock1 : State::ReadArray;
+			break;
+		case State::Unlock1:
+			m_state = _offset == g_unlockAddress2 && _value == g_unlockValue2
+				? State::Unlock2 : State::ReadArray;
+			break;
+		case State::Unlock2:
+			if(_offset != g_unlockAddress1)
+				m_state = State::ReadArray;
+			else if(_value == g_identifyCommand)
+				m_state = State::Identify;
+			else if(_value == g_programCommand)
+				m_state = State::Program;
+			else if(_value == g_eraseCommand)
+				m_state = State::EraseUnlock1;
+			else
+				m_state = State::ReadArray;
+			break;
+		case State::Program:
+			m_state = State::ReadArray;
+			return Operation{Operation::Type::ProgramWord, _offset, _value};
+		case State::EraseUnlock1:
+			m_state = _offset == g_unlockAddress1 && _value == g_unlockValue1
+				? State::EraseUnlock2 : State::ReadArray;
+			break;
+		case State::EraseUnlock2:
+			m_state = _offset == g_unlockAddress2 && _value == g_unlockValue2
+				? State::EraseCommand : State::ReadArray;
+			break;
+		case State::EraseCommand:
+			m_state = State::ReadArray;
+			if(_value == g_eraseSectorCommand)
+				return Operation{Operation::Type::EraseSector, _offset, 0xffff};
+			break;
+		}
+		return std::nullopt;
+	}
+
+	std::optional<uint16_t> FlashCommandDecoder::read16(const uint32_t _offset) const
+	{
+		if(m_state != State::Identify)
+			return std::nullopt;
+		if(_offset == 0)
+			return g_manufacturerId;
+		if(_offset == 2)
+			return g_deviceId;
+		return uint16_t{0};
+	}
+
+	std::optional<uint8_t> FlashCommandDecoder::read8(const uint32_t _offset) const
+	{
+		const auto word = read16(_offset & ~uint32_t{1});
+		if(!word)
+			return std::nullopt;
+		return (_offset & 1) ? static_cast<uint8_t>(*word)
+			: static_cast<uint8_t>(*word >> 8);
+	}
+}

--- a/source/elektron/md/mdLib/mdflash.h
+++ b/source/elektron/md/mdLib/mdflash.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+namespace md
+{
+	// AMD-compatible command interface used by the Machinedrum's 8 MiB NOR
+	// flash. The Microcontroller owns the bytes and applies returned mutations.
+	class FlashCommandDecoder
+	{
+	public:
+		struct Operation
+		{
+			enum class Type : uint8_t { ProgramWord, EraseSector };
+			Type type;
+			uint32_t offset;
+			uint16_t value;
+		};
+
+		static constexpr uint16_t g_manufacturerId = 0x0020;
+		static constexpr uint16_t g_deviceId = 0x22fd;
+		static constexpr uint32_t g_sectorSize = 0x10000;
+
+		std::optional<Operation> write16(uint32_t _offset, uint16_t _value);
+		std::optional<uint16_t> read16(uint32_t _offset) const;
+		std::optional<uint8_t> read8(uint32_t _offset) const;
+
+	private:
+		enum class State : uint8_t
+		{
+			ReadArray,
+			Unlock1,
+			Unlock2,
+			Identify,
+			Program,
+			EraseUnlock1,
+			EraseUnlock2,
+			EraseCommand
+		};
+
+		State m_state = State::ReadArray;
+	};
+}

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -1,8 +1,11 @@
 #include "mdhardware.h"
 
+#include "mdfirmwareupdate.h"
+#include "mdmemorymap.h"
 #include "mdmmwaveforms.h"
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
@@ -42,6 +45,33 @@ namespace md
 		return RomLoader::findROM(_model);
 	}
 
+	std::vector<uint8_t> initMainRam(const Rom& _rom)
+	{
+		std::vector<uint8_t> result;
+		if(firmwareUpdate::isConvertedRom(_rom.data()))
+			firmwareUpdate::readSection(_rom.data(), firmwareUpdate::Section::MainOs, result);
+		return result;
+	}
+
+	std::vector<uint8_t> initPatchRam(const Rom& _rom,
+		const std::vector<uint8_t>& _requested)
+	{
+		if(_requested.size() == memorymap::g_patchBootstrap.size())
+			return _requested;
+		std::vector<uint8_t> factory;
+		if(!firmwareUpdate::isConvertedRom(_rom.data())
+			|| !firmwareUpdate::readSection(_rom.data(),
+				firmwareUpdate::Section::FactoryData, factory)
+			|| factory.size() > memorymap::g_patchBootstrap.size())
+			return _requested;
+		factory.resize(memorymap::g_patchBootstrap.size(), 0);
+		// The physical bootstrap writes this warm-start cookie after expanding the
+		// factory image. Recreate it because direct update boot bypasses that code.
+		constexpr std::array<uint8_t, 4> cookie{{'D','A','V','E'}};
+		std::copy(cookie.begin(), cookie.end(), factory.end() - 8);
+		return factory;
+	}
+
 	uint64_t fingerprintRom(const std::vector<uint8_t>& _data)
 	{
 		uint64_t result = 14695981039346656037ull;
@@ -60,7 +90,7 @@ namespace md
 		: m_model(_model)
 		, m_rom(initRom(_romData, _romName, _model))
 		, m_firmwareFingerprint(fingerprintRom(m_rom.data()))
-		, m_uc(m_rom, m_model, _initialPatchRam)
+		, m_uc(m_rom, m_model, initPatchRam(m_rom, _initialPatchRam), initMainRam(m_rom))
 		, m_frontPanelPublisher(_frontPanelPublisher
 			? std::move(_frontPanelPublisher)
 			: std::make_shared<FrontPanelPublisher>())
@@ -436,8 +466,59 @@ namespace md
 			});
 		}
 
+		const bool firmwareUpdateBoot = firmwareUpdate::isConvertedRom(m_rom.data());
+		if(firmwareUpdateBoot)
+		{
+			std::vector<uint8_t> mixer;
+			std::vector<uint8_t> producer;
+			std::vector<uint8_t> common;
+			std::vector<uint8_t> mainOs;
+			const bool sectionsRead = firmwareUpdate::readSection(m_rom.data(),
+				firmwareUpdate::Section::MainOs, mainOs)
+				&& firmwareUpdate::readSection(m_rom.data(),
+					firmwareUpdate::Section::DspMixer, mixer)
+				&& firmwareUpdate::readSection(m_rom.data(),
+					firmwareUpdate::Section::DspProducer, producer)
+				&& firmwareUpdate::readSection(m_rom.data(),
+					firmwareUpdate::Section::DspCommon, common);
+			std::string error;
+			if(!sectionsRead || !m_dspMixer.loadFirmwareUpdate(mainOs, mixer, common, error)
+				|| !m_dspProducer.loadFirmwareUpdate(mainOs, producer, common, error))
+			{
+				std::fprintf(stderr, "[MD/MM] cannot direct-boot OS update %s: %s\n",
+					m_rom.getFilename().c_str(),
+					sectionsRead ? error.c_str() : "missing DSP section");
+				m_rom.invalidate();
+				return;
+			}
+			// On the instrument the DSPs execute while the much slower ColdFire
+			// expands the main OS. Give both programs time to finish their reset-time
+			// initialization before starting the already-expanded OS directly.
+			const uint64_t updateDspLeadCycles = isMonomachine()
+				? 173'400'000u : 335'100'000u;
+			while(m_dspMixer.dsp().getCycles() < updateDspLeadCycles
+				|| m_dspProducer.dsp().getCycles() < updateDspLeadCycles)
+			{
+				if(m_dspMixer.dsp().getCycles() <= m_dspProducer.dsp().getCycles())
+					m_dspMixer.dsp().exec();
+				else
+					m_dspProducer.dsp().exec();
+			}
+			m_uc.getSim().prepareFirmwareUpdateBoot(isMonomachine());
+		}
+
 		// Load SP/PC from the reset vectors before scheduled UC execution starts.
 		m_uc.reset();
+		if(firmwareUpdateBoot)
+		{
+			uint32_t factoryAddress = 0;
+			if(!firmwareUpdate::factoryFlashAddress(m_rom.data(), factoryAddress))
+			{
+				m_rom.invalidate();
+				return;
+			}
+			m_uc.prepareFirmwareUpdateBoot(factoryAddress);
+		}
 		m_uc.exec();	// prefetch warm-up (retires nothing; matches the synchronous harness)
 
 	}

--- a/source/elektron/md/mdLib/mdmc.cpp
+++ b/source/elektron/md/mdLib/mdmc.cpp
@@ -50,6 +50,8 @@ namespace md
 		: Mc68k(M68K_CPU_TYPE_MCF5206E)
 		, m_model(_model)
 		, m_rom(_rom)
+		, m_flashData(_model == MachineModel::Machinedrum
+			? _rom.data() : std::vector<uint8_t>{})
 		, m_patchRam(memorymap::g_patchBootstrap.size(), 0)
 		, m_mainRam(memorymap::g_mainRam.size(), 0)
 		, m_loaderRam(memorymap::g_loaderRam.size(), 0)
@@ -103,8 +105,16 @@ namespace md
 		cpu->cf_rambar = 0x01000001;
 		cpu->cf_mbar = 0x00300001;
 		m68k_set_reg(cpu, M68K_REG_D1, 1);
-		m68k_set_reg(cpu, M68K_REG_D2, _factoryFlashAddress - 0x10);
-		m68k_set_reg(cpu, M68K_REG_A2, _factoryFlashAddress);
+		if(m_model == MachineModel::Machinedrum)
+		{
+			m68k_set_reg(cpu, M68K_REG_D2, 0);
+			m68k_set_reg(cpu, M68K_REG_A2, _factoryFlashAddress - 1);
+		}
+		else
+		{
+			m68k_set_reg(cpu, M68K_REG_D2, _factoryFlashAddress - 0x10);
+			m68k_set_reg(cpu, M68K_REG_A2, _factoryFlashAddress);
+		}
 		// The physical first stage completes the panel-present handshake before it
 		// enters the main OS. Direct update boot skips that UART exchange, so publish
 		// the same bridge state and route subsequent bytes to the panel decoder.
@@ -155,7 +165,8 @@ namespace md
 		auto rom = [this](const uint32_t _offset) -> Region
 		{
 			Region r;
-			r.data = const_cast<uint8_t*>(m_rom.data().data());	// read-only region; writes are gated by 'writable'
+			r.data = m_flashData.empty()
+				? const_cast<uint8_t*>(m_rom.data().data()) : m_flashData.data();
 			r.offset = _offset;
 			r.size = static_cast<uint32_t>(m_rom.data().size());
 			r.writable = false;
@@ -279,7 +290,6 @@ namespace md
 
 	uint32_t Microcontroller::exec()
 	{
-
 		// Step the CPU one instruction, then advance the derived SIM and interrupt wiring.
 		const auto cycles = Mc68k::exec();
 		advanceAfterCpu(cycles);
@@ -445,6 +455,16 @@ namespace md
 
 	uint8_t Microcontroller::read8(const uint32_t _addr)
 	{
+		if(m_model == MachineModel::Machinedrum)
+		{
+			const auto offset = memorymap::g_flashLow.contains(_addr)
+				? memorymap::g_flashLow.offset(_addr)
+				: (memorymap::g_flashFull.contains(_addr)
+					? memorymap::g_flashFull.offset(_addr) : UINT32_MAX);
+			if(offset != UINT32_MAX)
+				if(const auto value = m_flashCommands.read8(offset))
+					return *value;
+		}
 		if(memorymap::g_sim.contains(_addr))		return m_sim.read8(memorymap::g_sim.offset(_addr));
 		if(memorymap::g_dsp1Hdi08.contains(_addr))	return m_hdi08Dsp1.read8(static_cast<mc68k::PeriphAddress>(memorymap::g_dsp1Hdi08.offset(_addr)));
 		if(memorymap::g_dsp2Hdi08.contains(_addr))	return m_hdi08Dsp2.read8(static_cast<mc68k::PeriphAddress>(memorymap::g_dsp2Hdi08.offset(_addr)));
@@ -509,6 +529,16 @@ namespace md
 
 	uint16_t Microcontroller::read16(const uint32_t _addr)
 	{
+		if(m_model == MachineModel::Machinedrum)
+		{
+			const auto offset = memorymap::g_flashLow.contains(_addr)
+				? memorymap::g_flashLow.offset(_addr)
+				: (memorymap::g_flashFull.contains(_addr)
+					? memorymap::g_flashFull.offset(_addr) : UINT32_MAX);
+			if(offset != UINT32_MAX)
+				if(const auto value = m_flashCommands.read16(offset))
+					return *value;
+		}
 		if(memorymap::g_sim.contains(_addr))		return m_sim.read16(memorymap::g_sim.offset(_addr));
 		if(memorymap::g_dsp1Hdi08.contains(_addr))	return m_hdi08Dsp1.read16(static_cast<mc68k::PeriphAddress>(memorymap::g_dsp1Hdi08.offset(_addr)));
 		if(memorymap::g_dsp2Hdi08.contains(_addr))	return m_hdi08Dsp2.read16(static_cast<mc68k::PeriphAddress>(memorymap::g_dsp2Hdi08.offset(_addr)));
@@ -539,6 +569,38 @@ namespace md
 
 	void Microcontroller::write16(const uint32_t _addr, const uint16_t _val)
 	{
+		if(m_model == MachineModel::Machinedrum)
+		{
+			const auto offset = memorymap::g_flashLow.contains(_addr)
+				? memorymap::g_flashLow.offset(_addr)
+				: (memorymap::g_flashFull.contains(_addr)
+					? memorymap::g_flashFull.offset(_addr) : UINT32_MAX);
+			if(offset != UINT32_MAX)
+			{
+				if(const auto operation = m_flashCommands.write16(offset, _val))
+				{
+					if(operation->type == FlashCommandDecoder::Operation::Type::ProgramWord
+						&& operation->offset + 1 < m_flashData.size())
+					{
+						m_flashData[operation->offset] &= static_cast<uint8_t>(operation->value >> 8);
+						m_flashData[operation->offset + 1] &= static_cast<uint8_t>(operation->value);
+					}
+					else if(operation->type == FlashCommandDecoder::Operation::Type::EraseSector)
+					{
+						const auto begin = operation->offset
+							& ~(FlashCommandDecoder::g_sectorSize - 1);
+						const auto end = std::min<uint32_t>(begin
+							+ FlashCommandDecoder::g_sectorSize,
+							static_cast<uint32_t>(m_flashData.size()));
+						if(begin < end)
+							std::fill(m_flashData.begin() + begin, m_flashData.begin() + end,
+								uint8_t{0xff});
+					}
+					m_immPageAddress = 0xffffffffu;
+				}
+				return;
+			}
+		}
 		if(memorymap::g_sim.contains(_addr))		{ m_sim.write16(memorymap::g_sim.offset(_addr), _val); return; }
 		if(memorymap::g_dsp1Hdi08.contains(_addr))	{ m_hdi08Dsp1.write16(static_cast<mc68k::PeriphAddress>(memorymap::g_dsp1Hdi08.offset(_addr)), _val); return; }
 		if(memorymap::g_dsp2Hdi08.contains(_addr))	{ m_hdi08Dsp2.write16(static_cast<mc68k::PeriphAddress>(memorymap::g_dsp2Hdi08.offset(_addr)), _val); return; }

--- a/source/elektron/md/mdLib/mdmc.cpp
+++ b/source/elektron/md/mdLib/mdmc.cpp
@@ -45,7 +45,8 @@ namespace md
 	}
 
 	Microcontroller::Microcontroller(const Rom& _rom, const MachineModel _model,
-		const std::vector<uint8_t>& _initialPatchRam)
+		const std::vector<uint8_t>& _initialPatchRam,
+		const std::vector<uint8_t>& _initialMainRam)
 		: Mc68k(M68K_CPU_TYPE_MCF5206E)
 		, m_model(_model)
 		, m_rom(_rom)
@@ -82,12 +83,35 @@ namespace md
 		// A complete patch-RAM image is already initialized and can be restored as-is.
 		if(_initialPatchRam.size() == m_patchRam.size())
 			m_patchRam = _initialPatchRam;
+		if(_initialMainRam.size() <= m_mainRam.size())
+			std::copy(_initialMainRam.begin(), _initialMainRam.end(), m_mainRam.begin());
 	}
 
 	std::vector<uint8_t> Microcontroller::copyPatchRam() const
 	{
 		std::shared_lock lock(m_patchRamMutex);
 		return m_patchRam;
+	}
+
+	void Microcontroller::prepareFirmwareUpdateBoot(const uint32_t _factoryFlashAddress)
+	{
+		// State established by the MCF5206E first-stage loader before the main OS
+		// handoff. ACR0/1 remain at reset (zero).
+		auto* const cpu = getCpuState();
+		cpu->vbr = 0x01000000;
+		cpu->cacr = 0x81000503;
+		cpu->cf_rambar = 0x01000001;
+		cpu->cf_mbar = 0x00300001;
+		m68k_set_reg(cpu, M68K_REG_D1, 1);
+		m68k_set_reg(cpu, M68K_REG_D2, _factoryFlashAddress - 0x10);
+		m68k_set_reg(cpu, M68K_REG_A2, _factoryFlashAddress);
+		// The physical first stage completes the panel-present handshake before it
+		// enters the main OS. Direct update boot skips that UART exchange, so publish
+		// the same bridge state and route subsequent bytes to the panel decoder.
+		m_panelProbeIndex = 0;
+		m_mmPanelProbeIndex = 0;
+		m_mmPanelHandshakeDone = true;
+		m_panelDisplayReady = true;
 	}
 
 	void Microcontroller::readMidiOut(std::vector<synthLib::SMidiEvent>& _midiOut)

--- a/source/elektron/md/mdLib/mdmc.h
+++ b/source/elektron/md/mdLib/mdmc.h
@@ -14,6 +14,7 @@
 #include "mc68k/mc68k.h"
 #include "mc68k/hdi08.h"
 
+#include "mdflash.h"
 #include "mdsim.h"
 #include "mdturbomidi.h"
 #include "mdtypes.h"
@@ -176,6 +177,8 @@ namespace md
 
 		const MachineModel m_model;
 		const Rom& m_rom;
+		FlashCommandDecoder m_flashCommands;
+		std::vector<uint8_t> m_flashData;
 
 		Sim m_sim;	// on-chip SIM peripheral window (MBAR base 0x300000)
 		struct MidiTxBuffer

--- a/source/elektron/md/mdLib/mdmc.h
+++ b/source/elektron/md/mdLib/mdmc.h
@@ -47,7 +47,8 @@ namespace md
 	{
 	public:
 		Microcontroller(const Rom& _rom, MachineModel _model = MachineModel::Machinedrum,
-			const std::vector<uint8_t>& _initialPatchRam = {});
+			const std::vector<uint8_t>& _initialPatchRam = {},
+			const std::vector<uint8_t>& _initialMainRam = {});
 
 		// mc68k::Mc68k overrides
 		uint32_t exec() override;
@@ -64,6 +65,7 @@ namespace md
 
 		uint32_t getResetPC() override;
 		uint32_t getResetSP() override;
+		void prepareFirmwareUpdateBoot(uint32_t _factoryFlashAddress);
 
 		// ColdFire-facing HI08 register files for the two DSPs. The Hardware owns the
 		// md::Dsp wrappers and registers their boot/bridge callbacks on these; the

--- a/source/elektron/md/mdLib/mdromloader.cpp
+++ b/source/elektron/md/mdLib/mdromloader.cpp
@@ -1,5 +1,11 @@
 #include "mdromloader.h"
 
+#include "mdfirmwareupdate.h"
+
+#include "baseLib/filesystem.h"
+
+#include <cstdio>
+
 namespace md
 {
 	Rom RomLoader::findROM()
@@ -10,15 +16,36 @@ namespace md
 	Rom RomLoader::findROM(const MachineModel _model)
 	{
 		const auto files = findFiles(".bin", g_romSize, g_romSize);
-
-		if(files.empty())
-			return {};
-
 		for (const auto& file : files)
 		{
 			auto rom = Rom(file);
 			if(rom.isValid() && isRomForModel(rom.data(), _model))
 				return rom;
+		}
+
+		// Official MD/MM updates can be placed in the same roms directory as a
+		// traditional dump. A real 8 MiB .bin remains the first choice; otherwise
+		// convert the .syx to Gearmulator's private update image in memory.
+		for(const auto& file : findFiles(".syx", 1, 16u * 1024u * 1024u))
+		{
+			std::vector<uint8_t> sysex;
+			if(!baseLib::filesystem::readFile(sysex, file))
+				continue;
+			std::vector<uint8_t> converted;
+			MachineModel model = MachineModel::Machinedrum;
+			std::string error;
+			if(!firmwareUpdate::convertSysexToRom(sysex, converted, model, error))
+			{
+				std::fprintf(stderr, "[MD/MM] ignoring OS update %s: %s\n",
+					file.c_str(), error.c_str());
+				continue;
+			}
+			if(model == _model)
+			{
+				std::fprintf(stderr, "[MD/MM] official OS update discovered at %s\n",
+					file.c_str());
+				return Rom(converted, file);
+			}
 		}
 		return {};
 	}
@@ -28,6 +55,9 @@ namespace md
 	{
 		if(_data.size() != g_romSize)
 			return false;
+		MachineModel updateModel = MachineModel::Machinedrum;
+		if(firmwareUpdate::model(_data, updateModel))
+			return updateModel == _model;
 
 		uint64_t fingerprint = 14695981039346656037ull;
 		for(const auto byte : _data)

--- a/source/elektron/md/mdLib/mdsim.cpp
+++ b/source/elektron/md/mdLib/mdsim.cpp
@@ -45,6 +45,47 @@ namespace md
 		}
 	}
 
+	void Sim::prepareFirmwareUpdateBoot(const bool _monomachine)
+	{
+		// Chip-select and board glue setup observed at the documented main-OS
+		// handoff. The differing values describe the MD and MM physical maps; all
+		// UART/port values below are ordinary MCF5206E programming-model fields.
+		const auto set = [this](const uint32_t _offset, const uint8_t _value)
+		{
+			write8(_offset, _value);
+		};
+		if(!_monomachine)
+		{
+			set(0x047, 0x25); set(0x04a, 0x40); set(0x04d, 0x20);
+			set(0x051, 0x0e); set(0x057, 0x27);
+		}
+		set(0x069, 0x0f);
+		set(0x06e, _monomachine ? 0x15 : 0x19);
+		set(0x06f, _monomachine ? 0xc3 : 0xdf);
+		set(0x071, 0x10); set(0x075, 0x0f);
+		set(0x07a, _monomachine ? 0x0d : 0x19);
+		set(0x07b, _monomachine ? 0xdb : 0xdf);
+		set(0x07d, 0x50); set(0x086, 0x01); set(0x087, 0x47);
+		set(0x089, 0x60); set(0x092, 0x01); set(0x093, 0x47);
+		if(_monomachine)
+		{
+			set(0x0a1, 0x20); set(0x0a5, 0x0f);
+			set(0x0aa, 0x01); set(0x0ab, 0x83);
+		}
+		set(0x0cb, 0x82);
+
+		set(g_uart1Base + g_uartMr, 0x07);
+		set(g_uart1Base + g_uartCr, 0x04);
+		set(g_uart1Base + g_uartBg2, 0x28);
+		set(g_uart1Base + g_uartIvr, 0x40);
+		set(g_uart2Base + g_uartMr, 0x07);
+		set(g_uart2Base + g_uartCr, 0x04);
+		set(g_uart2Base + g_uartBg2, 0x08);
+		set(g_uart2Base + g_uartIvr, 0x40);
+		set(g_ppddr, 0x01);
+		set(g_ppdat, 0xfe);
+	}
+
 	// -------------------------------------------------------------------------
 	// Byte access - all behavioural special cases live here; 16/32-bit accessors
 	// decompose into big-endian byte accesses so they share this logic.

--- a/source/elektron/md/mdLib/mdsim.h
+++ b/source/elektron/md/mdLib/mdsim.h
@@ -135,6 +135,9 @@ namespace md
 		// Return every register to its documented power-on state. Transmit callbacks
 		// (which are wiring, not device state) are preserved.
 		void reset();
+		// Recreate the SIM register state established by the MD/MM first-stage
+		// bootstrap before it hands control to the main OS.
+		void prepareFirmwareUpdateBoot(bool _monomachine);
 
 		// -------------------------------------------------------------------------
 		// Register access entry points. mdmc resolves an address in $300000..$30ffff

--- a/source/elektron/md/mdLib/test/mdfirmwareupdate_test.cpp
+++ b/source/elektron/md/mdLib/test/mdfirmwareupdate_test.cpp
@@ -1,0 +1,301 @@
+#include "mdLib/mdfirmwareupdate.h"
+#include "mdLib/mdhardware.h"
+#include "mdLib/mdromloader.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <cstdio>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+namespace
+{
+	void appendWord(std::vector<uint8_t>& _data, const uint32_t _word)
+	{
+		_data.push_back(static_cast<uint8_t>(_word));
+		_data.push_back(static_cast<uint8_t>(_word >> 8));
+		_data.push_back(static_cast<uint8_t>(_word >> 16));
+	}
+
+	void writeBe32(std::vector<uint8_t>& _data, const size_t _offset,
+		const uint32_t _value)
+	{
+		_data[_offset] = static_cast<uint8_t>(_value >> 24);
+		_data[_offset + 1] = static_cast<uint8_t>(_value >> 16);
+		_data[_offset + 2] = static_cast<uint8_t>(_value >> 8);
+		_data[_offset + 3] = static_cast<uint8_t>(_value);
+	}
+
+	class LiteralPacker
+	{
+	public:
+		LiteralPacker() : m_data(8, 0) {}
+
+		void bit(const bool _value)
+		{
+			if(!m_tagBits)
+			{
+				m_tagPosition = m_data.size();
+				m_data.push_back(0);
+				m_tagBits = 8;
+			}
+			if(_value)
+				m_data[m_tagPosition] |= static_cast<uint8_t>(1u << (m_tagBits - 1));
+			--m_tagBits;
+		}
+
+		void byte(const uint8_t _value) { m_data.push_back(_value); }
+
+		void gamma(const uint32_t _value)
+		{
+			unsigned bits = 0;
+			for(uint32_t value = _value; value; value >>= 1)
+				++bits;
+			for(int bitIndex = static_cast<int>(bits) - 2; bitIndex >= 0; --bitIndex)
+			{
+				bit((_value >> bitIndex) & 1);
+				bit(bitIndex == 0);
+			}
+		}
+
+		std::vector<uint8_t> finish(const std::vector<uint8_t>& _input)
+		{
+			for(const auto value : _input)
+			{
+				bit(true);
+				byte(value);
+			}
+			// The Elektron aPLib variant terminates with an intentionally wrapping
+			// raw offset: (0x1000002 << 8) + 0xff == 767 in 32 bits.
+			bit(false);
+			gamma(0x01000002);
+			byte(0xff);
+			writeBe32(m_data, 0, static_cast<uint32_t>(m_data.size() - 8));
+			uint32_t sum = 0;
+			for(size_t i = 8; i < m_data.size(); ++i)
+				sum += m_data[i];
+			writeBe32(m_data, 4, sum);
+			return std::move(m_data);
+		}
+
+	private:
+		std::vector<uint8_t> m_data;
+		size_t m_tagPosition = 0;
+		unsigned m_tagBits = 0;
+	};
+
+	std::vector<uint8_t> pack(const std::vector<uint8_t>& _input)
+	{
+		return LiteralPacker{}.finish(_input);
+	}
+
+	void appendNibbles(std::vector<uint8_t>& _data, const uint32_t _value)
+	{
+		for(int shift = 20; shift >= 0; shift -= 4)
+			_data.push_back(static_cast<uint8_t>((_value >> shift) & 0x0f));
+	}
+
+	std::vector<uint8_t> makeSysex(const uint8_t _device,
+		const std::vector<std::vector<uint8_t>>& _sections)
+	{
+		std::vector<uint8_t> container;
+		for(const auto& section : _sections)
+		{
+			const auto compressed = pack(section);
+			container.insert(container.end(), compressed.begin(), compressed.end());
+		}
+		std::vector<uint8_t> result{0xf0, 0x00, 0x20, 0x3c, _device, 0x00, 0x7e};
+		const size_t checksumPosition = result.size();
+		result.push_back(0);
+		result.push_back(0);
+		std::vector<uint8_t> counter;
+		appendNibbles(counter, 0x4000);
+		result.insert(result.end(), counter.begin(), counter.end());
+		unsigned payloadSum = 0;
+		for(size_t i = 0; i < container.size(); i += 2)
+		{
+			const uint16_t word = static_cast<uint16_t>(container[i] << 8)
+				| (i + 1 < container.size() ? container[i + 1] : 0);
+			result.push_back(static_cast<uint8_t>(word >> 14));
+			result.push_back(static_cast<uint8_t>((word >> 7) & 0x7f));
+			result.push_back(static_cast<uint8_t>(word & 0x7f));
+			payloadSum += word >> 8;
+			payloadSum += word & 0xff;
+		}
+		const unsigned checksum = payloadSum + counter[1] + (counter[2] << 4)
+			+ counter[3] + ((counter[4] & 0x0c) << 4);
+		result[checksumPosition] = static_cast<uint8_t>((checksum >> 4) & 0x0f);
+		result[checksumPosition + 1] = static_cast<uint8_t>(checksum & 0x0f);
+		result.push_back(0xf7);
+		result.insert(result.end(), {0xf0, 0x00, 0x20, 0x3c, _device, 0x00, 0x7f});
+		appendNibbles(result, static_cast<uint32_t>(container.size()));
+		result.push_back(0xf7);
+		return result;
+	}
+
+	struct Capture
+	{
+		uint32_t space = 0;
+		uint32_t address = 0;
+		std::vector<uint32_t> words;
+	};
+
+	bool capture(void* const _context, const uint32_t _space, const uint32_t _address,
+		const uint32_t* const _words, const size_t _count)
+	{
+		auto& result = *static_cast<Capture*>(_context);
+		result.space = _space;
+		result.address = _address;
+		result.words.assign(_words, _words + _count);
+		return true;
+	}
+
+	bool checkSyntheticConversion(const uint8_t _device,
+		const md::MachineModel _expectedModel)
+	{
+		std::vector<uint8_t> dsp;
+		for(const uint32_t word : {3u, 0x66u, 0u, 0x10u, 2u,
+			0x123456u, 0xabcdefu, 3u, 0x66u})
+			appendWord(dsp, word);
+		const std::vector<std::vector<uint8_t>> sections{
+			std::vector<uint8_t>(32, 0x4e), dsp, dsp, dsp,
+			std::vector<uint8_t>(32, 0xa5)
+		};
+		auto sysex = makeSysex(_device, sections);
+		std::vector<uint8_t> rom;
+		md::MachineModel model = md::MachineModel::Machinedrum;
+		std::string error;
+		if(!md::firmwareUpdate::convertSysexToRom(sysex, rom, model, error)
+			|| model != _expectedModel || !md::firmwareUpdate::isConvertedRom(rom)
+			|| rom.size() != md::g_romSize)
+		{
+			std::fprintf(stderr, "synthetic conversion failed: %s\n", error.c_str());
+			return false;
+		}
+		for(size_t i = 0; i < sections.size(); ++i)
+		{
+			std::vector<uint8_t> decoded;
+			if(!md::firmwareUpdate::readSection(rom,
+				static_cast<md::firmwareUpdate::Section>(i), decoded) || decoded != sections[i])
+			{
+				std::fprintf(stderr, "synthetic section %zu did not round-trip\n", i);
+				return false;
+			}
+		}
+		sysex[7] ^= 1;
+		if(md::firmwareUpdate::convertSysexToRom(sysex, rom, model, error))
+		{
+			std::fputs("corrupt packet checksum was accepted\n", stderr);
+			return false;
+		}
+		return true;
+	}
+
+	std::vector<uint8_t> load(const char* const _path)
+	{
+		std::ifstream input(_path, std::ios::binary);
+		return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+	}
+
+	void writeLcdPgm(const md::Hardware& _hardware)
+	{
+		const auto* const path = std::getenv("MD_FIRMWARE_UPDATE_LCD_PGM");
+		if(!path || !*path)
+			return;
+		const auto panel = _hardware.getFrontPanelSnapshot();
+		std::ofstream output(path, std::ios::binary);
+		output << "P5\n" << md::FrontPanel::g_lcdWidth << ' '
+			<< md::FrontPanel::g_lcdHeight << "\n255\n";
+		for(uint32_t y = 0; y < md::FrontPanel::g_lcdHeight; ++y)
+		{
+			for(uint32_t x = 0; x < md::FrontPanel::g_lcdWidth; ++x)
+				output.put(panel.getLcdPixel(x, y) ? '\0' : '\xff');
+		}
+	}
+}
+
+int main(const int _argc, char** const _argv)
+{
+	std::vector<uint8_t> stream;
+	for(const uint32_t word : {3u, 0x66u, 0u, 0x10u, 2u,
+		0x123456u, 0xabcdefu, 3u, 0x66u})
+		appendWord(stream, word);
+	Capture captured;
+	uint32_t entry = 0;
+	std::string error;
+	if(!md::firmwareUpdate::visitDspCommands(stream, capture, &captured,
+		entry, error) || entry != 0x66 || captured.space != 0
+		|| captured.address != 0x10
+		|| captured.words != std::vector<uint32_t>({0x123456u, 0xabcdefu})
+		|| !checkSyntheticConversion(0x02, md::MachineModel::Machinedrum)
+		|| !checkSyntheticConversion(0x03, md::MachineModel::Monomachine))
+	{
+		std::fprintf(stderr, "mdfirmwareupdate_test: failed: %s\n", error.c_str());
+		return 1;
+	}
+
+	if(_argc == 1)
+	{
+		std::puts("mdfirmwareupdate_test: PASS");
+		return 0;
+	}
+	if(_argc != 2)
+	{
+		std::fprintf(stderr, "usage: mdfirmwareupdate_test [official-os-update.syx]\n");
+		return 2;
+	}
+
+	const auto input = load(_argv[1]);
+	std::vector<uint8_t> rom;
+	md::MachineModel model = md::MachineModel::Machinedrum;
+	if(input.size() == md::g_romSize)
+	{
+		rom = input;
+		model = md::RomLoader::isRomForModel(rom, md::MachineModel::Monomachine)
+			? md::MachineModel::Monomachine : md::MachineModel::Machinedrum;
+	}
+	else if(!md::firmwareUpdate::convertSysexToRom(input, rom, model, error))
+	{
+		std::fprintf(stderr, "conversion failed: %s\n", error.c_str());
+		return 1;
+	}
+	const bool converted = md::firmwareUpdate::isConvertedRom(rom);
+	if(converted)
+	{
+		if(const auto* const path = std::getenv("MD_FIRMWARE_UPDATE_MAIN_DUMP"))
+		{
+			std::vector<uint8_t> mainOs;
+			if(*path && md::firmwareUpdate::readSection(rom,
+				md::firmwareUpdate::Section::MainOs, mainOs))
+			{
+				std::ofstream output(path, std::ios::binary);
+				output.write(reinterpret_cast<const char*>(mainOs.data()),
+					static_cast<std::streamsize>(mainOs.size()));
+			}
+		}
+	}
+	md::Hardware hardware(rom, _argv[1], model);
+	if(!hardware.isValid())
+	{
+		std::fputs("direct boot initialization failed\n", stderr);
+		return 1;
+	}
+	const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(20);
+	while(hardware.getFrontPanelSnapshot().countLitPixels() <= 2000)
+	{
+		hardware.advance(64);
+		if(std::chrono::steady_clock::now() >= deadline)
+		{
+			std::fprintf(stderr, "boot did not reach the front panel: uc=%08x\n",
+				hardware.getUC().getPC());
+			return 1;
+		}
+	}
+	writeLcdPgm(hardware);
+	std::printf("mdfirmwareupdate_test: PASS (%s, %zu-byte Gearmulator image)\n",
+		model == md::MachineModel::Monomachine ? "Monomachine" : "Machinedrum",
+		rom.size());
+	return 0;
+}

--- a/source/elektron/md/mdLib/test/mdfirmwareupdate_test.cpp
+++ b/source/elektron/md/mdLib/test/mdfirmwareupdate_test.cpp
@@ -1,3 +1,4 @@
+#include "mdLib/mdflash.h"
 #include "mdLib/mdfirmwareupdate.h"
 #include "mdLib/mdhardware.h"
 #include "mdLib/mdromloader.h"
@@ -159,10 +160,29 @@ namespace
 		for(const uint32_t word : {3u, 0x66u, 0u, 0x10u, 2u,
 			0x123456u, 0xabcdefu, 3u, 0x66u})
 			appendWord(dsp, word);
+		const bool machinedrum = _device == 0x02;
+		auto deviceDsp = dsp;
+		if(machinedrum)
+		{
+			std::vector<uint8_t> selector;
+			appendWord(selector, 4);
+			appendWord(selector, 0);
+			deviceDsp.insert(deviceDsp.begin() + 6, selector.begin(), selector.end());
+		}
+		auto secondDsp = deviceDsp;
+		const size_t firstPayloadByte = (machinedrum ? 7u : 5u) * 3u;
+		secondDsp[firstPayloadByte] ^= 1;
 		const std::vector<std::vector<uint8_t>> sections{
-			std::vector<uint8_t>(32, 0x4e), dsp, dsp, dsp,
+			std::vector<uint8_t>(32, 0x4e), deviceDsp, secondDsp,
+			machinedrum ? std::vector<uint8_t>(32, 0x33) : dsp,
 			std::vector<uint8_t>(32, 0xa5)
 		};
+		auto expectedSections = sections;
+		if(machinedrum)
+		{
+			std::swap(expectedSections[1], expectedSections[2]);
+			expectedSections[3].clear();
+		}
 		auto sysex = makeSysex(_device, sections);
 		std::vector<uint8_t> rom;
 		md::MachineModel model = md::MachineModel::Machinedrum;
@@ -174,11 +194,23 @@ namespace
 			std::fprintf(stderr, "synthetic conversion failed: %s\n", error.c_str());
 			return false;
 		}
-		for(size_t i = 0; i < sections.size(); ++i)
+		uint32_t factoryAddress = 0;
+		size_t expectedFactoryAddress = 0x4000;
+		const size_t handoffSection = machinedrum ? 3 : 4;
+		for(size_t i = 0; i < handoffSection; ++i)
+			expectedFactoryAddress += pack(sections[i]).size();
+		if(!md::firmwareUpdate::factoryFlashAddress(rom, factoryAddress)
+			|| factoryAddress != expectedFactoryAddress)
+		{
+			std::fputs("synthetic factory handoff address is incorrect\n", stderr);
+			return false;
+		}
+		for(size_t i = 0; i < expectedSections.size(); ++i)
 		{
 			std::vector<uint8_t> decoded;
 			if(!md::firmwareUpdate::readSection(rom,
-				static_cast<md::firmwareUpdate::Section>(i), decoded) || decoded != sections[i])
+				static_cast<md::firmwareUpdate::Section>(i), decoded)
+				|| decoded != expectedSections[i])
 			{
 				std::fprintf(stderr, "synthetic section %zu did not round-trip\n", i);
 				return false;
@@ -191,6 +223,38 @@ namespace
 			return false;
 		}
 		return true;
+	}
+
+	bool checkFlashCommands()
+	{
+		constexpr uint32_t unlock1 = 0x0000aaaa;
+		constexpr uint32_t unlock2 = 0x00005554;
+		md::FlashCommandDecoder flash;
+		flash.write16(unlock1, 0xaaaa);
+		flash.write16(unlock2, 0x5555);
+		flash.write16(unlock1, 0x9090);
+		if(flash.read16(0) != md::FlashCommandDecoder::g_manufacturerId
+			|| flash.read16(2) != md::FlashCommandDecoder::g_deviceId)
+			return false;
+		flash.write16(0, 0xf0f0);
+
+		flash.write16(unlock1, 0xaaaa);
+		flash.write16(unlock2, 0x5555);
+		flash.write16(unlock1, 0xa0a0);
+		const auto program = flash.write16(0x1234, 0xf0f0);
+		if(!program || program->type != md::FlashCommandDecoder::Operation::Type::ProgramWord
+			|| program->offset != 0x1234 || program->value != 0xf0f0)
+			return false;
+
+		flash.write16(unlock1, 0xaaaa);
+		flash.write16(unlock2, 0x5555);
+		flash.write16(unlock1, 0x8080);
+		flash.write16(unlock1, 0xaaaa);
+		flash.write16(unlock2, 0x5555);
+		const auto erase = flash.write16(0x23456, 0x3030);
+		return erase
+			&& erase->type == md::FlashCommandDecoder::Operation::Type::EraseSector
+			&& erase->offset == 0x23456;
 	}
 
 	std::vector<uint8_t> load(const char* const _path)
@@ -229,6 +293,7 @@ int main(const int _argc, char** const _argv)
 		entry, error) || entry != 0x66 || captured.space != 0
 		|| captured.address != 0x10
 		|| captured.words != std::vector<uint32_t>({0x123456u, 0xabcdefu})
+		|| !checkFlashCommands()
 		|| !checkSyntheticConversion(0x02, md::MachineModel::Machinedrum)
 		|| !checkSyntheticConversion(0x03, md::MachineModel::Monomachine))
 	{
@@ -283,8 +348,12 @@ int main(const int _argc, char** const _argv)
 		return 1;
 	}
 	const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(20);
-	while(hardware.getFrontPanelSnapshot().countLitPixels() <= 2000)
+	for(;;)
 	{
+		const auto panel = hardware.getFrontPanelSnapshot();
+		if(panel.countLitPixels() > 2000
+			|| (panel.getTileWriteCount() >= 64 && panel.countLitPixels() >= 100))
+			break;
 		hardware.advance(64);
 		if(std::chrono::steady_clock::now() >= deadline)
 		{

--- a/source/elektron/md/mdLibTest/CMakeLists.txt
+++ b/source/elektron/md/mdLibTest/CMakeLists.txt
@@ -8,6 +8,12 @@ set_tests_properties(mdLibTests PROPERTIES LABELS "UnitTest")
 
 set_property(TARGET mdLibTest PROPERTY FOLDER "Elektron")
 
+add_executable(mdFirmwareUpdateTest ../mdLib/test/mdfirmwareupdate_test.cpp)
+target_link_libraries(mdFirmwareUpdateTest PRIVATE mdLib)
+add_test(NAME mdFirmwareUpdateTest COMMAND mdFirmwareUpdateTest)
+set_tests_properties(mdFirmwareUpdateTest PROPERTIES LABELS "UnitTest")
+set_property(TARGET mdFirmwareUpdateTest PROPERTY FOLDER "Elektron")
+
 add_executable(mdAutomationMidiTest automationMidiTest.cpp)
 target_link_libraries(mdAutomationMidiTest PRIVATE mdLib)
 add_test(NAME mdAutomationMidiTest COMMAND mdAutomationMidiTest)

--- a/source/elektron/md/mdLibTest/turboMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/turboMidiTest.cpp
@@ -128,12 +128,36 @@ namespace
 		return check((sim.read8(md::Sim::g_ppdat) & 0x01) != 0,
 			"MKII Port A loopback did not invert LOW");
 	}
+
+	bool testFirmwareUpdateHandoff()
+	{
+		md::Sim mdHandoff;
+		mdHandoff.prepareFirmwareUpdateBoot(false);
+		if(!check(mdHandoff.read8(0x047) == 0x25
+			&& mdHandoff.read8(0x06e) == 0x19
+			&& mdHandoff.read8(md::Sim::g_uart1Base + md::Sim::g_uartBg2) == 0x28
+			&& mdHandoff.getParallelDirection() == 0x01
+			&& mdHandoff.getParallelData() == 0xfe,
+			"Machinedrum update handoff did not restore SIM/UART/GPIO state"))
+			return false;
+
+		md::Sim mmHandoff;
+		mmHandoff.prepareFirmwareUpdateBoot(true);
+		return check(mmHandoff.read8(0x047) == 0x00
+			&& mmHandoff.read8(0x06e) == 0x15
+			&& mmHandoff.read8(0x0aa) == 0x01
+			&& mmHandoff.read8(md::Sim::g_uart2Base + md::Sim::g_uartBg2) == 0x08
+			&& mmHandoff.getParallelDirection() == 0x01
+			&& mmHandoff.getParallelData() == 0xfe,
+			"Monomachine update handoff did not restore SIM/UART/GPIO state");
+	}
 }
 
 int main()
 {
 	if(!testTimeoutFallback() || !testDocumentedHandshake()
-		|| !testDspMemoryFallback() || !testMk2PortAInvertedLoopback())
+		|| !testDspMemoryFallback() || !testMk2PortAInvertedLoopback()
+		|| !testFirmwareUpdateHandoff())
 		return 1;
 	std::cout << "mdLib tests passed\n";
 	return 0;


### PR DESCRIPTION
## Summary

- Load official Machinedrum and Monomachine OS updater `.syx` files directly from each machine's `roms` directory.
- Validate the Elektron updater envelope, decode its payload, decompress it in memory, and boot the resulting private image without writing out a firmware `.bin`.
- Handle the official MD updater's two complete DSP streams, legacy selector record, DSP ordering, and two data-section roles independently from the MM layout.
- Model the MD's AMD-compatible mutable flash command path so the official OS can perform its normal startup writes.
- Keep existing `.bin` loading as the first choice, so current installations continue to work unchanged.
- Preserve Monomachine factory-data fallback behavior. This does not manufacture or include a factory DigiPRO bank.
- Include the MIT license and attribution for the transport and aPLib-derived portions adapted from `mischa85/elektron-firmware-tool`.

## Distribution boundary

No Elektron firmware, factory data, user bank, download URL, hash, or extracted image is included. Conversion happens privately in memory from a file supplied by the user, and the emulator does not export the decoded firmware.

## Validation

- Focused build and `mdFirmwareUpdateTest` CTest passed.
- An official Machinedrum/Machinedrum UW OS 1.63 updater was recognized, converted to the private 8 MiB in-memory image, initialized both DSPs, and produced a nonblank front-panel framebuffer locally.
- An official Monomachine OS 1.32B updater was loaded and booted locally through the same user-facing path.
- Synthetic MD and MM fixtures cover structural conversion, model-specific section normalization, the MD handoff address, NOR identify/program/erase commands, and corrupt-input rejection without containing firmware-derived data.
- The existing full-ROM Machinedrum runtime path still passes its boot/front-panel regression.

## Review order

This is PR 1 of 2 and is stacked on the current DAW-automation PR (`feature/md-mm-daw-automation`). The user-data SysEx sender is intentionally separate and stacked on this branch.
