### PR TITLE
Send user SysEx through the emulated MIDI port

### DIFF
--- a/doc/elektron_md_mm_sysex.md
+++ b/doc/elektron_md_mm_sysex.md
@@ -32,3 +32,29 @@ the required license text is shipped beside the implementation. Gearmulator
 adds a private in-memory image layout and direct initialization of the emulated
 ColdFire and DSP hardware. It does not reconstruct or export a hardware flash
 dump.
+
+## User-data sender
+
+The in-app sender is available under Esc > device settings. First use the
+emulated panel to enter the same receive screen used on hardware, then choose or
+drop one matching `.syx` file. The UI reports MIDI transfer progress without
+requiring a virtual MIDI port or an external transfer application.
+
+The sender validates the public Elektron SysEx envelope, negotiates TurboMIDI
+over the emulated MIDI input/output, and delivers bytes to the emulated UART. It
+contains no receiver-state addresses, firmware program-counter tests, call
+trampolines, or automatic calls into an OS image. `SENT` therefore means
+transport completion only. The emulated machine's display remains the authority
+on acceptance, validation, and storage.
+
+For Monomachine DigiPRO banks, EXIT/NO on the emulated panel starts the
+firmware's normal `WRITING WAVEFORMS` step after the sender reports `SENT`.
+Mutable DigiPRO user flash is private to each emulated machine and is included
+in version-2 plug-in state, so imported waves survive project recall. The source
+ROM is never modified, and legacy version-1 states remain readable.
+
+The manual firmware acceptance harness may reproduce a documented front-panel
+button sequence using the same panel packets as the UI. It observes only the
+rendered display, MIDI behavior, and flash-bus result. This automation is not
+used by the shipping sender because menu layout and starting selection can vary
+with machine state or firmware.

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -90,34 +90,6 @@ namespace mdJucePlugin
 		constexpr float g_encoderRange = 100.0f;
 		constexpr int g_encoderBurstCap = 8;	// max ±1 events emitted per Change
 
-		bool isMonomachineSysexStream(const std::vector<uint8_t>& _bytes)
-		{
-			if(_bytes.empty() || _bytes.size() > 8u * 1024u * 1024u)
-				return false;
-
-			size_t offset = 0;
-			size_t messages = 0;
-			while(offset < _bytes.size())
-			{
-				if(offset + 7 > _bytes.size() ||
-					_bytes[offset] != 0xf0 ||
-					_bytes[offset + 1] != 0x00 ||
-					_bytes[offset + 2] != 0x20 ||
-					_bytes[offset + 3] != 0x3c ||
-					_bytes[offset + 4] != 0x03)
-					return false;
-
-				const auto end = std::find(
-					_bytes.begin() + static_cast<std::ptrdiff_t>(offset),
-					_bytes.end(), 0xf7);
-				if(end == _bytes.end())
-					return false;
-				offset = static_cast<size_t>(end - _bytes.begin()) + 1;
-				++messages;
-			}
-			return messages != 0;
-		}
-
 		constexpr PanelButton g_panelButtons[] =
 		{
 			{ "trigKey0", md::PanelControl::Trigger1 }, { "trigKey1", md::PanelControl::Trigger2 },
@@ -990,89 +962,114 @@ namespace mdJucePlugin
 	{
 		auto* const button = findChild<juceRmlUi::ElemButton>("btSendSyx", false);
 		m_sysexStatus = findChild("syxStatus", false);
-		if(!button || getModel() != md::MachineModel::Monomachine)
+		if(!button)
 			return;
 
 		juceRmlUi::EventListener::Add(button, Rml::EventId::Click,
 			[this](Rml::Event&)
 			{
-				loadPreset([this](const juce::File& _file)
-				{
-					juce::MemoryBlock data;
-					if(!_file.loadFileAsData(data))
-					{
-						if(m_sysexStatus)
-							m_sysexStatus->SetInnerRML("READ FAILED");
-						return;
-					}
-
-					const auto* const begin = static_cast<const uint8_t*>(data.getData());
-					std::vector<uint8_t> bytes(begin, begin + data.getSize());
-					if(!isMonomachineSysexStream(bytes))
-					{
-						if(m_sysexStatus)
-							m_sysexStatus->SetInnerRML("NOT MM SYSEX");
-						return;
-					}
-
-					auto prepared = md::prepareMidiSysexTransfer(std::move(bytes));
-					const bool started = prepared
-						&& getProcessor().getPlugin().withDeviceLocked(
-							[&](synthLib::Device* const _device)
-							{
-								auto* const device = dynamic_cast<md::Device*>(_device);
-								return device && device->getHardware()
-									.startMidiSysexTransfer(*prepared);
-							});
-					if(!started)
-					{
-						if(m_sysexStatus)
-							m_sysexStatus->SetInnerRML("TRANSFER BUSY");
-						return;
-					}
-					if(m_sysexStatus)
-						m_sysexStatus->SetInnerRML("OPENING SYSEX RECEIVE...");
-				});
+				chooseSysexFile();
 			});
 	}
 
-	void Editor::updateSysexTransfer()
+	void Editor::chooseSysexFile()
 	{
-		if(!m_sysexStatus)
+		loadPreset([this](const juce::File& _file) { sendSysexFile(_file); });
+	}
+
+	void Editor::sendSysexFile(const juce::File& _file)
+	{
+		m_sysexStatusOverride.clear();
+		const auto fileSize = _file.getSize();
+		if(fileSize <= 0)
+		{
+			m_sysexStatusOverride = "EMPTY OR UNREADABLE FILE";
 			return;
+		}
+		if(static_cast<uint64_t>(fileSize) > md::g_midiSysexTransferMaxBytes)
+		{
+			m_sysexStatusOverride = "FILE IS LARGER THAN 8 MIB";
+			return;
+		}
+
+		juce::MemoryBlock data;
+		if(!_file.loadFileAsData(data))
+		{
+			m_sysexStatusOverride = "READ FAILED";
+			return;
+		}
+		const auto* const begin = static_cast<const uint8_t*>(data.getData());
+		std::vector<uint8_t> bytes(begin, begin + data.getSize());
+		switch(md::validateMidiSysexStream(bytes, getModel()))
+		{
+		case md::MidiSysexStreamValidation::Valid:
+			break;
+		case md::MidiSysexStreamValidation::WrongModel:
+			m_sysexStatusOverride = "SYSEX IS FOR THE OTHER MACHINE";
+			return;
+		case md::MidiSysexStreamValidation::FirmwareUpdate:
+			m_sysexStatusOverride = "OS UPDATE: PUT THIS FILE IN ROMS";
+			return;
+		case md::MidiSysexStreamValidation::TooLarge:
+			m_sysexStatusOverride = "FILE IS LARGER THAN 8 MIB";
+			return;
+		case md::MidiSysexStreamValidation::Empty:
+		case md::MidiSysexStreamValidation::InvalidFraming:
+			m_sysexStatusOverride = "NOT A VALID DEVICE SYSEX FILE";
+			return;
+		}
+
+		auto prepared = md::prepareMidiSysexTransfer(std::move(bytes));
+		const bool started = prepared
+			&& getProcessor().getPlugin().withDeviceLocked(
+				[&](synthLib::Device* const _device)
+				{
+					auto* const device = dynamic_cast<md::Device*>(_device);
+					return device && device->getHardware()
+						.startMidiSysexTransfer(*prepared);
+				});
+		if(!started)
+			m_sysexStatusOverride = "TRANSFER BUSY";
+	}
+
+	std::string Editor::sysexTransferStatusText() const
+	{
+		if(!m_sysexStatusOverride.empty())
+			return m_sysexStatusOverride;
 		auto* const device =
 			dynamic_cast<md::Device*>(getProcessor().getPlugin().getDevice());
 		if(!device)
-			return;
+			return "MACHINE NOT READY";
 
 		const auto progress = device->getMidiSysexTransferProgress();
 		switch(progress.state)
 		{
 		case md::MidiSysexTransferState::Idle:
-			m_sysexStatus->SetInnerRML("ENTER WAITING FIRST");
-			break;
+			return "READY";
 		case md::MidiSysexTransferState::Queued:
-			m_sysexStatus->SetInnerRML("PREPARING TRANSFER...");
-			break;
+			return "PREPARING TRANSFER...";
 		case md::MidiSysexTransferState::NegotiatingTurbo:
-			m_sysexStatus->SetInnerRML("NEGOTIATING TURBO...");
-			break;
+			return "NEGOTIATING TURBO...";
 		case md::MidiSysexTransferState::Sending:
 		{
 			const auto percent = progress.total
 				? static_cast<uint32_t>(100u * progress.sent / progress.total)
 				: 0u;
-			m_sysexStatus->SetInnerRML(
-				"SENDING " + (progress.turbo
+			return "SENDING " + (progress.turbo
 					? std::string(md::midiTurboSpeedLabel(progress.speedCode)) + "x "
 					: std::string("1x "))
-				+ std::to_string(percent) + "%");
-			break;
+				+ std::to_string(percent) + "%";
 		}
 		case md::MidiSysexTransferState::Complete:
-			m_sysexStatus->SetInnerRML("SENT - CHECK LCD");
-			break;
+			return "SENT - CHECK MACHINE DISPLAY";
 		}
+		return "UNKNOWN TRANSFER STATE";
+	}
+
+	void Editor::updateSysexTransfer()
+	{
+		if(m_sysexStatus)
+			m_sysexStatus->SetInnerRML(sysexTransferStatusText());
 	}
 
 	void Editor::configureEncoder(juceRmlUi::ElemKnob* const _knob,

--- a/source/elektron/md/mdJucePlugin/mdEditor.h
+++ b/source/elektron/md/mdJucePlugin/mdEditor.h
@@ -4,6 +4,7 @@
 #include <deque>
 #include <initializer_list>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "jucePluginEditorLib/pluginEditor.h"
@@ -66,6 +67,9 @@ namespace mdJucePlugin
 		void chooseStorageImage();
 		void restorePreviousStorage();
 		bool hasStorageRecoveryImage() const;
+		void chooseSysexFile();
+		void sendSysexFile(const juce::File& _file);
+		std::string sysexTransferStatusText() const;
 
 		static constexpr int g_panelSpeedPercents[] = {50, 75, 100, 150, 200, 300};
 
@@ -169,6 +173,7 @@ namespace mdJucePlugin
 		std::array<Rml::Element*, 16> m_stepLeds{};
 		std::array<Rml::Element*, 16> m_drumLeds{};
 		Rml::Element* m_sysexStatus = nullptr;
+		std::string m_sysexStatusOverride;
 
 		struct StatusLedElem
 		{

--- a/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.cpp
+++ b/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.cpp
@@ -5,6 +5,7 @@
 #include "jucePluginEditorLib/pluginProcessor.h"
 
 #include "juceRmlUi/rmlElemButton.h"
+#include "juceRmlUi/rmlDragTarget.h"
 #include "juceRmlUi/rmlEventListener.h"
 #include "juceRmlUi/rmlHelper.h"
 
@@ -12,10 +13,50 @@
 
 namespace mdJucePlugin
 {
+	class SysexDropTarget final : public juceRmlUi::DragTarget
+	{
+	public:
+		SysexDropTarget(Editor& _editor, Rml::Element* const _element)
+			: DragTarget(_element), m_editor(_editor)
+		{
+			setAllowLocations(false, false);
+			setAllowShift(false);
+		}
+
+		bool canDropFiles(const Rml::Event&,
+			const std::vector<std::string>& _files) override
+		{
+			return _files.size() == 1 && juce::File(_files.front())
+				.getFileExtension().equalsIgnoreCase(".syx");
+		}
+
+		void dropFiles(const Rml::Event&, const juceRmlUi::FileDragData*,
+			const std::vector<std::string>& _files) override
+		{
+			if(_files.size() == 1)
+				m_editor.sendSysexFile(juce::File(_files.front()));
+		}
+
+	private:
+		Editor& m_editor;
+	};
+
 	SettingsPanelFeel::SettingsPanelFeel(Editor& _editor, Rml::Element* _root) : m_editor(_editor)
 	{
 		bindGroup(_root, "btWheelSpeed", "panelWheelSpeedPercent");
 		bindGroup(_root, "btEncoderSpeed", "panelEncoderSpeedPercent");
+		if(auto* const chooseSysex = juceRmlUi::helper::findChild(
+			_root, "btSendSysexFile", false))
+		{
+			juceRmlUi::EventListener::AddClick(chooseSysex, [this]
+			{
+				m_editor.chooseSysexFile();
+			});
+		}
+		if(auto* const drop = juceRmlUi::helper::findChild(
+			_root, "sysexDropTarget", false))
+			m_sysexDropTarget = std::make_unique<SysexDropTarget>(m_editor, drop);
+		m_sysexStatus = juceRmlUi::helper::findChild(_root, "sysexTransferStatus", false);
 
 		if(auto* const loadFactory = juceRmlUi::helper::findChild(
 			_root, "btLoadInstalledFactoryStorage", false))
@@ -42,13 +83,20 @@ namespace mdJucePlugin
 				m_editor.restorePreviousStorage();
 			});
 			updateRestoreAvailability();
-			startTimerHz(2);
 		}
+		if(m_sysexStatus)
+			startTimerHz(10);
+		else if(m_restoreStorage)
+			startTimerHz(2);
 	}
+
+	SettingsPanelFeel::~SettingsPanelFeel() = default;
 
 	void SettingsPanelFeel::timerCallback()
 	{
 		updateRestoreAvailability();
+		if(m_sysexStatus)
+			m_sysexStatus->SetInnerRML(m_editor.sysexTransferStatusText());
 	}
 
 	void SettingsPanelFeel::updateRestoreAvailability()

--- a/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.h
+++ b/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.h
@@ -4,6 +4,8 @@
 
 #include "juce_events/juce_events.h"
 
+#include <memory>
+
 namespace Rml
 {
 	class Element;
@@ -12,6 +14,7 @@ namespace Rml
 namespace mdJucePlugin
 {
 	class Editor;
+	class SysexDropTarget;
 
 	// Device-specific GUI settings: MM storage selection plus panel encoder feel.
 	class SettingsPanelFeel : public jucePluginEditorLib::SettingsDeviceSpecific,
@@ -19,6 +22,7 @@ namespace mdJucePlugin
 	{
 	public:
 		SettingsPanelFeel(Editor& _editor, Rml::Element* _root);
+		~SettingsPanelFeel() override;
 
 	private:
 		void timerCallback() override;
@@ -27,5 +31,7 @@ namespace mdJucePlugin
 
 		Editor& m_editor;
 		Rml::Element* m_restoreStorage = nullptr;
+		Rml::Element* m_sysexStatus = nullptr;
+		std::unique_ptr<SysexDropTarget> m_sysexDropTarget;
 	};
 }

--- a/source/elektron/md/mdJucePlugin/tus_settings_gui_Machinedrum.rml
+++ b/source/elektron/md/mdJucePlugin/tus_settings_gui_Machinedrum.rml
@@ -1,7 +1,58 @@
 <template name="tus_settings_gui_Machinedrum">
 <head>
+	<style>
+		.settings-sysex-drop {
+			box-sizing: border-box;
+			width: 100%;
+			padding: 10dp;
+			border: 2dp rgba(172,176,179,90);
+			border-radius: 5dp;
+			text-align: center;
+		}
+		.settings-sysex-status {
+			display: block;
+			margin-top: 5dp;
+			text-align: center;
+		}
+		.settings-sysex-guide {
+			box-sizing: border-box;
+			width: 100%;
+			padding: 9dp;
+			border: 1dp rgba(172,176,179,90);
+			border-radius: 5dp;
+			background-color: rgba(10,14,17,120);
+		}
+		.settings-sysex-guide label {
+			display: block;
+			margin-bottom: 4dp;
+		}
+		.settings-sysex-guide-title {
+			font-weight: bold;
+		}
+	</style>
 </head>
 <body>
+	<settingsspacer1/>
+	<h1>SysEx File Transfer</h1>
+	<settingsspacer1/>
+	<label>Send kits, patterns, songs, globals, and other user-data .syx files through the emulated MIDI input.</label>
+	<settingsspacer1/>
+	<div class="settings-sysex-guide">
+		<label class="settings-sysex-guide-title">BEFORE CHOOSING THE FILE</label>
+		<label>1. On the machine panel, open GLOBAL EDIT &gt; FILE &gt; SYSEX REC.</label>
+		<label>2. Choose ORIG, or choose SPEC and its destination.</label>
+		<label>3. Press ENTER/YES until the machine display says WAITING.</label>
+		<label>4. Choose or drop the .syx file below.</label>
+	</div>
+	<settingsspacer1/>
+	<button id="btSendSysexFile" class="button">Choose .syx File...</button>
+	<settingsspacer1/>
+	<div id="sysexDropTarget" class="settings-sysex-drop">DROP ONE .SYX FILE HERE</div>
+	<label id="sysexTransferStatus" class="settings-sysex-status">READY</label>
+	<settingsspacer1/>
+	<label>"SENT" means all bytes reached the emulated MIDI input. Confirm the result on the machine display and finish or exit the receive screen as its manual directs.</label>
+	<settingsspacer1/>
+	<label>OS updater .syx files belong in Machinedrum/roms and are loaded at startup; they are not sent from this panel.</label>
 	<settingsspacer1/>
 	<div class="settings-advanced">
 		<h1>Panel Feel</h1>

--- a/source/elektron/md/mdJucePlugin/tus_settings_gui_Monomachine.rml
+++ b/source/elektron/md/mdJucePlugin/tus_settings_gui_Monomachine.rml
@@ -15,9 +15,61 @@
 		.settings-storage-actions .button:disabled {
 			opacity: 0.45;
 		}
+		.settings-sysex-drop {
+			box-sizing: border-box;
+			width: 100%;
+			padding: 10dp;
+			border: 2dp rgba(172,176,179,90);
+			border-radius: 5dp;
+			text-align: center;
+		}
+		.settings-sysex-status {
+			display: block;
+			margin-top: 5dp;
+			text-align: center;
+		}
+		.settings-sysex-guide {
+			box-sizing: border-box;
+			width: 100%;
+			padding: 9dp;
+			border: 1dp rgba(172,176,179,90);
+			border-radius: 5dp;
+			background-color: rgba(10,14,17,120);
+		}
+		.settings-sysex-guide label {
+			display: block;
+			margin-bottom: 4dp;
+		}
+		.settings-sysex-guide-title {
+			font-weight: bold;
+		}
 	</style>
 </head>
 <body>
+	<settingsspacer1/>
+	<h1>SysEx File Transfer</h1>
+	<settingsspacer1/>
+	<label>Send backups, user data, and DigiPRO waveform banks through the emulated MIDI input.</label>
+	<settingsspacer1/>
+	<div class="settings-sysex-guide">
+		<label class="settings-sysex-guide-title">DIGIPRO BANK — BEFORE CHOOSING THE FILE</label>
+		<label>1. Hold FUNCTION and press KIT (GLOBAL), then press ENTER for the highlighted Global slot.</label>
+		<label>2. Press DOWN twice to FILE, then RIGHT.</label>
+		<label>3. Press DOWN twice to DIGIPRO MGR, then ENTER.</label>
+		<label>4. RECEIVE is selected. Press RIGHT to ORG, then ENTER. The display must say WAITING.</label>
+		<label>5. Choose or drop the .syx file below. After SENT, press EXIT/NO and wait for WRITING WAVEFORMS to finish.</label>
+		<label class="settings-sysex-guide-title">BACKUP / USER DATA</label>
+		<label>Use the same first two steps, choose SYSEX RECV instead of DIGIPRO MGR, select its destination, and press ENTER until the display says WAITING.</label>
+	</div>
+	<settingsspacer1/>
+	<button id="btSendSysexFile" class="button">Choose .syx File...</button>
+	<settingsspacer1/>
+	<div id="sysexDropTarget" class="settings-sysex-drop">DROP ONE .SYX FILE HERE</div>
+	<label id="sysexTransferStatus" class="settings-sysex-status">READY</label>
+	<settingsspacer1/>
+	<label>"SENT" means all bytes reached the emulated MIDI input. The machine display is the authority on whether the file was accepted and stored.</label>
+	<settingsspacer1/>
+	<label>OS updater .syx files belong in Monomachine/roms and are loaded at startup; they are not sent from this panel.</label>
 	<settingsspacer1/>
 	<h1>Machine Storage</h1>
 	<settingsspacer1/>

--- a/source/elektron/md/mdLib/mddevice.cpp
+++ b/source/elektron/md/mdLib/mddevice.cpp
@@ -65,7 +65,8 @@ namespace md
 
 	bool Device::getState(std::vector<uint8_t>& _state, synthLib::StateType _type)
 	{
-		return encodeState(_state, m_hardware->copyPatchRam(), m_model, _type);
+		return encodeState(_state, m_hardware->copyPatchRam(), m_model, _type,
+			m_hardware->copyUserFlash());
 	}
 
 	bool Device::setState(const std::vector<uint8_t>& _state, synthLib::StateType _type)
@@ -82,12 +83,14 @@ namespace md
 			return {};
 
 		std::vector<uint8_t> patchRam;
-		if(!decodeState(patchRam, _state, _context->m_model, _type))
+		std::vector<uint8_t> userFlash;
+		if(!decodeState(patchRam, userFlash, _state, _context->m_model, _type))
 			return {};
 
 		auto replacement = std::make_unique<Hardware>(
 			_context->m_romData, _context->m_romName, _context->m_model, patchRam,
-			_context->m_frontPanelPublisher, _context->m_midiSysexProgressPublisher);
+			_context->m_frontPanelPublisher, _context->m_midiSysexProgressPublisher,
+			userFlash);
 		if(!replacement->isValid())
 			return {};
 

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -5,7 +5,6 @@
 #include "mdmmwaveforms.h"
 
 #include <algorithm>
-#include <array>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
@@ -86,11 +85,13 @@ namespace md
 	Hardware::Hardware(const std::vector<uint8_t>& _romData, const std::string& _romName,
 		const MachineModel _model, const std::vector<uint8_t>& _initialPatchRam,
 		std::shared_ptr<FrontPanelPublisher> _frontPanelPublisher,
-		std::shared_ptr<MidiSysexTransferProgressPublisher> _midiSysexProgressPublisher)
+		std::shared_ptr<MidiSysexTransferProgressPublisher> _midiSysexProgressPublisher,
+		const std::vector<uint8_t>& _initialUserFlash)
 		: m_model(_model)
 		, m_rom(initRom(_romData, _romName, _model))
 		, m_firmwareFingerprint(fingerprintRom(m_rom.data()))
-		, m_uc(m_rom, m_model, initPatchRam(m_rom, _initialPatchRam), initMainRam(m_rom))
+		, m_uc(m_rom, m_model, initPatchRam(m_rom, _initialPatchRam), initMainRam(m_rom),
+			_initialUserFlash)
 		, m_frontPanelPublisher(_frontPanelPublisher
 			? std::move(_frontPanelPublisher)
 			: std::make_shared<FrontPanelPublisher>())
@@ -100,6 +101,13 @@ namespace md
 	{
 		if(!m_rom.isValid())
 			return;
+		std::vector<uint8_t> updateMainOs;
+		if(firmwareUpdate::readSection(m_rom.data(),
+			firmwareUpdate::Section::MainOs, updateMainOs))
+		{
+			m_firmwareUpdateMainSize = updateMainOs.size();
+			m_firmwareUpdateMainFingerprint = fingerprintRom(updateMainOs);
+		}
 		if(isMonomachine())
 		{
 			auto& mixerMemory = m_dspMixer.dsp().memory();
@@ -476,7 +484,7 @@ namespace md
 			const bool sectionsRead = firmwareUpdate::readSection(m_rom.data(),
 				firmwareUpdate::Section::MainOs, mainOs)
 				&& firmwareUpdate::readSection(m_rom.data(),
-					firmwareUpdate::Section::DspMixer, mixer)
+				firmwareUpdate::Section::DspMixer, mixer)
 				&& firmwareUpdate::readSection(m_rom.data(),
 					firmwareUpdate::Section::DspProducer, producer)
 				&& firmwareUpdate::readSection(m_rom.data(),

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -54,7 +54,8 @@ namespace md
 			MachineModel _model = MachineModel::Machinedrum,
 			const std::vector<uint8_t>& _initialPatchRam = {},
 			std::shared_ptr<FrontPanelPublisher> _frontPanelPublisher = {},
-			std::shared_ptr<MidiSysexTransferProgressPublisher> _midiSysexProgressPublisher = {});
+			std::shared_ptr<MidiSysexTransferProgressPublisher> _midiSysexProgressPublisher = {},
+			const std::vector<uint8_t>& _initialUserFlash = {});
 		~Hardware();
 
 		bool isValid() const;
@@ -65,6 +66,11 @@ namespace md
 			return m_dspMixer.booted() && m_dspProducer.booted();
 		}
 		uint64_t firmwareFingerprint() const { return m_firmwareFingerprint; }
+		uint64_t firmwareUpdateMainFingerprint() const
+		{
+			return m_firmwareUpdateMainFingerprint;
+		}
+		size_t firmwareUpdateMainSize() const { return m_firmwareUpdateMainSize; }
 		uint64_t hostAudioOverflowCount() const
 		{
 			return m_schedHostAudioOverflow.load(std::memory_order_relaxed);
@@ -79,6 +85,7 @@ namespace md
 
 		Microcontroller& getUC() { return m_uc; }
 		std::vector<uint8_t> copyPatchRam() const { return m_uc.copyPatchRam(); }
+		std::vector<uint8_t> copyUserFlash() const { return m_uc.copyUserFlash(); }
 
 		// Role accessors used by the HI08 bridge and scheduler.
 		Dsp& getDspProducer() { return m_dspProducer; }	// DSP2, index 1
@@ -163,6 +170,8 @@ namespace md
 		const MachineModel m_model;
 		Rom m_rom;
 		const uint64_t m_firmwareFingerprint;
+		uint64_t m_firmwareUpdateMainFingerprint = 0;
+		size_t m_firmwareUpdateMainSize = 0;
 		Microcontroller m_uc;
 		FrontPanel m_frontPanel;	// writer-owned UART2 LCD/LED decoder
 		std::shared_ptr<FrontPanelPublisher> m_frontPanelPublisher;

--- a/source/elektron/md/mdLib/mdmc.cpp
+++ b/source/elektron/md/mdLib/mdmc.cpp
@@ -6,6 +6,7 @@
 
 #include "mc68k/memoryOps.h"
 #include "mc68k/Musashi/m68k.h"
+#include "mc68k/cpuState.h"
 
 #include <algorithm>
 #include <array>
@@ -22,6 +23,28 @@ namespace md
 {
 	namespace
 	{
+		// The SFX-60 MKII stores user DigiPRO waves in the uniform-sector portion of
+		// its 8 MiB AMD-compatible flash. The firmware erases it in 64 KiB sectors.
+		class MonomachineFlash final : public hwLib::Am29f
+		{
+		public:
+			MonomachineFlash(uint8_t* _data, const size_t _size)
+				: Am29f(_data, _size, false, true), m_size(_size)
+			{
+			}
+
+			bool eraseSector(const uint32_t _addr) const override
+			{
+				constexpr size_t sectorSize = 64 * 1024;
+				if((_addr % sectorSize) != 0 || _addr > m_size || sectorSize > m_size - _addr)
+					return false;
+				return Am29f::eraseSector(_addr, sectorSize / 1024);
+			}
+
+		private:
+			const size_t m_size;
+		};
+
 		constexpr auto makeMmPanelStartupProbe()
 		{
 			std::array<uint8_t, 30> probe{};
@@ -46,17 +69,30 @@ namespace md
 
 	Microcontroller::Microcontroller(const Rom& _rom, const MachineModel _model,
 		const std::vector<uint8_t>& _initialPatchRam,
-		const std::vector<uint8_t>& _initialMainRam)
+		const std::vector<uint8_t>& _initialMainRam,
+		const std::vector<uint8_t>& _initialUserFlash)
 		: Mc68k(M68K_CPU_TYPE_MCF5206E)
 		, m_model(_model)
 		, m_rom(_rom)
-		, m_flashData(_model == MachineModel::Machinedrum
-			? _rom.data() : std::vector<uint8_t>{})
+		, m_flashData(_rom.data())
 		, m_patchRam(memorymap::g_patchBootstrap.size(), 0)
 		, m_mainRam(memorymap::g_mainRam.size(), 0)
 		, m_loaderRam(memorymap::g_loaderRam.size(), 0)
 		, m_internalSram(memorymap::g_internalSram.size(), 0)
 	{
+		if(m_model == MachineModel::Monomachine
+			&& _initialUserFlash.size() == memorymap::g_mmUserFlash.size()
+			&& m_flashData.size() >= memorymap::g_flashFull.offset(
+				memorymap::g_mmUserFlash.end))
+		{
+			const auto offset = memorymap::g_flashFull.offset(
+				memorymap::g_mmUserFlash.begin);
+			std::copy(_initialUserFlash.begin(), _initialUserFlash.end(),
+				m_flashData.begin() + offset);
+		}
+		if(m_model == MachineModel::Monomachine && !m_flashData.empty())
+			m_flash = std::make_unique<MonomachineFlash>(m_flashData.data(), m_flashData.size());
+
 		// The current Monomachine target is the SFX-60 MKII motherboard. Its
 		// Monomachine MKII board identification uses an inverted Port A loopback.
 		m_sim.setMk2PortAInvertedLoopback(m_model == MachineModel::Monomachine);
@@ -93,6 +129,18 @@ namespace md
 	{
 		std::shared_lock lock(m_patchRamMutex);
 		return m_patchRam;
+	}
+
+	std::vector<uint8_t> Microcontroller::copyUserFlash() const
+	{
+		if(m_model != MachineModel::Monomachine
+			|| m_flashData.size() < memorymap::g_flashFull.offset(
+				memorymap::g_mmUserFlash.end))
+			return {};
+		std::shared_lock lock(m_flashMutex);
+		const auto begin = m_flashData.begin() + memorymap::g_flashFull.offset(
+			memorymap::g_mmUserFlash.begin);
+		return {begin, begin + memorymap::g_mmUserFlash.size()};
 	}
 
 	void Microcontroller::prepareFirmwareUpdateBoot(const uint32_t _factoryFlashAddress)
@@ -165,10 +213,9 @@ namespace md
 		auto rom = [this](const uint32_t _offset) -> Region
 		{
 			Region r;
-			r.data = m_flashData.empty()
-				? const_cast<uint8_t*>(m_rom.data().data()) : m_flashData.data();
+			r.data = m_flashData.data();	// writes go through the flash command state machine
 			r.offset = _offset;
-			r.size = static_cast<uint32_t>(m_rom.data().size());
+			r.size = static_cast<uint32_t>(m_flashData.size());
 			r.writable = false;
 			return r;
 		};
@@ -604,6 +651,22 @@ namespace md
 		if(memorymap::g_sim.contains(_addr))		{ m_sim.write16(memorymap::g_sim.offset(_addr), _val); return; }
 		if(memorymap::g_dsp1Hdi08.contains(_addr))	{ m_hdi08Dsp1.write16(static_cast<mc68k::PeriphAddress>(memorymap::g_dsp1Hdi08.offset(_addr)), _val); return; }
 		if(memorymap::g_dsp2Hdi08.contains(_addr))	{ m_hdi08Dsp2.write16(static_cast<mc68k::PeriphAddress>(memorymap::g_dsp2Hdi08.offset(_addr)), _val); return; }
+		if(m_flash && memorymap::g_flashFull.contains(_addr))
+		{
+			std::unique_lock flashLock(m_flashMutex);
+			m_flash->write(memorymap::g_flashFull.offset(_addr), _val);
+			m_immPageAddress = 0xffffffffu;
+			m_immPageData = nullptr;
+			return;
+		}
+		if(m_flash && memorymap::g_flashLow.contains(_addr))
+		{
+			std::unique_lock flashLock(m_flashMutex);
+			m_flash->write(memorymap::g_flashLow.offset(_addr), _val);
+			m_immPageAddress = 0xffffffffu;
+			m_immPageData = nullptr;
+			return;
+		}
 		const bool patchRam = memorymap::isPatchRam(_addr);
 		std::unique_lock patchLock(m_patchRamMutex, std::defer_lock);
 		if(patchRam)

--- a/source/elektron/md/mdLib/mdmc.h
+++ b/source/elektron/md/mdLib/mdmc.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
@@ -13,6 +14,7 @@
 
 #include "mc68k/mc68k.h"
 #include "mc68k/hdi08.h"
+#include "hardwareLib/am29f.h"
 
 #include "mdflash.h"
 #include "mdsim.h"
@@ -49,7 +51,8 @@ namespace md
 	public:
 		Microcontroller(const Rom& _rom, MachineModel _model = MachineModel::Machinedrum,
 			const std::vector<uint8_t>& _initialPatchRam = {},
-			const std::vector<uint8_t>& _initialMainRam = {});
+			const std::vector<uint8_t>& _initialMainRam = {},
+			const std::vector<uint8_t>& _initialUserFlash = {});
 
 		// mc68k::Mc68k overrides
 		uint32_t exec() override;
@@ -150,6 +153,7 @@ namespace md
 		}
 
 		std::vector<uint8_t> copyPatchRam() const;
+		std::vector<uint8_t> copyUserFlash() const;
 
 
 	private:
@@ -178,7 +182,11 @@ namespace md
 		const MachineModel m_model;
 		const Rom& m_rom;
 		FlashCommandDecoder m_flashCommands;
+		// Each emulated machine owns a private flash image. Firmware may program this
+		// copy without changing the user's ROM file or another plug-in instance.
 		std::vector<uint8_t> m_flashData;
+		std::unique_ptr<hwLib::Am29f> m_flash;
+		mutable std::shared_mutex m_flashMutex;
 
 		Sim m_sim;	// on-chip SIM peripheral window (MBAR base 0x300000)
 		struct MidiTxBuffer

--- a/source/elektron/md/mdLib/mdmemorymap.h
+++ b/source/elektron/md/mdLib/mdmemorymap.h
@@ -28,6 +28,9 @@ namespace md::memorymap
 	inline constexpr Range g_patchOsAlias    {0x00700000, 0x00800000};
 	inline constexpr Range g_internalSram    {0x01000000, 0x01010000};
 	inline constexpr Range g_flashFull       {0x10000000, 0x10800000};
+	// MM MKII user DigiPRO records occupy the uniform-sector half-open range
+	// 0x10200000..0x103fffff within the full flash alias.
+	inline constexpr Range g_mmUserFlash     {0x10200000, 0x10400000};
 	inline constexpr Range g_mainHighAlias   {0x20000000, 0x20100000};
 	inline constexpr Range g_mainExecAlias   {0x40000000, 0x40100000};
 

--- a/source/elektron/md/mdLib/mdstate.cpp
+++ b/source/elektron/md/mdLib/mdstate.cpp
@@ -8,8 +8,10 @@ namespace md
 	namespace
 	{
 		constexpr std::array<uint8_t, 4> g_magic = {'M', 'D', 'S', 'T'};
-		constexpr uint16_t g_version = 1;
-		constexpr uint16_t g_headerSize = 20;
+		constexpr uint16_t g_versionPatchOnly = 1;
+		constexpr uint16_t g_versionWithUserFlash = 2;
+		constexpr uint16_t g_headerSizePatchOnly = 20;
+		constexpr uint16_t g_headerSizeWithUserFlash = 28;
 
 		void appendU16(std::vector<uint8_t>& _dst, const uint16_t _value)
 		{
@@ -66,51 +68,92 @@ namespace md
 	}
 
 	bool encodeState(std::vector<uint8_t>& _state, const std::vector<uint8_t>& _patchRam,
-		const MachineModel _model, const synthLib::StateType _type)
+		const MachineModel _model, const synthLib::StateType _type,
+		const std::vector<uint8_t>& _userFlash)
 	{
 		if(_patchRam.size() != g_patchRamStateSize || !validStateType(_type))
 			return false;
+		const bool hasUserFlash = !_userFlash.empty();
+		if(hasUserFlash && (_model != MachineModel::Monomachine
+			|| _userFlash.size() != g_mmUserFlashStateSize))
+			return false;
 
 		const auto originalSize = _state.size();
-		_state.reserve(originalSize + g_headerSize + _patchRam.size());
+		const auto headerSize = hasUserFlash
+			? g_headerSizeWithUserFlash : g_headerSizePatchOnly;
+		_state.reserve(originalSize + headerSize + _patchRam.size() + _userFlash.size());
 		_state.insert(_state.end(), g_magic.begin(), g_magic.end());
-		appendU16(_state, g_version);
-		appendU16(_state, g_headerSize);
+		appendU16(_state, hasUserFlash ? g_versionWithUserFlash : g_versionPatchOnly);
+		appendU16(_state, headerSize);
 		_state.push_back(modelTag(_model));
 		_state.push_back(static_cast<uint8_t>(_type));
 		appendU16(_state, 0);
 		appendU32(_state, static_cast<uint32_t>(_patchRam.size()));
 		appendU32(_state, crc32(_patchRam.data(), _patchRam.size()));
+		if(hasUserFlash)
+		{
+			appendU32(_state, static_cast<uint32_t>(_userFlash.size()));
+			appendU32(_state, crc32(_userFlash.data(), _userFlash.size()));
+		}
 		_state.insert(_state.end(), _patchRam.begin(), _patchRam.end());
+		_state.insert(_state.end(), _userFlash.begin(), _userFlash.end());
 		return true;
 	}
 
 	bool decodeState(std::vector<uint8_t>& _patchRam, const std::vector<uint8_t>& _state,
 		const MachineModel _expectedModel, const synthLib::StateType _expectedType)
 	{
-		if(!validStateType(_expectedType) || _state.size() < g_headerSize)
+		std::vector<uint8_t> ignoredUserFlash;
+		return decodeState(_patchRam, ignoredUserFlash, _state, _expectedModel,
+			_expectedType);
+	}
+
+	bool decodeState(std::vector<uint8_t>& _patchRam, std::vector<uint8_t>& _userFlash,
+		const std::vector<uint8_t>& _state, const MachineModel _expectedModel,
+		const synthLib::StateType _expectedType)
+	{
+		if(!validStateType(_expectedType) || _state.size() < g_headerSizePatchOnly)
 			return false;
 		for(size_t i = 0; i < g_magic.size(); ++i)
 			if(_state[i] != g_magic[i])
 				return false;
-		if(readU16(_state, 4) != g_version || readU16(_state, 6) != g_headerSize)
+		const auto version = readU16(_state, 4);
+		const auto headerSize = readU16(_state, 6);
+		if((version == g_versionPatchOnly && headerSize != g_headerSizePatchOnly)
+			|| (version == g_versionWithUserFlash
+				&& headerSize != g_headerSizeWithUserFlash)
+			|| (version != g_versionPatchOnly && version != g_versionWithUserFlash))
 			return false;
 		if(_state[8] != modelTag(_expectedModel) ||
 			_state[9] != static_cast<uint8_t>(_expectedType) ||
 			readU16(_state, 10) != 0)
 			return false;
 
-		const auto payloadSize = readU32(_state, 12);
-		if(payloadSize != g_patchRamStateSize ||
-			_state.size() != static_cast<size_t>(g_headerSize) + payloadSize)
+		const auto patchSize = readU32(_state, 12);
+		if(patchSize != g_patchRamStateSize)
+			return false;
+		uint32_t userFlashSize = 0;
+		if(version == g_versionWithUserFlash)
+		{
+			userFlashSize = readU32(_state, 20);
+			if(_expectedModel != MachineModel::Monomachine
+				|| userFlashSize != g_mmUserFlashStateSize)
+				return false;
+		}
+		if(_state.size() != static_cast<size_t>(headerSize) + patchSize + userFlashSize)
 			return false;
 
-		const auto* const payload = _state.data() + g_headerSize;
-		if(readU32(_state, 16) != crc32(payload, payloadSize))
+		const auto* const patch = _state.data() + headerSize;
+		if(readU32(_state, 16) != crc32(patch, patchSize))
+			return false;
+		const auto* const userFlash = patch + patchSize;
+		if(userFlashSize && readU32(_state, 24) != crc32(userFlash, userFlashSize))
 			return false;
 
-		std::vector<uint8_t> decoded(payload, payload + payloadSize);
-		_patchRam.swap(decoded);
+		std::vector<uint8_t> decodedPatch(patch, patch + patchSize);
+		std::vector<uint8_t> decodedUserFlash(userFlash, userFlash + userFlashSize);
+		_patchRam.swap(decodedPatch);
+		_userFlash.swap(decodedUserFlash);
 		return true;
 	}
 }

--- a/source/elektron/md/mdLib/mdstate.h
+++ b/source/elektron/md/mdLib/mdstate.h
@@ -10,14 +10,19 @@
 namespace md
 {
 	constexpr uint32_t g_patchRamStateSize = 0x100000;
+	constexpr uint32_t g_mmUserFlashStateSize = 0x200000;
 
 	// Append a self-describing patch-RAM image to _state. The synthLib plugin wrapper may
 	// already have placed its own two-byte envelope in the vector, so this function does
 	// not clear it.
 	bool encodeState(std::vector<uint8_t>& _state, const std::vector<uint8_t>& _patchRam,
-		MachineModel _model, synthLib::StateType _type);
+		MachineModel _model, synthLib::StateType _type,
+		const std::vector<uint8_t>& _userFlash = {});
 
 	// Validate and decode a device payload. No output is changed on failure.
 	bool decodeState(std::vector<uint8_t>& _patchRam, const std::vector<uint8_t>& _state,
 		MachineModel _expectedModel, synthLib::StateType _expectedType);
+	bool decodeState(std::vector<uint8_t>& _patchRam, std::vector<uint8_t>& _userFlash,
+		const std::vector<uint8_t>& _state, MachineModel _expectedModel,
+		synthLib::StateType _expectedType);
 }

--- a/source/elektron/md/mdLib/mdsysextransfer.h
+++ b/source/elektron/md/mdLib/mdsysextransfer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -7,10 +8,61 @@
 #include <utility>
 #include <vector>
 
+#include "mdtypes.h"
+
 namespace md
 {
 	class Hardware;
 	class TurboMidiTransfer;
+
+	inline constexpr size_t g_midiSysexTransferMaxBytes = 8u * 1024u * 1024u;
+
+	enum class MidiSysexStreamValidation : uint8_t
+	{
+		Valid,
+		Empty,
+		TooLarge,
+		InvalidFraming,
+		WrongModel,
+		FirmwareUpdate
+	};
+
+	// Validate the exact, concatenated Elektron messages accepted by the in-app
+	// sender. OS-update streams use a separate boot path and are deliberately
+	// rejected here so they cannot be confused with user-data transfers.
+	inline MidiSysexStreamValidation validateMidiSysexStream(
+		const std::vector<uint8_t>& _bytes, const MachineModel _model)
+	{
+		if(_bytes.empty())
+			return MidiSysexStreamValidation::Empty;
+		if(_bytes.size() > g_midiSysexTransferMaxBytes)
+			return MidiSysexStreamValidation::TooLarge;
+
+		const uint8_t expectedProduct = _model == MachineModel::Monomachine
+			? uint8_t{0x03} : uint8_t{0x02};
+		size_t offset = 0;
+		bool firmwareUpdate = false;
+		while(offset < _bytes.size())
+		{
+			if(offset + 8 > _bytes.size() || _bytes[offset] != 0xf0
+				|| _bytes[offset + 1] != 0x00 || _bytes[offset + 2] != 0x20
+				|| _bytes[offset + 3] != 0x3c)
+				return MidiSysexStreamValidation::InvalidFraming;
+			if(_bytes[offset + 4] != expectedProduct)
+				return MidiSysexStreamValidation::WrongModel;
+
+			const auto end = std::find(
+				_bytes.begin() + static_cast<std::ptrdiff_t>(offset + 7),
+				_bytes.end(), uint8_t{0xf7});
+			if(end == _bytes.end())
+				return MidiSysexStreamValidation::InvalidFraming;
+			const uint8_t command = _bytes[offset + 6];
+			firmwareUpdate |= command == 0x7e || command == 0x7f;
+			offset = static_cast<size_t>(end - _bytes.begin()) + 1;
+		}
+		return firmwareUpdate ? MidiSysexStreamValidation::FirmwareUpdate
+			: MidiSysexStreamValidation::Valid;
+	}
 
 	// Owns one validated, fully framed SysEx stream before it crosses into the
 	// emulation-owned transfer state. Moving file-sized storage into this object is
@@ -55,6 +107,10 @@ namespace md
 		Sending,
 		Complete
 	};
+
+	// Complete is deliberately a transport result: every byte has crossed the
+	// emulated MIDI UART boundary. Acceptance, validation, and persistence remain
+	// owned by the machine firmware and are reported on its front-panel display.
 
 	// Stable, format-free explanation for a TurboMIDI negotiation that continued
 	// at standard MIDI speed. This is published with transfer progress so UI and

--- a/source/elektron/md/mdLib/test/mdfirmwareupdate_test.cpp
+++ b/source/elektron/md/mdLib/test/mdfirmwareupdate_test.cpp
@@ -1,7 +1,9 @@
 #include "mdLib/mdflash.h"
 #include "mdLib/mdfirmwareupdate.h"
 #include "mdLib/mdhardware.h"
+#include "mdLib/mdmmwaveforms.h"
 #include "mdLib/mdromloader.h"
+#include "mdLib/mdsysextransfer.h"
 
 #include <chrono>
 #include <cstdlib>
@@ -263,6 +265,27 @@ namespace
 		return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
 	}
 
+	uint64_t fingerprintDigiProBank(md::Hardware& _hardware)
+	{
+		auto& memory = _hardware.getDspProducer().dsp().memory();
+		uint64_t result = 14695981039346656037ull;
+		for(uint32_t wave = 0; wave < md::mmwaveforms::g_waveformCount; ++wave)
+		{
+			const auto base = md::mmwaveforms::g_destinationBase
+				+ wave * md::mmwaveforms::g_destinationStride;
+			for(uint32_t word = 0; word < md::mmwaveforms::g_wordsPerWave; ++word)
+			{
+				const auto value = memory.get(dsp56k::MemArea_X, base + word);
+				for(int shift = 16; shift >= 0; shift -= 8)
+				{
+					result ^= static_cast<uint8_t>(value >> shift);
+					result *= 1099511628211ull;
+				}
+			}
+		}
+		return result;
+	}
+
 	void writeLcdPgm(const md::Hardware& _hardware)
 	{
 		const auto* const path = std::getenv("MD_FIRMWARE_UPDATE_LCD_PGM");
@@ -306,9 +329,10 @@ int main(const int _argc, char** const _argv)
 		std::puts("mdfirmwareupdate_test: PASS");
 		return 0;
 	}
-	if(_argc != 2)
+	if(_argc < 2 || _argc > 3)
 	{
-		std::fprintf(stderr, "usage: mdfirmwareupdate_test [official-os-update.syx]\n");
+		std::fprintf(stderr,
+			"usage: mdfirmwareupdate_test [official-os-update.syx] [user-data.syx]\n");
 		return 2;
 	}
 
@@ -362,7 +386,50 @@ int main(const int _argc, char** const _argv)
 			return 1;
 		}
 	}
-	writeLcdPgm(hardware);
+	if(model == md::MachineModel::Monomachine && (converted || _argc == 3))
+	{
+		auto transferBytes = _argc == 3 ? load(_argv[2]) : std::vector<uint8_t>{
+			0xf0, 0x00, 0x20, 0x3c, 0x03, 0x00, 0x54, 0xf7};
+		if(md::validateMidiSysexStream(transferBytes, model)
+			!= md::MidiSysexStreamValidation::Valid)
+		{
+			std::fputs("user-data SysEx failed stream validation\n", stderr);
+			return 1;
+		}
+		const auto waveBankBefore = fingerprintDigiProBank(hardware);
+		auto prepared = md::prepareMidiSysexTransfer(std::move(transferBytes));
+		if(!prepared || !hardware.startMidiSysexTransfer(*prepared))
+		{
+			std::fputs("converted Monomachine transfer did not start\n", stderr);
+			return 1;
+		}
+		const auto transferDeadline = std::chrono::steady_clock::now()
+			+ std::chrono::seconds(90);
+		uint8_t payloadSpeed = 1;
+		for(;;)
+		{
+			hardware.advance(64);
+			const auto progress = hardware.getMidiSysexTransferProgress();
+			if(progress.state == md::MidiSysexTransferState::Sending)
+				payloadSpeed = progress.speedCode;
+			if(progress.state == md::MidiSysexTransferState::Complete)
+				break;
+			if(std::chrono::steady_clock::now() >= transferDeadline)
+			{
+				std::fputs("converted Monomachine SysEx delivery timed out\n", stderr);
+				return 1;
+			}
+		}
+		auto waveBankAfter = fingerprintDigiProBank(hardware);
+		std::printf("Monomachine user-data transfer: %sx, DigiPRO=%016llx -> %016llx\n",
+			md::midiTurboSpeedLabel(payloadSpeed),
+			static_cast<unsigned long long>(waveBankBefore),
+			static_cast<unsigned long long>(waveBankAfter));
+		writeLcdPgm(hardware);
+		// This harness deliberately does not navigate a private firmware menu.
+		// Completion proves hardware-boundary delivery only; installation belongs
+		// to a separate panel-driven integration test.
+	}
 	std::printf("mdfirmwareupdate_test: PASS (%s, %zu-byte Gearmulator image)\n",
 		model == md::MachineModel::Monomachine ? "Monomachine" : "Machinedrum",
 		rom.size());

--- a/source/elektron/md/mdLib/test/mdflash_test.cpp
+++ b/source/elektron/md/mdLib/test/mdflash_test.cpp
@@ -1,0 +1,92 @@
+#include "mdLib/mdmc.h"
+#include "mdLib/mdrom.h"
+
+#include <cstdio>
+#include <vector>
+
+namespace
+{
+	constexpr uint32_t g_flashBase = 0x10000000;
+	constexpr uint32_t g_commandAa = g_flashBase + 0xaaaa;
+	constexpr uint32_t g_command55 = g_flashBase + 0x5554;
+
+	void program(md::Microcontroller& _uc, const uint32_t _address, const uint16_t _value)
+	{
+		_uc.write16(g_commandAa, 0xaaaa);
+		_uc.write16(g_command55, 0x5555);
+		_uc.write16(g_commandAa, 0xa0a0);
+		_uc.write16(_address, _value);
+	}
+
+	void eraseSector(md::Microcontroller& _uc, const uint32_t _address)
+	{
+		_uc.write16(g_commandAa, 0xaaaa);
+		_uc.write16(g_command55, 0x5555);
+		_uc.write16(g_commandAa, 0x8080);
+		_uc.write16(g_commandAa, 0xaaaa);
+		_uc.write16(g_command55, 0x5555);
+		_uc.write16(_address, 0x3030);
+	}
+}
+
+int main()
+{
+	std::vector<uint8_t> bytes(md::g_romSize, 0xff);
+	md::Rom rom(bytes, "synthetic-mm-flash.bin");
+	md::Microcontroller mm(rom, md::MachineModel::Monomachine);
+
+	constexpr uint32_t sector = g_flashBase + 0x200000;
+	constexpr uint32_t target = sector + 0x1234;
+	program(mm, target, 0x5aa5);
+	if(mm.read16(target) != 0x5aa5)
+	{
+		std::puts("FAIL: Monomachine flash program command did not change the private image");
+		return 1;
+	}
+	if(rom.data()[target - g_flashBase] != 0xff)
+	{
+		std::puts("FAIL: flash programming changed the source ROM image");
+		return 1;
+	}
+
+	eraseSector(mm, sector);
+	if(mm.read16(target) != 0xffff)
+	{
+		std::puts("FAIL: Monomachine 64 KiB sector erase did not complete");
+		return 1;
+	}
+
+	auto savedUserFlash = mm.copyUserFlash();
+	const auto savedOffset = target - (g_flashBase + 0x200000);
+	savedUserFlash[savedOffset] = 0x12;
+	savedUserFlash[savedOffset + 1] = 0x34;
+	md::Microcontroller restored(rom, md::MachineModel::Monomachine, {}, {},
+		savedUserFlash);
+	if(restored.read16(target) != 0x1234)
+	{
+		std::puts("FAIL: saved Monomachine user flash was not restored");
+		return 1;
+	}
+
+	md::Microcontroller md(rom, md::MachineModel::Machinedrum);
+	program(md, target, 0x5aa5);
+	if(md.read16(target) != 0x5aa5)
+	{
+		std::puts("FAIL: Machinedrum flash program command did not change the private image");
+		return 1;
+	}
+	if(rom.data()[target - g_flashBase] != 0xff)
+	{
+		std::puts("FAIL: Machinedrum flash programming changed the source ROM image");
+		return 1;
+	}
+	eraseSector(md, sector);
+	if(md.read16(target) != 0xffff)
+	{
+		std::puts("FAIL: Machinedrum 64 KiB sector erase did not complete");
+		return 1;
+	}
+
+	std::puts("PASS: MD/MM flash programs privately and MM storage restores");
+	return 0;
+}

--- a/source/elektron/md/mdLib/test/mdstate_test.cpp
+++ b/source/elektron/md/mdLib/test/mdstate_test.cpp
@@ -1,0 +1,110 @@
+#include "mdLib/mdstate.h"
+
+#include <cstdio>
+#include <vector>
+
+namespace
+{
+	int g_failures = 0;
+
+	void check(const bool _condition, const char* const _message)
+	{
+		std::printf("[%s] %s\n", _condition ? "PASS" : "FAIL", _message);
+		if(!_condition)
+			++g_failures;
+	}
+
+	std::vector<uint8_t> makePatchRam()
+	{
+		std::vector<uint8_t> result(md::g_patchRamStateSize);
+		uint32_t value = 0x12345678;
+		for(auto& byte : result)
+		{
+			value = value * 1664525u + 1013904223u;
+			byte = static_cast<uint8_t>(value >> 24);
+		}
+		return result;
+	}
+
+	std::vector<uint8_t> makeUserFlash()
+	{
+		std::vector<uint8_t> result(md::g_mmUserFlashStateSize);
+		for(size_t i = 0; i < result.size(); ++i)
+			result[i] = static_cast<uint8_t>((i * 29u + (i >> 9)) & 0xffu);
+		return result;
+	}
+}
+
+int main()
+{
+	std::printf("md state codec test\n\n");
+
+	const auto original = makePatchRam();
+	std::vector<uint8_t> encoded = {1, synthLib::StateTypeGlobal};
+	check(md::encodeState(encoded, original, md::MachineModel::Monomachine,
+		synthLib::StateTypeGlobal), "global Monomachine state encodes after plugin envelope");
+	check(encoded.size() == 2 + 20 + original.size(), "encoded state has exact expected size");
+
+	const std::vector<uint8_t> payload(encoded.begin() + 2, encoded.end());
+	std::vector<uint8_t> decoded = {0xaa};
+	check(md::decodeState(decoded, payload, md::MachineModel::Monomachine,
+		synthLib::StateTypeGlobal), "matching state decodes");
+	check(decoded == original, "patch RAM round-trips byte exactly");
+
+	const auto originalUserFlash = makeUserFlash();
+	std::vector<uint8_t> encodedWithFlash;
+	check(md::encodeState(encodedWithFlash, original, md::MachineModel::Monomachine,
+		synthLib::StateTypeGlobal, originalUserFlash),
+		"Monomachine state encodes mutable DigiPRO flash storage");
+	check(encodedWithFlash.size() == 28 + original.size() + originalUserFlash.size(),
+		"DigiPRO state has the exact version-2 size");
+	std::vector<uint8_t> decodedUserFlash;
+	check(md::decodeState(decoded, decodedUserFlash, encodedWithFlash,
+		md::MachineModel::Monomachine, synthLib::StateTypeGlobal),
+		"version-2 Monomachine state decodes");
+	check(decoded == original && decodedUserFlash == originalUserFlash,
+		"patch RAM and DigiPRO flash round-trip byte exactly");
+	decodedUserFlash = {0x55};
+	check(md::decodeState(decoded, decodedUserFlash, payload,
+		md::MachineModel::Monomachine, synthLib::StateTypeGlobal)
+		&& decodedUserFlash.empty(),
+		"legacy version-1 Monomachine state remains compatible");
+
+	std::vector<uint8_t> currentProgram;
+	check(md::encodeState(currentProgram, original, md::MachineModel::Machinedrum,
+		synthLib::StateTypeCurrentProgram), "current-program Machinedrum state encodes");
+	check(md::decodeState(decoded, currentProgram, md::MachineModel::Machinedrum,
+		synthLib::StateTypeCurrentProgram), "current-program Machinedrum state decodes");
+
+	decoded = {0x55};
+	check(!md::decodeState(decoded, payload, md::MachineModel::Machinedrum,
+		synthLib::StateTypeGlobal), "wrong machine model is rejected");
+	check(decoded == std::vector<uint8_t>{0x55}, "failed decode leaves output untouched");
+	check(!md::decodeState(decoded, payload, md::MachineModel::Monomachine,
+		synthLib::StateTypeCurrentProgram), "wrong state type is rejected");
+
+	auto corrupt = payload;
+	corrupt.back() ^= 0x80;
+	check(!md::decodeState(decoded, corrupt, md::MachineModel::Monomachine,
+		synthLib::StateTypeGlobal), "payload corruption is rejected by CRC");
+
+	auto truncated = payload;
+	truncated.pop_back();
+	check(!md::decodeState(decoded, truncated, md::MachineModel::Monomachine,
+		synthLib::StateTypeGlobal), "truncated payload is rejected");
+
+	auto trailing = payload;
+	trailing.push_back(0);
+	check(!md::decodeState(decoded, trailing, md::MachineModel::Monomachine,
+		synthLib::StateTypeGlobal), "trailing bytes are rejected");
+
+	std::vector<uint8_t> invalidRam(original.size() - 1);
+	std::vector<uint8_t> unchanged = {0x12, 0x34};
+	check(!md::encodeState(unchanged, invalidRam, md::MachineModel::Monomachine,
+		synthLib::StateTypeGlobal), "wrong patch-RAM size is rejected");
+	check(unchanged == std::vector<uint8_t>({0x12, 0x34}),
+		"failed encode leaves destination untouched");
+
+	std::printf("\n%s (%d failures)\n", g_failures == 0 ? "OK" : "FAILED", g_failures);
+	return g_failures == 0 ? 0 : 1;
+}

--- a/source/elektron/md/mdLib/test/mdturbomidi_test.cpp
+++ b/source/elektron/md/mdLib/test/mdturbomidi_test.cpp
@@ -1,0 +1,91 @@
+#include "mdLib/mdhardware.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <fstream>
+#include <iterator>
+#include <thread>
+#include <vector>
+
+namespace
+{
+	std::vector<uint8_t> load(const char* const _path)
+	{
+		std::ifstream input(_path, std::ios::binary);
+		return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+	}
+}
+
+int main(int _argc, char** _argv)
+{
+	if(_argc != 3)
+	{
+		std::fprintf(stderr,
+			"usage: mdturbomidi_test <machinedrum-rom> <machinedrum-sysex-file>\n");
+		return 2;
+	}
+
+	const auto rom = load(_argv[1]);
+	auto bytes = load(_argv[2]);
+	if(bytes.empty())
+	{
+		std::fprintf(stderr, "cannot read SysEx file: %s\n", _argv[2]);
+		return 2;
+	}
+
+	md::Hardware hardware(rom, _argv[1], md::MachineModel::Machinedrum);
+	if(!hardware.isValid())
+	{
+		std::printf("[TurboMIDI test] SKIP: Machinedrum firmware not found\n");
+		return 77;
+	}
+
+	const auto bootStart = std::chrono::steady_clock::now();
+	while(hardware.getFrontPanelSnapshot().countLitPixels() <= 2000)
+	{
+		hardware.advance(64);
+		if(std::chrono::steady_clock::now() - bootStart > std::chrono::seconds(90))
+		{
+			std::fprintf(stderr, "[TurboMIDI test] firmware boot timed out\n");
+			return 1;
+		}
+	}
+
+	auto prepared = md::prepareMidiSysexTransfer(std::move(bytes));
+	if(!prepared || !hardware.startMidiSysexTransfer(*prepared))
+	{
+		std::fprintf(stderr, "[TurboMIDI test] transfer did not start\n");
+		return 1;
+	}
+
+	const auto transferStart = std::chrono::steady_clock::now();
+	uint8_t maximumSpeed = 1;
+	uint8_t payloadSpeed = 1;
+	for(;;)
+	{
+		hardware.advance(64);
+		const auto progress = hardware.getMidiSysexTransferProgress();
+		maximumSpeed = std::max(maximumSpeed, progress.speedCode);
+		if(progress.state == md::MidiSysexTransferState::Sending)
+			payloadSpeed = progress.speedCode;
+		if(progress.state == md::MidiSysexTransferState::Complete)
+		{
+			const auto elapsed = std::chrono::duration<double>(
+				std::chrono::steady_clock::now() - transferStart).count();
+			std::printf("[TurboMIDI test] complete: bytes=%zu maxObserved=%sx payload=%sx wall=%.3fs\n",
+				progress.total, md::midiTurboSpeedLabel(maximumSpeed),
+				md::midiTurboSpeedLabel(payloadSpeed), elapsed);
+			// speed1's link test can complete between two public progress polls;
+			// payloadSpeed is stable for the whole file and proves Turbo was engaged.
+			return payloadSpeed > 1 ? 0 : 1;
+		}
+		if(std::chrono::steady_clock::now() - transferStart > std::chrono::seconds(90))
+		{
+			std::fprintf(stderr, "[TurboMIDI test] transfer timed out (maxObserved=%sx, payload=%sx)\n",
+				md::midiTurboSpeedLabel(maximumSpeed),
+				md::midiTurboSpeedLabel(payloadSpeed));
+			return 1;
+		}
+	}
+}

--- a/source/elektron/md/mdLib/test/mmturbomidi_test.cpp
+++ b/source/elektron/md/mdLib/test/mmturbomidi_test.cpp
@@ -1,0 +1,266 @@
+#include "mdLib/mdhardware.h"
+#include "mdLib/mdstate.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <cstdio>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+namespace
+{
+	std::vector<uint8_t> load(const char* const _path)
+	{
+		std::ifstream input(_path, std::ios::binary);
+		return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+	}
+
+	void settle(md::Hardware& _hardware, const size_t _steps = 100)
+	{
+		for(size_t i = 0; i < _steps; ++i)
+			_hardware.advance(64);
+	}
+
+	void pulse(md::Hardware& _hardware, const md::PanelControl _control)
+	{
+		const auto packet = md::panelPacket(md::MachineModel::Monomachine, _control);
+		if(!packet)
+			return;
+		_hardware.sendPanelEvent(packet->row, packet->mask);
+		settle(_hardware, 8);
+		_hardware.sendPanelEvent(packet->row, 0);
+		settle(_hardware);
+	}
+
+	void chord(md::Hardware& _hardware, const md::PanelControl _control)
+	{
+		const auto function = md::panelPacket(md::MachineModel::Monomachine,
+			md::PanelControl::Function);
+		const auto target = md::panelPacket(md::MachineModel::Monomachine, _control);
+		if(!function || !target)
+			return;
+		md::PanelRowState rows;
+		auto packet = rows.press(*function);
+		_hardware.sendPanelEvent(packet.row, packet.mask);
+		settle(_hardware, 4);
+		packet = rows.press(*target);
+		_hardware.sendPanelEvent(packet.row, packet.mask);
+		settle(_hardware, 8);
+		packet = rows.release(*target);
+		_hardware.sendPanelEvent(packet.row, packet.mask);
+		settle(_hardware, 4);
+		packet = rows.release(*function);
+		_hardware.sendPanelEvent(packet.row, packet.mask);
+		settle(_hardware);
+	}
+
+	void writePanel(const md::Hardware& _hardware, const std::string& _path)
+	{
+		const auto panel = _hardware.getFrontPanelSnapshot();
+		std::ofstream output(_path, std::ios::binary);
+		output << "P5\n" << md::FrontPanel::g_lcdWidth << ' '
+			<< md::FrontPanel::g_lcdHeight << "\n255\n";
+		for(uint32_t y = 0; y < md::FrontPanel::g_lcdHeight; ++y)
+			for(uint32_t x = 0; x < md::FrontPanel::g_lcdWidth; ++x)
+				output.put(panel.getLcdPixel(x, y) ? '\0' : '\xff');
+	}
+
+	uint64_t panelFingerprint(const md::Hardware& _hardware)
+	{
+		const auto panel = _hardware.getFrontPanelSnapshot();
+		uint64_t result = 14695981039346656037ull;
+		for(uint32_t y = 0; y < md::FrontPanel::g_lcdHeight; ++y)
+			for(uint32_t x = 0; x < md::FrontPanel::g_lcdWidth; ++x)
+			{
+				result ^= panel.getLcdPixel(x, y) ? 1u : 0u;
+				result *= 1099511628211ull;
+			}
+		return result;
+	}
+
+	bool enterDigiProReceive(md::Hardware& _hardware)
+	{
+		const auto* const prefix = std::getenv("MM_PANEL_PROBE_PREFIX");
+		const auto save = [&_hardware, prefix](const int _index)
+		{
+			if(prefix && *prefix)
+				writePanel(_hardware,
+					std::string(prefix) + std::to_string(_index) + ".pgm");
+		};
+		save(0);
+		chord(_hardware, md::PanelControl::Kit);
+		save(1);
+		pulse(_hardware, md::PanelControl::Enter);
+		save(2);
+		pulse(_hardware, md::PanelControl::Down);
+		save(3);
+		pulse(_hardware, md::PanelControl::Down);
+		save(4);
+		pulse(_hardware, md::PanelControl::Right);
+		save(5);
+		pulse(_hardware, md::PanelControl::Down);
+		save(6);
+		pulse(_hardware, md::PanelControl::Down);
+		save(7);
+		pulse(_hardware, md::PanelControl::Enter);
+		save(8);
+		pulse(_hardware, md::PanelControl::Right);
+		save(9);
+		const auto beforeWaiting = panelFingerprint(_hardware);
+		pulse(_hardware, md::PanelControl::Enter);
+		save(10);
+		return panelFingerprint(_hardware) != beforeWaiting;
+	}
+
+}
+
+int main(const int _argc, char** _argv)
+{
+	if(_argc != 4)
+	{
+		std::fprintf(stderr,
+			"usage: mmturbomidi_test <monomachine-rom> <factory-patch-ram> <sysex-file>\n");
+		return 2;
+	}
+
+	const auto rom = load(_argv[1]);
+	const auto patchRam = load(_argv[2]);
+	auto bytes = load(_argv[3]);
+	// Match the shipping plug-in path: each rack worker owns a deterministic
+	// scheduler-backed machine, with the fidelity/catch-up options enabled.
+	md::Hardware hardware(rom, _argv[1], md::MachineModel::Monomachine, patchRam);
+	if(!hardware.isValid() || patchRam.size() != 0x100000 || bytes.empty())
+		return 2;
+
+	const auto bootDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(180);
+	while(!hardware.isAudioReady() ||
+		hardware.getFrontPanelSnapshot().countLitPixels() <= 2000)
+	{
+		hardware.advance(64);
+		if(std::chrono::steady_clock::now() >= bootDeadline)
+		{
+			std::fprintf(stderr,
+				"[TurboMIDI MM test] boot timeout: audio=%s pixels=%zu ucPC=%08x\n",
+				hardware.isAudioReady() ? "yes" : "no",
+				static_cast<size_t>(hardware.getFrontPanelSnapshot().countLitPixels()),
+				hardware.getUC().getPC());
+			return 1;
+		}
+	}
+	if(bytes.size() > 6 && bytes[6] == 0x5d)
+	{
+		const auto end = std::find(bytes.begin(), bytes.end(), uint8_t{0xf7});
+		if(end == bytes.end())
+			return 2;
+		const auto flashAtMainScreen = hardware.copyUserFlash();
+		auto boundaryProbe = md::prepareMidiSysexTransfer(
+			std::vector<uint8_t>(bytes.begin(), end + 1));
+		if(!boundaryProbe || !hardware.startMidiSysexTransfer(*boundaryProbe))
+			return 1;
+		const auto boundaryDeadline = std::chrono::steady_clock::now()
+			+ std::chrono::seconds(30);
+		for(;;)
+		{
+			hardware.advance(64);
+			if(hardware.getMidiSysexTransferProgress().state
+				== md::MidiSysexTransferState::Complete)
+				break;
+			if(std::chrono::steady_clock::now() >= boundaryDeadline)
+			{
+				std::fputs("[TurboMIDI MM test] boundary probe timed out\n", stderr);
+				return 1;
+			}
+		}
+		settle(hardware, 700);
+		if(hardware.copyUserFlash() != flashAtMainScreen)
+		{
+			std::fputs("[TurboMIDI MM test] sender bypassed the receive screen\n", stderr);
+			return 1;
+		}
+		std::puts("[TurboMIDI MM test] boundary guard: main-screen send left flash unchanged");
+	}
+	if(!enterDigiProReceive(hardware))
+	{
+		std::fputs("[TurboMIDI MM test] panel did not enter DigiPRO WAITING screen\n",
+			stderr);
+		return 1;
+	}
+	if(const auto* const prefix = std::getenv("MM_PANEL_PROBE_PREFIX");
+		prefix && *prefix)
+		return 0;
+	const auto flashBefore = hardware.copyUserFlash();
+	auto prepared = md::prepareMidiSysexTransfer(std::move(bytes));
+	if(!prepared || !hardware.startMidiSysexTransfer(*prepared))
+		return 1;
+
+	const auto start = std::chrono::steady_clock::now();
+	uint8_t payloadSpeed = 1;
+	for(;;)
+	{
+		hardware.advance(64);
+		const auto progress = hardware.getMidiSysexTransferProgress();
+		if(progress.state == md::MidiSysexTransferState::Sending)
+			payloadSpeed = progress.speedCode;
+		if(progress.state == md::MidiSysexTransferState::Complete)
+		{
+			// Completion means the UART boundary drained, not that the firmware has
+			// stored anything. Let its parser consume the tail, then perform the same
+			// externally observable EXIT/NO action required on the hardware.
+			settle(hardware, 700);
+			pulse(hardware, md::PanelControl::Exit);
+			const auto storeDeadline = std::chrono::steady_clock::now()
+				+ std::chrono::seconds(60);
+			std::vector<uint8_t> flashAfter = flashBefore;
+			bool flashChanged = false;
+			size_t stableObservations = 0;
+			do
+			{
+				settle(hardware, 200);
+				auto observed = hardware.copyUserFlash();
+				if(observed != flashAfter)
+				{
+					flashChanged = true;
+					stableObservations = 0;
+					flashAfter = std::move(observed);
+				}
+				else if(flashChanged)
+					++stableObservations;
+			} while(stableObservations < 10
+				&& std::chrono::steady_clock::now() < storeDeadline);
+			size_t changedFlashBytes = 0;
+			if(flashBefore.size() == flashAfter.size())
+				for(size_t i = 0; i < flashBefore.size(); ++i)
+					changedFlashBytes += flashBefore[i] != flashAfter[i] ? 1u : 0u;
+			std::vector<uint8_t> encodedState;
+			const bool stateEncoded = md::encodeState(encodedState,
+				hardware.copyPatchRam(), md::MachineModel::Monomachine,
+				synthLib::StateTypeGlobal, flashAfter);
+			std::vector<uint8_t> restoredPatchRam;
+			std::vector<uint8_t> restoredFlash;
+			const bool stateRoundTrip = stateEncoded && md::decodeState(
+				restoredPatchRam, restoredFlash, encodedState,
+				md::MachineModel::Monomachine, synthLib::StateTypeGlobal)
+				&& restoredFlash == flashAfter;
+			const auto elapsed = std::chrono::duration<double>(
+				std::chrono::steady_clock::now() - start).count();
+			std::printf("[TurboMIDI MM test] panel-driven: bytes=%zu "
+				"payload=%sx flashChanged=%zu stateRoundTrip=%s wall=%.3fs\n",
+				progress.total, md::midiTurboSpeedLabel(payloadSpeed),
+				changedFlashBytes, stateRoundTrip ? "yes" : "no", elapsed);
+			return payloadSpeed > 1 && changedFlashBytes > 0
+				&& stableObservations >= 10 && stateRoundTrip ? 0 : 1;
+		}
+		if(std::chrono::steady_clock::now() - start > std::chrono::seconds(90))
+		{
+			std::fprintf(stderr,
+				"[TurboMIDI MM test] transfer timed out: progress=%u sent=%zu/%zu "
+				"ucPC=%08x\n",
+				static_cast<unsigned>(progress.state), progress.sent, progress.total,
+				hardware.getUC().getPC());
+			return 1;
+		}
+	}
+}

--- a/source/elektron/md/mdLibTest/CMakeLists.txt
+++ b/source/elektron/md/mdLibTest/CMakeLists.txt
@@ -14,6 +14,28 @@ add_test(NAME mdFirmwareUpdateTest COMMAND mdFirmwareUpdateTest)
 set_tests_properties(mdFirmwareUpdateTest PROPERTIES LABELS "UnitTest")
 set_property(TARGET mdFirmwareUpdateTest PROPERTY FOLDER "Elektron")
 
+add_executable(mdFlashTest ../mdLib/test/mdflash_test.cpp)
+target_link_libraries(mdFlashTest PRIVATE mdLib)
+add_test(NAME mdFlashTest COMMAND mdFlashTest)
+set_tests_properties(mdFlashTest PROPERTIES LABELS "UnitTest")
+set_property(TARGET mdFlashTest PROPERTY FOLDER "Elektron")
+
+add_executable(mdStateTest ../mdLib/test/mdstate_test.cpp)
+target_link_libraries(mdStateTest PRIVATE mdLib)
+add_test(NAME mdStateTest COMMAND mdStateTest)
+set_tests_properties(mdStateTest PROPERTIES LABELS "UnitTest")
+set_property(TARGET mdStateTest PROPERTY FOLDER "Elektron")
+
+# Manual firmware acceptance tests; intentionally not registered with ctest
+# because they require user-supplied ROM and SysEx paths.
+add_executable(mdTurboMidiTest ../mdLib/test/mdturbomidi_test.cpp)
+target_link_libraries(mdTurboMidiTest PRIVATE mdLib)
+set_property(TARGET mdTurboMidiTest PROPERTY FOLDER "Elektron")
+
+add_executable(mmTurboMidiTest ../mdLib/test/mmturbomidi_test.cpp)
+target_link_libraries(mmTurboMidiTest PRIVATE mdLib)
+set_property(TARGET mmTurboMidiTest PROPERTY FOLDER "Elektron")
+
 add_executable(mdAutomationMidiTest automationMidiTest.cpp)
 target_link_libraries(mdAutomationMidiTest PRIVATE mdLib)
 add_test(NAME mdAutomationMidiTest COMMAND mdAutomationMidiTest)

--- a/source/elektron/md/mdLibTest/turboMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/turboMidiTest.cpp
@@ -101,6 +101,41 @@ namespace
 				"TurboMIDI transfer unexpectedly fell back");
 	}
 
+	bool testModelValidation()
+	{
+		using md::MidiSysexStreamValidation;
+		const std::vector<uint8_t> mdMessage{
+			0xf0, 0x00, 0x20, 0x3c, 0x02, 0x00, 0x52, 0x01, 0xf7};
+		const std::vector<uint8_t> mmMessage{
+			0xf0, 0x00, 0x20, 0x3c, 0x03, 0x00, 0x5d, 0x01, 0xf7};
+		const std::vector<uint8_t> mmOsUpdate{
+			0xf0, 0x00, 0x20, 0x3c, 0x03, 0x00, 0x7e, 0x00, 0xf7};
+		if(!check(md::validateMidiSysexStream(mdMessage,
+				md::MachineModel::Machinedrum) == MidiSysexStreamValidation::Valid,
+			"Machinedrum user-data stream was rejected")
+			|| !check(md::validateMidiSysexStream(mmMessage,
+				md::MachineModel::Monomachine) == MidiSysexStreamValidation::Valid,
+			"Monomachine user-data stream was rejected")
+			|| !check(md::validateMidiSysexStream(mdMessage,
+				md::MachineModel::Monomachine) == MidiSysexStreamValidation::WrongModel,
+			"wrong-model stream was accepted")
+			|| !check(md::validateMidiSysexStream(mmOsUpdate,
+				md::MachineModel::Monomachine) == MidiSysexStreamValidation::FirmwareUpdate,
+			"OS updater was accepted as user data"))
+			return false;
+
+		auto concatenated = mmMessage;
+		concatenated.insert(concatenated.end(), mmMessage.begin(), mmMessage.end());
+		if(!check(md::validateMidiSysexStream(concatenated,
+				md::MachineModel::Monomachine) == MidiSysexStreamValidation::Valid,
+			"concatenated user-data messages were rejected"))
+			return false;
+		concatenated.push_back(0x00);
+		return check(md::validateMidiSysexStream(concatenated,
+			md::MachineModel::Monomachine) == MidiSysexStreamValidation::InvalidFraming,
+			"trailing non-SysEx data was accepted");
+	}
+
 	bool testDspMemoryFallback()
 	{
 		dsp56k::DefaultMemoryValidator validator;
@@ -155,7 +190,7 @@ namespace
 
 int main()
 {
-	if(!testTimeoutFallback() || !testDocumentedHandshake()
+	if(!testTimeoutFallback() || !testDocumentedHandshake() || !testModelValidation()
 		|| !testDspMemoryFallback() || !testMk2PortAInvertedLoopback()
 		|| !testFirmwareUpdateHandoff())
 		return 1;


### PR DESCRIPTION
## Summary

- Add an in-app picker and drag-and-drop path for sending user-data SysEx through the emulated machine's MIDI input.
- Validate Elektron manufacturer/model framing and reject OS updater files here, directing those to the ROM loader instead.
- Show concise instructions, progress, and transport status alongside the control in the escape-menu overlay.
- Route bytes through the normal UART/TurboMIDI path. `SENT` means transport completed; the emulated machine's own display remains authoritative about whether it accepted the data.
- Add writable private Monomachine user flash and versioned state persistence so installed DigiPRO data survives save/restore without modifying the source ROM.
- Preserve the current public stack's generic `TurboMidiTransfer` architecture; no firmware-address adapter or exact-memory preparation path is introduced.

## Architecture boundary

The sender contains no firmware program-counter checks, receiver-state addresses, trampolines, or direct firmware calls. It only delivers validated bytes through the emulated MIDI hardware path; the running firmware decides what the data means and whether the current UI state permits installation.

## Validation

- Five focused current-stack tests passed: generic MIDI/validation, updater, flash, state, and automation coexistence.
- Both Gearmulator MD and Gearmulator MM shared-code products compile with their product-specific settings assets.
- Real panel-driven Monomachine DigiPRO import passed: main-screen transfer left flash unchanged, the panel was navigated to its waiting state, the bank transferred at 8x, 376,503 flash bytes changed, and the result survived a state round-trip.
- An official Monomachine updater boot plus user-data transport cross-test passed.

No proprietary firmware, factory bank, or test SysEx data is committed.

## Review order

This is PR 2 of 2 and is stacked on `feature/md-mm-os-updater-sysex`, which is itself stacked on the current DAW-automation PR. Review the updater PR first; this PR can then be retargeted as the lower stack lands.
