### PR TITLE
Polish Machinedrum and Monomachine panel graphics

### DIFF
--- a/source/elektron/md/mdJucePlugin/skins/mdDefault/mdDefault.rml
+++ b/source/elektron/md/mdJucePlugin/skins/mdDefault/mdDefault.rml
@@ -334,9 +334,9 @@
 			<button id="btPattern" class="juceButton elektronButton elektronKey" isToggle="0"/>
 			<div id="altGlobal" class="juceLabel elektronButtonCaption elektronSecondary mdAffordance" title="FUNCTION + PATTERN/SONG: Global">GLOBAL</div>
 		</div>
-		<div class="jucePos elektronCaptionedKey elektronCaptionedKey--wide" style="left: 1011dp; top: 377dp;">
+		<div class="jucePos elektronCaptionedKey" style="left: 1015dp; top: 377dp;">
 			<button id="btKit" class="juceButton elektronButton elektronKey" isToggle="0"/>
-			<div id="altSongSetup" class="juceLabel elektronButtonCaption elektronButtonCaption--wide elektronSecondary compact mdAffordance" title="FUNCTION + KIT: Song setup">SONG SETUP</div>
+			<div id="altSongSetup" class="juceLabel elektronButtonCaption elektronSecondary compact mdAffordance" title="FUNCTION + KIT: Song setup">SONG SETUP</div>
 		</div>
 
 		<!-- Compact 16-pad hardware row with external number/machine legends. -->

--- a/source/elektron/md/mdJucePlugin/skins/mdDefault/mdDefault.rml
+++ b/source/elektron/md/mdJucePlugin/skins/mdDefault/mdDefault.rml
@@ -451,7 +451,7 @@
 				</div>
 			</div>
 			<button id="btScale" class="juceButton elektronButton elektronKey elektronScaleButton" isToggle="0"/>
-			<div id="altScaleSetup" class="juceLabel elektronButtonCaption elektronButtonCaption--wide elektronScaleSetup elektronSecondary compact mdAffordance" title="FUNCTION + SCALE: Scale setup">SCALE SETUP</div>
+			<div id="altScaleSetup" class="juceLabel elektronButtonCaption elektronScaleSetup elektronSecondary compact mdAffordance" title="FUNCTION + SCALE: Scale setup">SCALE SETUP</div>
 		</div>
 	</body>
 </rml>

--- a/source/elektron/md/mdJucePlugin/skins/mmSfx60/mmSfx60.rcss
+++ b/source/elektron/md/mdJucePlugin/skins/mmSfx60/mmSfx60.rcss
@@ -15,12 +15,6 @@ body
 	border: 2dp #74756f;
 }
 
-.mmTopRail
-{
-	background-color: #00000000;
-	border-bottom: 1dp #858680;
-}
-
 .mmLowerBracket, .mmTrigBracket, .mmTrigBracketDot
 {
 	background-color: #898a84;

--- a/source/elektron/md/mdJucePlugin/skins/mmSfx60/mmSfx60.rml
+++ b/source/elektron/md/mdJucePlugin/skins/mmSfx60/mmSfx60.rml
@@ -260,7 +260,7 @@
 		<div class="jucePos juceLabel mmKeyLabel elektronActionLabel" style="left: 435dp; top: 315dp; width: 49dp; height: 10dp; line-height: 10dp;">BANK</div>
 		<div class="jucePos elektronCaptionedKey elektronCaptionedKey--wide" style="left: 430dp; top: 327dp;">
 			<button id="btBankGrp" class="juceButton elektronButton elektronKey mmBankGroup" isToggle="0"/>
-			<div id="altMuteMode" class="juceLabel elektronButtonCaption elektronButtonCaption--wide elektronSecondary compact mmAffordance" title="FUNCTION + BANK: Mute mode">MUTE MODE</div>
+			<div id="altMuteMode" class="juceLabel elektronButtonCaption elektronSecondary compact mmAffordance" title="FUNCTION + BANK: Mute mode">MUTE MODE</div>
 		</div>
 		<div class="jucePos mmBankLetterRule" style="left: 494dp; top: 340dp; width: 230dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mmBankLetter" style="left: 495dp; top: 315dp; width: 49dp; height: 10dp; line-height: 10dp;">A</div>
@@ -292,7 +292,7 @@
 
 		<!-- Compact transport. -->
 
-		<div id="mmRecordLed" class="jucePos elektronLed mmTransportIcon mmRecordIcon" style="left: 781dp; top: 350dp;"/>
+		<div id="mmRecordLed" class="jucePos elektronLed mmTransportIcon mmRecordIcon" style="left: 781dp; top: 347dp;"/>
 		<div class="jucePos elektronPlayIcon mmTransportIcon mmPlayIcon" style="left: 840dp; top: 345dp; width: 14dp; height: 14dp;"/>
 		<div class="jucePos mmTransportIcon mmStopIcon" style="left: 902dp; top: 348dp; width: 8dp; height: 8dp;"/>
 		<div class="jucePos elektronCaptionedKey" style="left: 759dp; top: 377dp;">
@@ -426,7 +426,7 @@
 				</div>
 			</div>
 			<button id="btScale" class="juceButton elektronButton elektronKey elektronScaleButton mmScaleButton" isToggle="0"/>
-			<div id="altScaleSetup" class="juceLabel elektronButtonCaption elektronButtonCaption--wide elektronScaleSetup elektronSecondary compact mmAffordance" title="FUNCTION + SCALE: Scale setup">SCALE SETUP</div>
+			<div id="altScaleSetup" class="juceLabel elektronButtonCaption elektronScaleSetup elektronSecondary compact mmAffordance" title="FUNCTION + SCALE: Scale setup">SCALE SETUP</div>
 		</div>
 	</body>
 </rml>

--- a/source/elektron/md/mdJucePlugin/skins/mmSfx60/mmSfx60.rml
+++ b/source/elektron/md/mdJucePlugin/skins/mmSfx60/mmSfx60.rml
@@ -17,7 +17,7 @@
 
 		<!-- Rear connector rail. -->
 
-		<div class="jucePos mmTopRail" style="left: 18dp; top: 17dp; width: 1064dp; height: 18dp;"/>
+		<div class="jucePos elektronPanelGroove mmRuleH" style="left: 0dp; top: 35dp; width: 1100dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 80dp; top: 3dp; width: 45dp; height: 13dp; line-height: 13dp;">PHONES</div>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 137dp; top: 3dp; width: 50dp; height: 13dp; line-height: 13dp;">A / LEFT</div>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 195dp; top: 3dp; width: 50dp; height: 13dp; line-height: 13dp;">B / RIGHT</div>

--- a/source/elektron/md/mdJucePlugin/skins/mmSfx60/mmSfx60.rml
+++ b/source/elektron/md/mdJucePlugin/skins/mmSfx60/mmSfx60.rml
@@ -258,7 +258,7 @@
 		<!-- BANK is the upper key; A-D are the separate lower hardware row. -->
 
 		<div class="jucePos juceLabel mmKeyLabel elektronActionLabel" style="left: 435dp; top: 315dp; width: 49dp; height: 10dp; line-height: 10dp;">BANK</div>
-		<div class="jucePos elektronCaptionedKey elektronCaptionedKey--wide" style="left: 430dp; top: 327dp;">
+		<div class="jucePos elektronCaptionedKey" style="left: 434dp; top: 327dp;">
 			<button id="btBankGrp" class="juceButton elektronButton elektronKey mmBankGroup" isToggle="0"/>
 			<div id="altMuteMode" class="juceLabel elektronButtonCaption elektronSecondary compact mmAffordance" title="FUNCTION + BANK: Mute mode">MUTE MODE</div>
 		</div>

--- a/source/elektron/md/mdJucePlugin/skins/mmSfx60/mmSfx60.rml
+++ b/source/elektron/md/mdJucePlugin/skins/mmSfx60/mmSfx60.rml
@@ -227,7 +227,6 @@
 		<div class="jucePos mmLowerBracket" style="left: 74dp; top: 405dp; width: 1dp; height: 3dp;"/>
 		<div class="jucePos mmLowerBracket" style="left: 74dp; top: 413dp; width: 1dp; height: 3dp;"/>
 		<div class="jucePos mmLowerBracket" style="left: 74dp; top: 414dp; width: 9dp; height: 1dp;"/>
-		<div class="jucePos mmLowerBracket" style="left: 495dp; top: 421dp; width: 229dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mmKeyLabel mmSetupLabel" style="left: 16dp; top: 339dp; width: 60dp; height: 28dp; line-height: 12dp;">KIT / SONG<br/>SETUP</div>
 		<div class="jucePos elektronStatusList" style="left: 84dp; top: 321dp; width: 65dp; height: 36dp;">
 			<div class="elektronStatusItem">

--- a/source/framework/juce/jucePluginData/elektron_panel.rcss
+++ b/source/framework/juce/jucePluginData/elektron_panel.rcss
@@ -233,23 +233,17 @@
 
 .elektronSecondary.compact
 {
-	font-size: 8dp;
+	font-size: 7dp;
 	letter-spacing: 0dp;
 }
 
-/* Reversed captions below keys share one optical gap and the key width. Wide
-   captions are a text-container variant, never another physical key size. */
+/* Reversed captions below keys share one optical gap and the key width. */
 .elektronButtonCaption
 {
 	box-sizing: border-box;
 	height: 13dp;
 	line-height: 13dp;
 	width: 52dp;
-}
-
-.elektronButtonCaption--wide
-{
-	width: 60dp;
 }
 
 /* A key and its alternate-function caption are one component. The panel owns
@@ -263,11 +257,6 @@
 	gap: 3dp;
 	height: 44dp;
 	width: 52dp;
-}
-
-.elektronCaptionedKey--wide
-{
-	width: 60dp;
 }
 
 .elektronCaptionedKey > .elektronButtonCaption,

--- a/source/framework/juce/jucePluginData/elektron_panel.rcss
+++ b/source/framework/juce/jucePluginData/elektron_panel.rcss
@@ -685,9 +685,9 @@
 .elektronScaleSetup
 {
 	height: 13dp;
-	left: 8dp;
+	left: 12dp;
 	line-height: 13dp;
 	position: absolute;
 	top: 81dp;
-	width: 60dp;
+	width: 52dp;
 }


### PR DESCRIPTION
Corrects several small faceplate graphics issues:\n\n- Removes the redundant Monomachine rule beneath ARP, TRANSP, SWING, and SLIDE.\n- Extends the Monomachine top seam edge-to-edge and matches the other engraved aluminum dividers.\n- Matches every reversed button caption to its 52dp key and removes the wide-caption escape hatches.\n- Uses compact typography with measured clearance for MUTE MODE, SCALE SETUP, and SONG SETUP.\n- Aligns the Monomachine record LED with the play and stop symbols.\n\nValidation:\n- xmllint --noout on both panel RML files\n- Roboto Bold caption-width measurement at the configured compact font size\n- git diff --check