### PR TITLE
Fix Monomachine step LED mapping

### DIFF
--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -1206,14 +1206,16 @@ namespace mdJucePlugin
 			return;
 
 		const auto& fp = m_frontPanelSnapshot;
+		const auto isMonomachine = getModel() == md::MachineModel::Monomachine;
 
 		for(uint32_t i=0; i<16; ++i)
 		{
 			if(m_stepLeds[i])
-				m_stepLeds[i]->SetClass("lit", fp.getStepLed(i));
+				m_stepLeds[i]->SetClass("lit", isMonomachine
+					? fp.getMonomachineStepLed(i) : fp.getStepLed(i));
 		}
 
-		if(getModel() == md::MachineModel::Monomachine)
+		if(isMonomachine)
 		{
 			const struct { uint8_t greenBank, greenBit, redBank, redBit; } tracks[] =
 			{

--- a/source/elektron/md/mdLib/mdfrontpanel.cpp
+++ b/source/elektron/md/mdLib/mdfrontpanel.cpp
@@ -174,6 +174,16 @@ namespace md
 		return ((raw >> bit) & 1) == 0;   // active-low: 0 bit = lit
 	}
 
+	bool FrontPanel::getMonomachineStepLed(uint32_t _index) const
+	{
+		if(_index >= 16)
+			return false;
+		const auto bank = static_cast<uint8_t>(g_firstLedBank + (_index >> 2));
+		const uint8_t raw = m_ledBank[bankIndex(bank)];
+		const uint32_t bit = ((_index & 3) << 1) + 1;
+		return ((raw >> bit) & 1) == 0;
+	}
+
 	bool FrontPanel::getDrumLed(uint32_t _index) const
 	{
 		if (_index >= 16)

--- a/source/elektron/md/mdLib/mdfrontpanel.h
+++ b/source/elektron/md/mdLib/mdfrontpanel.h
@@ -104,7 +104,8 @@ namespace md
 		bool wasLedBankWritten(uint8_t _command) const;
 
 		// Decoded LED state. All return true when the LED is lit.
-		bool getStepLed(uint32_t _index) const;  // _index 0..15 -> steps 1..16
+		bool getStepLed(uint32_t _index) const; // Machinedrum steps 1..16
+		bool getMonomachineStepLed(uint32_t _index) const; // Monomachine steps 1..16
 		bool getDrumLed(uint32_t _index) const;  // _index 0..15 -> tracks 1..16
 		bool getStatusLed(StatusLed _led) const;
 		bool getModeLed(ModeLed _led) const;

--- a/source/elektron/md/mdLibTest/turboMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/turboMidiTest.cpp
@@ -1,3 +1,4 @@
+#include "mdLib/mdfrontpanel.h"
 #include "mdLib/mdrealtimemidiqueue.h"
 #include "mdLib/mdsim.h"
 #include "mdLib/mdturbomidi.h"
@@ -184,6 +185,36 @@ namespace
 			&& check(!queue.hasPending(), "drained realtime MIDI queue is not empty");
 	}
 
+	bool testFrontPanelStepLeds()
+	{
+		bool mmMappingMatches = true;
+		for(uint32_t step = 0; step < 16; ++step)
+		{
+			md::FrontPanel panel;
+			const uint8_t command = static_cast<uint8_t>(
+				md::FrontPanel::g_firstLedBank + (step >> 2));
+			const uint8_t bit = static_cast<uint8_t>(((step & 3) << 1) + 1);
+			const uint8_t message[] = {command,
+				static_cast<uint8_t>(~static_cast<uint8_t>(1u << bit))};
+			panel.processBytes(message, sizeof(message));
+			for(uint32_t candidate = 0; candidate < 16; ++candidate)
+				mmMappingMatches &= panel.getMonomachineStepLed(candidate)
+					== (candidate == step);
+		}
+		if(!check(mmMappingMatches, "Monomachine step LED mapping is wrong"))
+			return false;
+
+		md::FrontPanel panel;
+		const uint8_t mdMessage[] = {0x20, 0xfe, 0x21, 0x7f};
+		panel.processBytes(mdMessage, sizeof(mdMessage));
+		return check(panel.getStepLed(0) && panel.getStepLed(15),
+			"Machinedrum step LED mapping changed")
+			&& check(!panel.getStepLed(1) && !panel.getStepLed(14),
+				"Machinedrum unlit step decoding changed")
+			&& check(!panel.getStepLed(16) && !panel.getMonomachineStepLed(16),
+				"out-of-range step LED was accepted");
+	}
+
 	bool testFirmwareUpdateHandoff()
 	{
 		md::Sim mdHandoff;
@@ -212,7 +243,7 @@ int main()
 {
 	if(!testTimeoutFallback() || !testDocumentedHandshake() || !testModelValidation()
 		|| !testDspMemoryFallback() || !testMk2PortAInvertedLoopback()
-		|| !testRealtimeMidiPendingState()
+		|| !testRealtimeMidiPendingState() || !testFrontPanelStepLeds()
 		|| !testFirmwareUpdateHandoff())
 		return 1;
 	std::cout << "mdLib tests passed\n";


### PR DESCRIPTION
Summary

- Decode the Monomachine step LEDs using its four-bank panel layout.
- Select the model-specific decoder in the editor while retaining the existing Machinedrum path.
- Cover every Monomachine step position and Machinedrum compatibility with synthetic unit checks.

Testing

- Focused mdLib test executable passes.