### PR TITLE
Add Machinedrum UW ROM/RAM machine support

### DIFF
--- a/source/elektron/md/mdJucePlugin/mdController.cpp
+++ b/source/elektron/md/mdJucePlugin/mdController.cpp
@@ -192,11 +192,18 @@ namespace mdJucePlugin
 		if(!firmwareReadyForAutomation())
 			return;
 		if(!m_haveGlobal.load(std::memory_order_acquire))
-			sendSysEx(toPluginSysex(md::automation::sysex::statusRequest(m_model,
+			sendSynchronizationRequest(toPluginSysex(md::automation::sysex::statusRequest(m_model,
 				md::automation::sysex::StatusParameter::Global)));
 		if(!m_haveKit.load(std::memory_order_acquire))
-			sendSysEx(toPluginSysex(md::automation::sysex::statusRequest(m_model,
+			sendSynchronizationRequest(toPluginSysex(md::automation::sysex::statusRequest(m_model,
 				md::automation::sysex::StatusParameter::Kit)));
+	}
+
+	void Controller::sendSynchronizationRequest(const pluginLib::SysEx& _message) const
+	{
+		synthLib::SMidiEvent event(synthLib::MidiEventSource::Internal);
+		event.sysex = _message;
+		sendMidiEvent(event);
 	}
 
 	void Controller::onControllerTimer()
@@ -211,9 +218,9 @@ namespace mdJucePlugin
 			if(now - m_lastStatePollMs.load(std::memory_order_acquire) < 5000)
 				return;
 			m_lastStatePollMs.store(now, std::memory_order_release);
-			sendSysEx(toPluginSysex(md::automation::sysex::statusRequest(m_model,
+			sendSynchronizationRequest(toPluginSysex(md::automation::sysex::statusRequest(m_model,
 				md::automation::sysex::StatusParameter::Global)));
-			sendSysEx(toPluginSysex(md::automation::sysex::statusRequest(m_model,
+			sendSynchronizationRequest(toPluginSysex(md::automation::sysex::statusRequest(m_model,
 				md::automation::sysex::StatusParameter::Kit)));
 			return;
 		}
@@ -360,7 +367,7 @@ namespace mdJucePlugin
 						|| now - requested >= g_dumpRequestRetryMs)
 					{
 						m_globalDumpRequestMs.store(now, std::memory_order_release);
-						sendSysEx(toPluginSysex(md::automation::sysex::globalRequest(
+						sendSynchronizationRequest(toPluginSysex(md::automation::sysex::globalRequest(
 							m_model, status->value)));
 					}
 				}
@@ -382,7 +389,7 @@ namespace mdJucePlugin
 						|| now - requested >= g_dumpRequestRetryMs)
 					{
 						m_kitDumpRequestMs.store(now, std::memory_order_release);
-						sendSysEx(toPluginSysex(md::automation::sysex::kitRequest(
+						sendSynchronizationRequest(toPluginSysex(md::automation::sysex::kitRequest(
 							m_model, status->value)));
 					}
 				}
@@ -427,7 +434,7 @@ namespace mdJucePlugin
 				m_automationReady.store(false, std::memory_order_release);
 				m_haveGlobal.store(false, std::memory_order_release);
 				m_globalDumpRequestMs.store(milliseconds(), std::memory_order_release);
-				sendSysEx(toPluginSysex(md::automation::sysex::globalRequest(
+				sendSynchronizationRequest(toPluginSysex(md::automation::sysex::globalRequest(
 					m_model, _message[8])));
 			}
 			else if(_message[7] == static_cast<uint8_t>(

--- a/source/elektron/md/mdJucePlugin/mdController.cpp
+++ b/source/elektron/md/mdJucePlugin/mdController.cpp
@@ -201,7 +201,9 @@ namespace mdJucePlugin
 
 	void Controller::sendSynchronizationRequest(const pluginLib::SysEx& _message) const
 	{
-		synthLib::SMidiEvent event(synthLib::MidiEventSource::Internal);
+		// Editor is the routable controller-to-device source. Hardware recognizes
+		// these exact read-only requests and keeps them factory-baseline-neutral.
+		synthLib::SMidiEvent event(synthLib::MidiEventSource::Editor);
 		event.sysex = _message;
 		sendMidiEvent(event);
 	}
@@ -338,7 +340,11 @@ namespace mdJucePlugin
 			[&ready](synthLib::Device* const _device)
 			{
 				if(const auto* const device = dynamic_cast<md::Device*>(_device))
-					ready = device->getHardware().isAudioReady();
+				{
+					const auto& hardware = device->getHardware();
+					ready = hardware.isAudioReady()
+						&& !hardware.isProjectStateRestorePending();
+				}
 			});
 		return ready;
 	}

--- a/source/elektron/md/mdJucePlugin/mdController.h
+++ b/source/elektron/md/mdJucePlugin/mdController.h
@@ -83,6 +83,7 @@ namespace mdJucePlugin
 		void applyKitParameters(const std::vector<md::automation::ParameterChange>& _changes);
 		void onControllerTimer() override;
 		void sendMissingSynchronizationRequests();
+		void sendSynchronizationRequest(const pluginLib::SysEx& _message) const;
 		static uint64_t milliseconds();
 
 		const md::MachineModel m_model;

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
@@ -69,6 +69,17 @@ namespace
 
 namespace mdJucePlugin
 {
+	auto AudioPluginAudioProcessor::makeBuses(const md::MachineModel _model)
+		-> BusesProperties
+	{
+		if(_model == md::MachineModel::Machinedrum)
+			return BusesProperties()
+				.withInput("Input", juce::AudioChannelSet::stereo(), true)
+				.withOutput("Out", juce::AudioChannelSet::stereo(), true);
+		return BusesProperties()
+			.withOutput("Out", juce::AudioChannelSet::stereo(), true);
+	}
+
 	void AudioPluginAudioProcessor::saveChunkData(baseLib::BinaryStream& _stream)
 	{
 		jucePluginEditorLib::Processor::saveChunkData(_stream);
@@ -287,8 +298,7 @@ namespace mdJucePlugin
 	AudioPluginAudioProcessor::AudioPluginAudioProcessor(const md::MachineModel _model,
 		std::vector<uint8_t> _initialPatchRam, const bool _allowMcpServer,
 		const bool _ephemeralConfig) :
-		Processor(BusesProperties()
-			.withOutput("Out", juce::AudioChannelSet::stereo(), true),
+		Processor(makeBuses(_model),
 			getOptions(_model, _ephemeralConfig), makeProcessorProperties(_model),
 			_allowMcpServer, _ephemeralConfig
 				? jucePluginEditorLib::Processor::ConfigMode::Ephemeral

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
@@ -39,6 +39,7 @@ namespace mdJucePlugin
 		void loadChunkData(baseLib::ChunkReader& _reader) override;
 
 	private:
+		static BusesProperties makeBuses(md::MachineModel _model);
 		AudioPluginAudioProcessor(md::MachineModel _model,
 			std::vector<uint8_t> _initialPatchRam, bool _allowMcpServer,
 			bool _ephemeralConfig);

--- a/source/elektron/md/mdLib/CMakeLists.txt
+++ b/source/elektron/md/mdLib/CMakeLists.txt
@@ -8,7 +8,6 @@ set(SOURCES
 	mdautomation.cpp mdautomation.h
 	mddevice.cpp mddevice.h
 	mddsp.cpp mddsp.h
-	mdflash.cpp mdflash.h
 	mdfrontpanel.cpp mdfrontpanel.h
 	mdflash.cpp mdflash.h
 	mdfirmwareupdate.cpp mdfirmwareupdate.h

--- a/source/elektron/md/mdLib/CMakeLists.txt
+++ b/source/elektron/md/mdLib/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES
 	mdautomation.cpp mdautomation.h
 	mddevice.cpp mddevice.h
 	mddsp.cpp mddsp.h
+	mdflash.cpp mdflash.h
 	mdfrontpanel.cpp mdfrontpanel.h
 	mdflash.cpp mdflash.h
 	mdfirmwareupdate.cpp mdfirmwareupdate.h

--- a/source/elektron/md/mdLib/mddevice.cpp
+++ b/source/elektron/md/mdLib/mddevice.cpp
@@ -1,6 +1,7 @@
 #include "mddevice.h"
 
 #include "mdstate.h"
+#include "mdromloader.h"
 #include "mdtypes.h"
 
 #include "baseLib/filesystem.h"
@@ -41,24 +42,50 @@ namespace
 		if(_model != md::MachineModel::Machinedrum || _params.homePath.empty())
 			return {};
 		return baseLib::filesystem::validatePath(_params.homePath)
-			+ "nvram/md-uw-1.63-flash.dat";
+			+ "nvram/md-uw-1.63-factory-v1.cache";
 	}
 
 	std::vector<uint8_t> loadInitialMdFlash(
 		const synthLib::DeviceCreateParams& _params, const md::MachineModel _model)
 	{
 		const auto filename = mdFlashCacheFilename(_params, _model);
-		std::vector<uint8_t> data;
-		if(filename.empty() || !baseLib::filesystem::readFile(data, filename))
+		std::vector<uint8_t> cache;
+		if(filename.empty() || !baseLib::filesystem::readFile(cache, filename))
 			return {};
-		if(data.size() != md::g_romSize)
+
+		md::Rom rom;
+		if(!_params.romData.empty())
+		{
+			md::Rom supplied(_params.romData, _params.romName);
+			if(supplied.isValid() && md::RomLoader::isRomForModel(
+				supplied.data(), _model))
+				rom = std::move(supplied);
+		}
+		if(!rom.isValid())
+			rom = md::RomLoader::findROM(_model);
+
+		std::vector<uint8_t> flash;
+		if(!rom.isValid() || !md::decodeFactoryFlashCache(flash, cache, rom.data()))
 		{
 			std::fprintf(stderr,
-				"[MD] ignoring UW flash cache with unexpected size: %s (%zu bytes)\n",
-				filename.c_str(), data.size());
+				"[MD] ignoring invalid or ROM-mismatched UW factory cache: %s\n",
+				filename.c_str());
 			return {};
 		}
-		return data;
+		return flash;
+	}
+
+	md::Rom loadStateRom(const std::vector<uint8_t>& _romData,
+		const std::string& _romName,
+		const md::MachineModel _model)
+	{
+		if(!_romData.empty())
+		{
+			md::Rom rom(_romData, _romName);
+			if(rom.isValid() && md::RomLoader::isRomForModel(rom.data(), _model))
+				return rom;
+		}
+		return md::RomLoader::findROM(_model);
 	}
 }
 
@@ -82,13 +109,26 @@ namespace md
 
 	Device::~Device()
 	{
-		if(m_mdFlashCacheFilename.empty() || !m_hardware || !m_hardware->flashDirty())
+		if(m_mdFlashCacheFilename.empty() || !m_hardware
+			|| !m_hardware->factoryFlashCacheReady())
+			return;
+
+		// A valid cache is immutable: project activity can never update it. An
+		// exclusive create also makes simultaneous first boots harmless.
+		std::vector<uint8_t> existing;
+		std::vector<uint8_t> decoded;
+		if(baseLib::filesystem::readFile(existing, m_mdFlashCacheFilename)
+			&& decodeFactoryFlashCache(decoded, existing, m_hardware->flashBaseline()))
+			return;
+
+		std::vector<uint8_t> cache;
+		if(!encodeFactoryFlashCache(cache, m_hardware->copyFlashData(),
+			m_hardware->flashBaseline()))
 			return;
 		baseLib::filesystem::createDirectory(
 			baseLib::filesystem::getPath(m_mdFlashCacheFilename));
-		const auto flash = m_hardware->copyFlashData();
-		if(!baseLib::filesystem::writeFile(m_mdFlashCacheFilename, flash))
-			std::fprintf(stderr, "[MD] failed to persist UW flash cache: %s\n",
+		if(baseLib::filesystem::writeFileExclusive(m_mdFlashCacheFilename, cache))
+			std::fprintf(stderr, "[MD] created immutable UW factory cache: %s\n",
 				m_mdFlashCacheFilename.c_str());
 	}
 
@@ -104,8 +144,12 @@ namespace md
 
 	bool Device::getState(std::vector<uint8_t>& _state, synthLib::StateType _type)
 	{
-		return encodeState(_state, m_hardware->copyPatchRam(), m_model, _type,
-			m_hardware->copyUserFlash());
+		const auto patchRam = m_hardware->copyPatchRam();
+		if(m_model == MachineModel::Monomachine)
+			return encodeState(_state, patchRam, m_model, _type,
+				m_hardware->copyUserFlash());
+		return encodeState(_state, patchRam, m_hardware->copyFlashData(),
+			m_hardware->flashBaseline(), m_model, _type);
 	}
 
 	bool Device::setState(const std::vector<uint8_t>& _state, synthLib::StateType _type)
@@ -122,19 +166,42 @@ namespace md
 			return {};
 
 		std::vector<uint8_t> patchRam;
-		std::vector<uint8_t> userFlash;
-		if(!decodeState(patchRam, userFlash, _state, _context->m_model, _type))
-			return {};
+		std::vector<uint8_t> initialFlash;
+		bool containsFlash = false;
+		if(_context->m_model == MachineModel::Monomachine)
+		{
+			if(!decodeState(patchRam, initialFlash, _state, _context->m_model, _type))
+				return {};
+		}
+		else
+		{
+			auto stateRom = loadStateRom(_context->m_romData, _context->m_romName,
+				_context->m_model);
+			if(!stateRom.isValid())
+				return {};
+			DecodedState decoded;
+			if(!decodeState(decoded, _state, stateRom.data(), _context->m_model, _type))
+				return {};
+			patchRam = std::move(decoded.patchRam);
+			containsFlash = decoded.containsFlash;
+			if(containsFlash)
+				initialFlash = std::move(decoded.flashData);
+		}
 
 		auto replacement = std::make_unique<Hardware>(
 			_context->m_romData, _context->m_romName, _context->m_model, patchRam,
 			_context->m_frontPanelPublisher, _context->m_midiSysexProgressPublisher,
-			userFlash);
+			initialFlash);
 		if(!replacement->isValid())
 			return {};
+		// A project restore is never evidence of a pristine factory initializer,
+		// even if the firmware performs a later housekeeping flash write.
+		if(_context->m_model == MachineModel::Machinedrum)
+			replacement->disqualifyFactoryFlashCache();
 
 		return std::unique_ptr<PreparedState>(
-			new PreparedState(std::move(_context), std::move(replacement)));
+			new PreparedState(std::move(_context), std::move(replacement),
+				containsFlash));
 	}
 
 	bool Device::commitPreparedState(PreparedState& _prepared)
@@ -147,7 +214,7 @@ namespace md
 		const auto clockPercent = getDspClockPercent();
 		_prepared.m_hardware->getDspMixer().getPeriph().getEssiClock()
 			.setSpeedPercent(clockPercent);
-		if(m_model == MachineModel::Machinedrum)
+		if(m_model == MachineModel::Machinedrum && !_prepared.m_containsFlash)
 			_prepared.m_hardware->replaceFlashData(m_hardware->copyFlashData(),
 				m_hardware->flashDirty());
 

--- a/source/elektron/md/mdLib/mddevice.cpp
+++ b/source/elektron/md/mdLib/mddevice.cpp
@@ -34,6 +34,32 @@ namespace
 			filename.c_str(), data.size());
 		return data;
 	}
+
+	std::string mdFlashCacheFilename(const synthLib::DeviceCreateParams& _params,
+		const md::MachineModel _model)
+	{
+		if(_model != md::MachineModel::Machinedrum || _params.homePath.empty())
+			return {};
+		return baseLib::filesystem::validatePath(_params.homePath)
+			+ "nvram/md-uw-1.63-flash.dat";
+	}
+
+	std::vector<uint8_t> loadInitialMdFlash(
+		const synthLib::DeviceCreateParams& _params, const md::MachineModel _model)
+	{
+		const auto filename = mdFlashCacheFilename(_params, _model);
+		std::vector<uint8_t> data;
+		if(filename.empty() || !baseLib::filesystem::readFile(data, filename))
+			return {};
+		if(data.size() != md::g_romSize)
+		{
+			std::fprintf(stderr,
+				"[MD] ignoring UW flash cache with unexpected size: %s (%zu bytes)\n",
+				filename.c_str(), data.size());
+			return {};
+		}
+		return data;
+	}
 }
 
 namespace md
@@ -49,8 +75,21 @@ namespace md
 			m_frontPanelPublisher, m_midiSysexProgressPublisher))
 		, m_hardware(std::make_unique<Hardware>(_params.romData, _params.romName, m_model,
 			loadInitialPatchRam(_params, m_model, _initialPatchRam), m_frontPanelPublisher,
-			m_midiSysexProgressPublisher))
+			m_midiSysexProgressPublisher, loadInitialMdFlash(_params, m_model)))
+		, m_mdFlashCacheFilename(mdFlashCacheFilename(_params, m_model))
 	{
+	}
+
+	Device::~Device()
+	{
+		if(m_mdFlashCacheFilename.empty() || !m_hardware || !m_hardware->flashDirty())
+			return;
+		baseLib::filesystem::createDirectory(
+			baseLib::filesystem::getPath(m_mdFlashCacheFilename));
+		const auto flash = m_hardware->copyFlashData();
+		if(!baseLib::filesystem::writeFile(m_mdFlashCacheFilename, flash))
+			std::fprintf(stderr, "[MD] failed to persist UW flash cache: %s\n",
+				m_mdFlashCacheFilename.c_str());
 	}
 
 	float Device::getSamplerate() const
@@ -108,6 +147,9 @@ namespace md
 		const auto clockPercent = getDspClockPercent();
 		_prepared.m_hardware->getDspMixer().getPeriph().getEssiClock()
 			.setSpeedPercent(clockPercent);
+		if(m_model == MachineModel::Machinedrum)
+			_prepared.m_hardware->replaceFlashData(m_hardware->copyFlashData(),
+				m_hardware->flashDirty());
 
 		m_frontPanelPublisher->reset();
 		m_hardware.swap(_prepared.m_hardware);

--- a/source/elektron/md/mdLib/mddevice.cpp
+++ b/source/elektron/md/mdLib/mddevice.cpp
@@ -186,8 +186,9 @@ namespace md
 			return encodeState(_state, patchRam, pending,
 				m_hardware->flashBaseline(), m_model, _type);
 		// If interaction happened before the first machine-local baseline was
-		// captured, preserve every changed flash sector relative to the ROM. Restore
-		// reapplies those sectors after normal factory initialization completes.
+		// captured, preserve a complete flash image. An absolute sector set records
+		// ROM-equal deletions and lets the replacement boot coherently without waiting
+		// for another factory-initialization pass.
 		return encodeState(_state, patchRam, m_hardware->copyFlashData(),
 			m_hardware->flashBaseline(), m_hardware->flashBaseline(), m_model, _type);
 	}
@@ -233,6 +234,15 @@ namespace md
 				{
 					if(!applyFlashOverlay(initialFlash, decoded.flashOverlay,
 						factory.flash, stateRom.data()))
+						return {};
+				}
+				else if(decoded.flashOverlay.sectors.size()
+					== g_romSize / g_uwFlashSectorSize)
+				{
+					// A complete overlay is baseline-independent. Materialize it before
+					// the replacement starts so firmware boots from one coherent project.
+					if(!applyFlashOverlay(initialFlash, decoded.flashOverlay,
+						stateRom.data(), stateRom.data()))
 						return {};
 				}
 				else

--- a/source/elektron/md/mdLib/mddevice.cpp
+++ b/source/elektron/md/mdLib/mddevice.cpp
@@ -36,16 +36,28 @@ namespace
 		return data;
 	}
 
+	std::string mdFlashCacheFilename(const std::string& _homePath,
+		const md::MachineModel _model)
+	{
+		if(_model != md::MachineModel::Machinedrum || _homePath.empty())
+			return {};
+		return baseLib::filesystem::validatePath(_homePath)
+			+ "nvram/md-uw-1.63-factory-v2.cache";
+	}
+
 	std::string mdFlashCacheFilename(const synthLib::DeviceCreateParams& _params,
 		const md::MachineModel _model)
 	{
-		if(_model != md::MachineModel::Machinedrum || _params.homePath.empty())
-			return {};
-		return baseLib::filesystem::validatePath(_params.homePath)
-			+ "nvram/md-uw-1.63-factory-v1.cache";
+		return mdFlashCacheFilename(_params.homePath, _model);
 	}
 
-	std::vector<uint8_t> loadInitialMdFlash(
+	struct InitialMdFlash
+	{
+		std::vector<uint8_t> flash;
+		std::vector<uint8_t> cache;
+	};
+
+	InitialMdFlash loadInitialMdFlash(
 		const synthLib::DeviceCreateParams& _params, const md::MachineModel _model)
 	{
 		const auto filename = mdFlashCacheFilename(_params, _model);
@@ -64,15 +76,28 @@ namespace
 		if(!rom.isValid())
 			rom = md::RomLoader::findROM(_model);
 
-		std::vector<uint8_t> flash;
-		if(!rom.isValid() || !md::decodeFactoryFlashCache(flash, cache, rom.data()))
+		InitialMdFlash result;
+		if(!rom.isValid()
+			|| !md::decodeFactoryFlashCache(result.flash, cache, rom.data()))
 		{
 			std::fprintf(stderr,
 				"[MD] ignoring invalid or ROM-mismatched UW factory cache: %s\n",
 				filename.c_str());
 			return {};
 		}
-		return flash;
+		result.cache = std::move(cache);
+		return result;
+	}
+
+	InitialMdFlash loadInitialMdFlash(const md::Rom& _rom,
+		const std::string& _filename)
+	{
+		InitialMdFlash result;
+		if(!_rom.isValid() || _filename.empty()
+			|| !baseLib::filesystem::readFile(result.cache, _filename)
+			|| !md::decodeFactoryFlashCache(result.flash, result.cache, _rom.data()))
+			return {};
+		return result;
 	}
 
 	md::Rom loadStateRom(const std::vector<uint8_t>& _romData,
@@ -100,11 +125,12 @@ namespace md
 			std::make_shared<MidiSysexTransferProgressPublisher>())
 		, m_preparationContext(new PreparationContext(_params, m_model,
 			m_frontPanelPublisher, m_midiSysexProgressPublisher))
-		, m_hardware(std::make_unique<Hardware>(_params.romData, _params.romName, m_model,
-			loadInitialPatchRam(_params, m_model, _initialPatchRam), m_frontPanelPublisher,
-			m_midiSysexProgressPublisher, loadInitialMdFlash(_params, m_model)))
 		, m_mdFlashCacheFilename(mdFlashCacheFilename(_params, m_model))
 	{
+		auto initialFlash = loadInitialMdFlash(_params, m_model);
+		m_hardware = std::make_unique<Hardware>(_params.romData, _params.romName, m_model,
+			loadInitialPatchRam(_params, m_model, _initialPatchRam), m_frontPanelPublisher,
+			m_midiSysexProgressPublisher, initialFlash.flash, initialFlash.cache);
 	}
 
 	Device::~Device()
@@ -121,9 +147,8 @@ namespace md
 			&& decodeFactoryFlashCache(decoded, existing, m_hardware->flashBaseline()))
 			return;
 
-		std::vector<uint8_t> cache;
-		if(!encodeFactoryFlashCache(cache, m_hardware->copyFlashData(),
-			m_hardware->flashBaseline()))
+		auto cache = m_hardware->copyFactoryFlashCache();
+		if(cache.empty())
 			return;
 		baseLib::filesystem::createDirectory(
 			baseLib::filesystem::getPath(m_mdFlashCacheFilename));
@@ -148,8 +173,15 @@ namespace md
 		if(m_model == MachineModel::Monomachine)
 			return encodeState(_state, patchRam, m_model, _type,
 				m_hardware->copyUserFlash());
-		return encodeState(_state, patchRam, m_hardware->copyFlashData(),
-			m_hardware->flashBaseline(), m_model, _type);
+		std::vector<uint8_t> factoryBaseline;
+		if(m_hardware->copyFactoryFlashBaseline(factoryBaseline))
+			return encodeState(_state, patchRam, m_hardware->copyFlashData(),
+				factoryBaseline, m_hardware->flashBaseline(), m_model, _type);
+		FlashSectorOverlay pending;
+		if(m_hardware->copyPendingFlashOverlay(pending))
+			return encodeState(_state, patchRam, pending,
+				m_hardware->flashBaseline(), m_model, _type);
+		return encodeState(_state, patchRam, m_model, _type);
 	}
 
 	bool Device::setState(const std::vector<uint8_t>& _state, synthLib::StateType _type)
@@ -184,8 +216,32 @@ namespace md
 				return {};
 			patchRam = std::move(decoded.patchRam);
 			containsFlash = decoded.containsFlash;
+			auto factory = loadInitialMdFlash(stateRom,
+				mdFlashCacheFilename(_context->m_homePath, _context->m_model));
+			FlashSectorOverlay pending;
 			if(containsFlash)
-				initialFlash = std::move(decoded.flashData);
+			{
+				if(!factory.flash.empty())
+				{
+					if(!applyFlashOverlay(initialFlash, decoded.flashOverlay,
+						factory.flash))
+						return {};
+				}
+				else
+					pending = std::move(decoded.flashOverlay);
+			}
+			else if(!factory.flash.empty())
+				initialFlash = factory.flash;
+
+			auto replacement = std::make_unique<Hardware>(
+				_context->m_romData, _context->m_romName, _context->m_model, patchRam,
+				_context->m_frontPanelPublisher, _context->m_midiSysexProgressPublisher,
+				initialFlash, factory.cache, pending);
+			if(!replacement->isValid())
+				return {};
+			return std::unique_ptr<PreparedState>(
+				new PreparedState(std::move(_context), std::move(replacement),
+					containsFlash));
 		}
 
 		auto replacement = std::make_unique<Hardware>(
@@ -194,11 +250,6 @@ namespace md
 			initialFlash);
 		if(!replacement->isValid())
 			return {};
-		// A project restore is never evidence of a pristine factory initializer,
-		// even if the firmware performs a later housekeeping flash write.
-		if(_context->m_model == MachineModel::Machinedrum)
-			replacement->disqualifyFactoryFlashCache();
-
 		return std::unique_ptr<PreparedState>(
 			new PreparedState(std::move(_context), std::move(replacement),
 				containsFlash));
@@ -215,8 +266,13 @@ namespace md
 		_prepared.m_hardware->getDspMixer().getPeriph().getEssiClock()
 			.setSpeedPercent(clockPercent);
 		if(m_model == MachineModel::Machinedrum && !_prepared.m_containsFlash)
+		{
+			const auto factoryCache = m_hardware->copyFactoryFlashCache();
+			if(!factoryCache.empty())
+				_prepared.m_hardware->replaceFactoryFlashCache(factoryCache);
 			_prepared.m_hardware->replaceFlashData(m_hardware->copyFlashData(),
 				m_hardware->flashDirty());
+		}
 
 		m_frontPanelPublisher->reset();
 		m_hardware.swap(_prepared.m_hardware);

--- a/source/elektron/md/mdLib/mddevice.cpp
+++ b/source/elektron/md/mdLib/mddevice.cpp
@@ -164,7 +164,7 @@ namespace md
 
 	uint32_t Device::getChannelCountIn()
 	{
-		return 0;
+		return m_model == MachineModel::Machinedrum ? 2 : 0;
 	}
 
 	uint32_t Device::getChannelCountOut()
@@ -194,7 +194,12 @@ namespace md
 
 	void Device::processAudio(const synthLib::TAudioInputs& _inputs, const synthLib::TAudioOutputs& _outputs, const size_t _samples)
 	{
-		m_hardware->processAudio(_outputs, static_cast<uint32_t>(_samples), getExtraLatencySamples());
+		if(m_model == MachineModel::Machinedrum)
+			m_hardware->processAudio(_inputs, _outputs,
+				static_cast<uint32_t>(_samples), getExtraLatencySamples());
+		else
+			m_hardware->processAudio(_outputs, static_cast<uint32_t>(_samples),
+				getExtraLatencySamples());
 		m_numSamplesProcessed += static_cast<uint32_t>(_samples);
 	}
 

--- a/source/elektron/md/mdLib/mddevice.cpp
+++ b/source/elektron/md/mdLib/mddevice.cpp
@@ -139,12 +139,13 @@ namespace md
 			|| !m_hardware->factoryFlashCacheReady())
 			return;
 
-		// A valid cache is immutable: project activity can never update it. An
-		// exclusive create also makes simultaneous first boots harmless.
+		// Project activity can never update a valid cache. Invalid or ROM-mismatched
+		// data is replaced atomically so one damaged cache cannot poison every boot.
 		std::vector<uint8_t> existing;
 		std::vector<uint8_t> decoded;
-		if(baseLib::filesystem::readFile(existing, m_mdFlashCacheFilename)
-			&& decodeFactoryFlashCache(decoded, existing, m_hardware->flashBaseline()))
+		const bool exists = baseLib::filesystem::readFile(existing, m_mdFlashCacheFilename);
+		if(exists && decodeFactoryFlashCache(decoded, existing,
+			m_hardware->flashBaseline()))
 			return;
 
 		auto cache = m_hardware->copyFactoryFlashCache();
@@ -152,8 +153,11 @@ namespace md
 			return;
 		baseLib::filesystem::createDirectory(
 			baseLib::filesystem::getPath(m_mdFlashCacheFilename));
-		if(baseLib::filesystem::writeFileExclusive(m_mdFlashCacheFilename, cache))
-			std::fprintf(stderr, "[MD] created immutable UW factory cache: %s\n",
+		const bool written = exists
+			? baseLib::filesystem::writeFileAtomic(m_mdFlashCacheFilename, cache)
+			: baseLib::filesystem::writeFileExclusive(m_mdFlashCacheFilename, cache);
+		if(written)
+			std::fprintf(stderr, "[MD] stored UW factory cache: %s\n",
 				m_mdFlashCacheFilename.c_str());
 	}
 
@@ -181,7 +185,11 @@ namespace md
 		if(m_hardware->copyPendingFlashOverlay(pending))
 			return encodeState(_state, patchRam, pending,
 				m_hardware->flashBaseline(), m_model, _type);
-		return encodeState(_state, patchRam, m_model, _type);
+		// If interaction happened before the first machine-local baseline was
+		// captured, preserve every changed flash sector relative to the ROM. Restore
+		// reapplies those sectors after normal factory initialization completes.
+		return encodeState(_state, patchRam, m_hardware->copyFlashData(),
+			m_hardware->flashBaseline(), m_hardware->flashBaseline(), m_model, _type);
 	}
 
 	bool Device::setState(const std::vector<uint8_t>& _state, synthLib::StateType _type)
@@ -224,7 +232,7 @@ namespace md
 				if(!factory.flash.empty())
 				{
 					if(!applyFlashOverlay(initialFlash, decoded.flashOverlay,
-						factory.flash))
+						factory.flash, stateRom.data()))
 						return {};
 				}
 				else

--- a/source/elektron/md/mdLib/mddevice.h
+++ b/source/elektron/md/mdLib/mddevice.h
@@ -64,13 +64,15 @@ namespace md
 			friend struct DevicePreparedStateTestAccess;
 
 			PreparedState(std::shared_ptr<const PreparationContext> _context,
-				std::unique_ptr<Hardware> _hardware)
+				std::unique_ptr<Hardware> _hardware, const bool _containsFlash)
 				: m_context(std::move(_context)), m_hardware(std::move(_hardware))
+				, m_containsFlash(_containsFlash)
 			{
 			}
 
 			std::shared_ptr<const PreparationContext> m_context;
 			std::unique_ptr<Hardware> m_hardware;
+			bool m_containsFlash = false;
 			bool m_committed = false;
 		};
 

--- a/source/elektron/md/mdLib/mddevice.h
+++ b/source/elektron/md/mdLib/mddevice.h
@@ -30,6 +30,7 @@ namespace md
 				std::shared_ptr<MidiSysexTransferProgressPublisher> _midiSysexProgressPublisher)
 				: m_romData(_params.romData)
 				, m_romName(_params.romName)
+				, m_homePath(_params.homePath)
 				, m_model(_model)
 				, m_frontPanelPublisher(std::move(_frontPanelPublisher))
 				, m_midiSysexProgressPublisher(std::move(_midiSysexProgressPublisher))
@@ -44,6 +45,7 @@ namespace md
 			// separate, wider memory-layout change.
 			const std::vector<uint8_t> m_romData;
 			const std::string m_romName;
+			const std::string m_homePath;
 			const MachineModel m_model;
 			const std::shared_ptr<FrontPanelPublisher> m_frontPanelPublisher;
 			const std::shared_ptr<MidiSysexTransferProgressPublisher>

--- a/source/elektron/md/mdLib/mddevice.h
+++ b/source/elektron/md/mdLib/mddevice.h
@@ -76,6 +76,7 @@ namespace md
 
 		Device(const synthLib::DeviceCreateParams& _params,
 			const std::vector<uint8_t>& _initialPatchRam = {});
+		~Device() override;
 
 		float getSamplerate() const override;
 		bool isValid() const override;
@@ -139,5 +140,6 @@ namespace md
 		std::unique_ptr<Hardware> m_hardware;
 		uint32_t m_numSamplesProcessed = 0;
 		bool m_nativeProgramChangesEnabled = false;
+		std::string m_mdFlashCacheFilename;
 	};
 }

--- a/source/elektron/md/mdLib/mddsp.cpp
+++ b/source/elektron/md/mdLib/mddsp.cpp
@@ -24,10 +24,13 @@ namespace md
 		constexpr TWord g_trapFillEnd = 0x020000;
 		constexpr TWord g_fillInstr   = 0x00000C;	// RTS
 
-		// Compatibility response used by the MAME Elektron driver during DSP2 boot.
+		// Compatibility responses used by the MAME Elektron driver during DSP2 boot.
+		// The Machinedrum firmware interprets 0x65 as the DSP2/UW memory profile;
+		// keep the existing 0x64 response for Monomachine.
 		constexpr uint8_t  g_hostCmd88Vector = 0x10;
 		constexpr uint32_t g_bootQuery       = 0x147fff;
-		constexpr uint32_t g_bootResponse    = 0x64;
+		constexpr uint32_t g_bootResponseMdUw = 0x65;
+		constexpr uint32_t g_bootResponseMm   = 0x64;
 	}
 
 	Dsp::Dsp(Hardware& _hw, mc68k::Hdi08& _hdiUc, const uint32_t _index)
@@ -432,7 +435,8 @@ namespace md
 
 			if((_word & 0xffffff) == g_bootQuery)
 			{
-				m_hdiUC.writeRx(g_bootResponse);
+				m_hdiUC.writeRx(m_hardware.isMonomachine()
+					? g_bootResponseMm : g_bootResponseMdUw);
 				m_hardware.notifyHostPumpStateChanged();
 				return;
 			}

--- a/source/elektron/md/mdLib/mddsp.cpp
+++ b/source/elektron/md/mdLib/mddsp.cpp
@@ -24,9 +24,7 @@ namespace md
 		constexpr TWord g_trapFillEnd = 0x020000;
 		constexpr TWord g_fillInstr   = 0x00000C;	// RTS
 
-		// Compatibility responses used by the MAME Elektron driver during DSP2 boot.
-		// The Machinedrum firmware interprets 0x65 as the DSP2/UW memory profile;
-		// keep the existing 0x64 response for Monomachine.
+		// Select the model-specific DSP2 boot profile.
 		constexpr uint8_t  g_hostCmd88Vector = 0x10;
 		constexpr uint32_t g_bootQuery       = 0x147fff;
 		constexpr uint32_t g_bootResponseMdUw = 0x65;

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -97,10 +97,12 @@ namespace md
 		const MachineModel _model, const std::vector<uint8_t>& _initialPatchRam,
 		std::shared_ptr<FrontPanelPublisher> _frontPanelPublisher,
 		std::shared_ptr<MidiSysexTransferProgressPublisher> _midiSysexProgressPublisher,
-		const std::vector<uint8_t>& _initialUserFlash)
+		const std::vector<uint8_t>& _initialUserFlash,
+		const std::vector<uint8_t>& _factoryFlashCache,
+		const FlashSectorOverlay& _pendingFlashOverlay)
 		: Hardware(false, _romData, _romName, _model, _initialPatchRam,
 			std::move(_frontPanelPublisher), std::move(_midiSysexProgressPublisher),
-			_initialUserFlash)
+			_initialUserFlash, _factoryFlashCache, _pendingFlashOverlay)
 	{
 	}
 
@@ -109,12 +111,20 @@ namespace md
 		const MachineModel _model, const std::vector<uint8_t>& _initialPatchRam,
 		std::shared_ptr<FrontPanelPublisher> _frontPanelPublisher,
 		std::shared_ptr<MidiSysexTransferProgressPublisher> _midiSysexProgressPublisher,
-		const std::vector<uint8_t>& _initialUserFlash)
+		const std::vector<uint8_t>& _initialUserFlash,
+		const std::vector<uint8_t>& _factoryFlashCache,
+		const FlashSectorOverlay& _pendingFlashOverlay)
 		: m_model(_model)
 		, m_rom(initRom(_romData, _romName, _model, _syntheticProfile))
 		, m_firmwareFingerprint(_syntheticProfile ? 0 : fingerprintRom(m_rom.data()))
-		, m_uc(m_rom, m_model, initPatchRam(m_rom, _initialPatchRam), initMainRam(m_rom),
-			_initialUserFlash)
+		, m_uc(m_rom, m_model, initPatchRam(m_rom,
+			_pendingFlashOverlay.valid ? std::vector<uint8_t>{} : _initialPatchRam),
+			initMainRam(m_rom), _initialUserFlash)
+		, m_factoryFlashReady(!_factoryFlashCache.empty())
+		, m_factoryFlashCache(_factoryFlashCache)
+		, m_pendingFlashOverlay(_pendingFlashOverlay)
+		, m_pendingPatchRam(_pendingFlashOverlay.valid
+			? _initialPatchRam : std::vector<uint8_t>{})
 		, m_frontPanelPublisher(_frontPanelPublisher
 			? std::move(_frontPanelPublisher)
 			: std::make_shared<FrontPanelPublisher>())
@@ -590,20 +600,126 @@ namespace md
 
 	bool Hardware::isValid() const
 	{
-		return m_rom.isValid();
+		return m_rom.isValid()
+			&& !m_pendingFlashRestoreFailed.load(std::memory_order_acquire);
 	}
 
-	bool Hardware::factoryFlashCacheReady() const
+	std::vector<uint8_t> Hardware::copyPatchRam() const
 	{
-		// Do not mistake an early pause in the one-time initializer for completion.
-		// The qualified OS 1.63 path completes inside ten emulated CPU seconds; also
-		// require two seconds without a flash write and no host-originated control.
+		std::lock_guard lock(m_factoryFlashMutex);
+		return m_pendingFlashOverlay.valid ? m_pendingPatchRam : m_uc.copyPatchRam();
+	}
+
+	bool Hardware::finalizeFactoryFlashBaselineLocked()
+	{
+		if(m_model != MachineModel::Machinedrum)
+			return false;
+		if(m_factoryFlashReady.load(std::memory_order_relaxed))
+			return true;
+		if(m_externalInteraction.load(std::memory_order_relaxed))
+			return false;
+
+		// Require sustained flash inactivity after the one-time initialization pass.
 		constexpr uint64_t minimumAge = g_ucClockHz * 10;
 		constexpr uint64_t quietPeriod = g_ucClockHz * 2;
-		return m_model == MachineModel::Machinedrum && m_uc.flashDirty()
-			&& m_uc.getCycles() >= minimumAge
-			&& m_uc.flashIdleCycles() >= quietPeriod
-			&& !m_externalInteraction.load(std::memory_order_relaxed);
+		if(!m_uc.flashDirty() || m_uc.getCycles() < minimumAge
+			|| m_uc.flashIdleCycles() < quietPeriod)
+			return false;
+
+		m_factoryFlashBaseline = m_uc.copyFlashData();
+		if(m_pendingFlashOverlay.valid)
+		{
+			std::vector<uint8_t> restored;
+			if(!applyFlashOverlay(restored, m_pendingFlashOverlay,
+				m_factoryFlashBaseline)
+				|| !m_uc.replaceFlashData(restored, !m_pendingFlashOverlay.data.empty())
+				|| !m_uc.replacePatchRam(m_pendingPatchRam))
+			{
+				m_pendingFlashRestoreFailed.store(true, std::memory_order_release);
+				m_externalInteraction.store(true, std::memory_order_relaxed);
+				std::fprintf(stderr,
+					"[MD] project flash does not match the initialized factory baseline\n");
+				return false;
+			}
+			m_pendingFlashOverlay = {};
+			m_pendingPatchRam.clear();
+			m_externalInteraction.store(true, std::memory_order_relaxed);
+		}
+		m_factoryFlashReady.store(true, std::memory_order_release);
+		return true;
+	}
+
+	bool Hardware::factoryFlashCacheReady()
+	{
+		if(m_factoryFlashReady.load(std::memory_order_acquire))
+			return true;
+		std::lock_guard lock(m_factoryFlashMutex);
+		return finalizeFactoryFlashBaselineLocked();
+	}
+
+	bool Hardware::copyFactoryFlashBaseline(std::vector<uint8_t>& _baseline)
+	{
+		std::lock_guard lock(m_factoryFlashMutex);
+		if(!finalizeFactoryFlashBaselineLocked())
+			return false;
+		if(!m_factoryFlashBaseline.empty())
+		{
+			_baseline = m_factoryFlashBaseline;
+			return true;
+		}
+		return decodeFactoryFlashCache(_baseline, m_factoryFlashCache, m_rom.data());
+	}
+
+	std::vector<uint8_t> Hardware::copyFactoryFlashCache()
+	{
+		std::lock_guard lock(m_factoryFlashMutex);
+		if(!finalizeFactoryFlashBaselineLocked())
+			return {};
+		if(m_factoryFlashCache.empty()
+			&& !encodeFactoryFlashCache(m_factoryFlashCache,
+				m_factoryFlashBaseline, m_rom.data()))
+			return {};
+		return m_factoryFlashCache;
+	}
+
+	bool Hardware::copyPendingFlashOverlay(FlashSectorOverlay& _overlay) const
+	{
+		std::lock_guard lock(m_factoryFlashMutex);
+		if(!m_pendingFlashOverlay.valid)
+			return false;
+		_overlay = m_pendingFlashOverlay;
+		return true;
+	}
+
+	bool Hardware::replaceFactoryFlashCache(const std::vector<uint8_t>& _cache)
+	{
+		std::vector<uint8_t> ignored;
+		if(_cache.empty() || !decodeFactoryFlashCache(ignored, _cache, m_rom.data()))
+			return false;
+		std::lock_guard lock(m_factoryFlashMutex);
+		m_factoryFlashCache = _cache;
+		m_factoryFlashBaseline.clear();
+		m_factoryFlashReady.store(true, std::memory_order_release);
+		return true;
+	}
+
+	void Hardware::registerExternalInteraction()
+	{
+		if(m_factoryFlashReady.load(std::memory_order_acquire))
+		{
+			m_externalInteraction.store(true, std::memory_order_relaxed);
+			return;
+		}
+		std::lock_guard lock(m_factoryFlashMutex);
+		if(finalizeFactoryFlashBaselineLocked())
+			m_externalInteraction.store(true, std::memory_order_relaxed);
+		else if(!m_pendingFlashOverlay.valid)
+			m_externalInteraction.store(true, std::memory_order_relaxed);
+	}
+
+	void Hardware::disqualifyFactoryFlashCache()
+	{
+		registerExternalInteraction();
 	}
 
 	void Hardware::mdLinkWindowFlushed()
@@ -666,7 +782,7 @@ namespace md
 
 	bool Hardware::trySendPanelEvent(const uint8_t _cmd, const uint8_t _arg)
 	{
-		m_externalInteraction.store(true, std::memory_order_relaxed);
+		registerExternalInteraction();
 		return m_panelIn.tryPush(_cmd, _arg);
 	}
 
@@ -1093,6 +1209,8 @@ namespace md
 		}
 
 		schedDrainCodecOutput();					// final drain (also covers a UC-only advance window)
+		if(!m_factoryFlashReady.load(std::memory_order_relaxed))
+			factoryFlashCacheReady();
 		// Never make the emulation/audio thread wait for a UI snapshot read. If the
 		// reader owns the short copy lock, the next machine interval republishes.
 		m_frontPanelPublisher->tryPublish(m_frontPanel);
@@ -1100,10 +1218,9 @@ namespace md
 
 	bool Hardware::sendMidi(const synthLib::SMidiEvent& _ev)
 	{
-		// Host-generated clock is tagged Internal by synthLib and does not contain
-		// project data. Real host/editor/physical/unknown events disqualify caching.
+		// Internal clock traffic does not affect the factory baseline.
 		if(_ev.source != synthLib::MidiEventSource::Internal)
-			m_externalInteraction.store(true, std::memory_order_relaxed);
+			registerExternalInteraction();
 		m_midiIn.push_back(_ev);
 		return true;
 	}
@@ -1221,7 +1338,7 @@ namespace md
 
 	bool Hardware::startMidiSysexTransfer(PreparedMidiSysexTransfer& _transfer)
 	{
-		m_externalInteraction.store(true, std::memory_order_relaxed);
+		registerExternalInteraction();
 		return m_midiSysexTransfer.start(
 			_transfer, m_realtimeMidiIn.writePosition());
 	}

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -3,6 +3,7 @@
 #include "mdfirmwareupdate.h"
 #include "mdmemorymap.h"
 #include "mdmmwaveforms.h"
+#include "mdsysexautomation.h"
 
 #include <algorithm>
 #include <chrono>
@@ -120,10 +121,16 @@ namespace md
 		, m_uc(m_rom, m_model, initPatchRam(m_rom,
 			_pendingFlashOverlay.valid ? std::vector<uint8_t>{} : _initialPatchRam),
 			initMainRam(m_rom), _initialUserFlash)
+		// A complete project image can boot directly without a local factory cache,
+		// but it must never become the machine-local factory baseline itself.
+		, m_externalInteraction(_model == MachineModel::Machinedrum
+			&& !_initialUserFlash.empty() && _factoryFlashCache.empty()
+			&& !_pendingFlashOverlay.valid)
 		, m_factoryFlashReady(!_factoryFlashCache.empty())
 		, m_factoryFlashCache(_factoryFlashCache)
 		, m_factoryFlashBaseline(_model == MachineModel::Machinedrum
 			&& _factoryFlashCache.empty() ? g_romSize : 0)
+		, m_pendingFlashImage(_pendingFlashOverlay.valid ? g_romSize : 0)
 		, m_pendingFlashOverlay(_pendingFlashOverlay)
 		, m_pendingPatchRam(_pendingFlashOverlay.valid
 			? _initialPatchRam : std::vector<uint8_t>{})
@@ -613,46 +620,6 @@ namespace md
 		return m_pendingFlashOverlay.valid ? m_pendingPatchRam : m_uc.copyPatchRam();
 	}
 
-	bool Hardware::finalizeFactoryFlashBaselineLocked()
-	{
-		if(m_model != MachineModel::Machinedrum)
-			return false;
-		if(m_factoryFlashReady.load(std::memory_order_relaxed))
-			return true;
-		if(m_externalInteraction.load(std::memory_order_relaxed))
-			return false;
-
-		// Require sustained flash inactivity after the one-time initialization pass.
-		constexpr uint64_t minimumAge = g_ucClockHz * 10;
-		constexpr uint64_t quietPeriod = g_ucClockHz * 2;
-		if(!m_uc.flashDirty() || m_uc.getCycles() < minimumAge
-			|| m_uc.flashIdleCycles() < quietPeriod)
-			return false;
-
-		m_factoryFlashBaseline = m_uc.copyFlashData();
-		if(m_pendingFlashOverlay.valid)
-		{
-			std::vector<uint8_t> restored;
-			if(!applyFlashOverlay(restored, m_pendingFlashOverlay,
-				m_factoryFlashBaseline, m_rom.data())
-				|| !m_uc.replaceFlashData(restored, !m_pendingFlashOverlay.data.empty())
-				|| !m_uc.replacePatchRam(m_pendingPatchRam))
-			{
-				m_pendingFlashRestoreFailed.store(true, std::memory_order_release);
-				m_externalInteraction.store(true, std::memory_order_relaxed);
-				std::fprintf(stderr,
-					"[MD] project flash does not match the initialized factory baseline\n");
-				return false;
-			}
-			m_pendingFlashOverlay = {};
-			m_pendingPatchRam.clear();
-			m_pendingFlashRestoreActive.store(false, std::memory_order_release);
-			m_externalInteraction.store(true, std::memory_order_relaxed);
-		}
-		m_factoryFlashReady.store(true, std::memory_order_release);
-		return true;
-	}
-
 	void Hardware::advanceFactoryFlashCapture()
 	{
 		if(m_model != MachineModel::Machinedrum
@@ -682,6 +649,9 @@ namespace md
 			if(!m_uc.copyFlashDataRangeRealtime(destination,
 				m_factoryFlashCaptureOffset, count))
 				return;
+			if(m_pendingFlashOverlay.valid)
+				std::copy_n(destination, count, m_pendingFlashImage.begin()
+					+ m_factoryFlashCaptureOffset);
 			for(size_t i = 0; i < count; ++i)
 			{
 				m_factoryFlashCaptureFingerprint ^= destination[i];
@@ -718,20 +688,26 @@ namespace md
 			const auto destination = static_cast<size_t>(
 				m_pendingFlashOverlay.sectors[index]) * g_uwFlashSectorSize;
 			const auto source = index * static_cast<size_t>(g_uwFlashSectorSize);
-			if(!m_uc.replaceFlashDataRangeRealtime(destination,
-				m_pendingFlashOverlay.data.data() + source, g_uwFlashSectorSize, true))
-				m_pendingFlashRestoreFailed.store(true, std::memory_order_release);
+			std::copy_n(m_pendingFlashOverlay.data.data() + source,
+				g_uwFlashSectorSize, m_pendingFlashImage.begin() + destination);
 			return;
 		}
 
-		if(m_pendingPatchRamOffset < m_pendingPatchRam.size())
+		// Host snapshots hold this mutex while selecting pending or published state.
+		// Never make the scheduler wait for one; retry at the next callback instead.
+		std::unique_lock stateLock(m_factoryFlashMutex, std::try_to_lock);
+		if(!stateLock.owns_lock())
+			return;
+		const auto publishResult = m_uc.publishStateImagesRealtime(
+			m_pendingFlashImage, m_pendingPatchRam,
+			!m_pendingFlashOverlay.data.empty());
+		if(publishResult == Microcontroller::StateImagePublishResult::Busy)
+			return;
+		if(publishResult != Microcontroller::StateImagePublishResult::Published)
 		{
-			const auto count = std::min(sliceSize,
-				m_pendingPatchRam.size() - m_pendingPatchRamOffset);
-			if(!m_uc.replacePatchRamRangeRealtime(m_pendingPatchRamOffset,
-				m_pendingPatchRam.data() + m_pendingPatchRamOffset, count))
-				m_pendingFlashRestoreFailed.store(true, std::memory_order_release);
-			m_pendingPatchRamOffset += count;
+			m_pendingFlashRestoreFailed.store(true, std::memory_order_release);
+			m_pendingFlashRestoreActive.store(false, std::memory_order_release);
+			m_externalInteraction.store(true, std::memory_order_relaxed);
 			return;
 		}
 
@@ -746,17 +722,14 @@ namespace md
 
 	bool Hardware::factoryFlashCacheReady()
 	{
-		if(m_factoryFlashReady.load(std::memory_order_acquire))
-			return true;
-		std::lock_guard lock(m_factoryFlashMutex);
-		return finalizeFactoryFlashBaselineLocked();
+		return m_factoryFlashReady.load(std::memory_order_acquire);
 	}
 
 	bool Hardware::copyFactoryFlashBaseline(std::vector<uint8_t>& _baseline)
 	{
-		std::lock_guard lock(m_factoryFlashMutex);
-		if(!finalizeFactoryFlashBaselineLocked())
+		if(!m_factoryFlashReady.load(std::memory_order_acquire))
 			return false;
+		std::lock_guard lock(m_factoryFlashMutex);
 		if(!m_factoryFlashBaseline.empty())
 		{
 			_baseline = m_factoryFlashBaseline;
@@ -767,9 +740,9 @@ namespace md
 
 	std::vector<uint8_t> Hardware::copyFactoryFlashCache()
 	{
-		std::lock_guard lock(m_factoryFlashMutex);
-		if(!finalizeFactoryFlashBaselineLocked())
+		if(!m_factoryFlashReady.load(std::memory_order_acquire))
 			return {};
+		std::lock_guard lock(m_factoryFlashMutex);
 		if(m_factoryFlashCache.empty()
 			&& !encodeFactoryFlashCache(m_factoryFlashCache,
 				m_factoryFlashBaseline, m_rom.data()))
@@ -892,7 +865,11 @@ namespace md
 		// release/acquire pending count is a counted-work wake, not a second dirty
 		// bit: a racing producer can make us defer once, but the count cannot clear
 		// until this single consumer drains the published packet.
-		if(m_panelIn.hasPending())
+		// Do not let input mutate the bootstrap machine and then disappear when the
+		// coherent project images are published. Queues remain intact until restore.
+		const bool projectRestorePending =
+			m_pendingFlashRestoreActive.load(std::memory_order_acquire);
+		if(!projectRestorePending && m_panelIn.hasPending())
 		{
 			PanelInputQueue::DrainBuffer panelInput;
 			const auto availablePackets = m_uc.availablePanelRxBytes() / 2;
@@ -911,8 +888,9 @@ namespace md
 		// Avoid entering MIDI arbitration when every source is idle; a producer
 		// racing this observation is visible at the next instruction boundary.
 		const bool transferActive = m_midiSysexTransfer.ownsMidiWire();
-		if(transferActive || m_midiInByteCursor != 0 || !m_midiIn.empty()
-			|| m_realtimeMidiIn.hasPending())
+		if(!projectRestorePending && (transferActive || m_midiInByteCursor != 0
+			|| !m_midiIn.empty()
+			|| m_realtimeMidiIn.hasPending()))
 			pumpMidiIngress();
 
 		// Drive DSP2's HI08 HREQ into the ColdFire external IRQ4 BEFORE stepping the CPU, so the
@@ -1307,8 +1285,11 @@ namespace md
 
 	bool Hardware::sendMidi(const synthLib::SMidiEvent& _ev)
 	{
-		// Internal clock traffic does not affect the factory baseline.
-		if(_ev.source != synthLib::MidiEventSource::Internal)
+		// Internal clock traffic and the controller's exact read-only state queries
+		// do not affect the factory baseline. All other routable traffic does.
+		if(_ev.source != synthLib::MidiEventSource::Internal
+			&& (_ev.sysex.empty() || !automation::sysex::isReadOnlyRequest(
+				m_model, _ev.sysex)))
 			registerExternalInteraction();
 		m_midiIn.push_back(_ev);
 		return true;

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -593,6 +593,19 @@ namespace md
 		return m_rom.isValid();
 	}
 
+	bool Hardware::factoryFlashCacheReady() const
+	{
+		// Do not mistake an early pause in the one-time initializer for completion.
+		// The qualified OS 1.63 path completes inside ten emulated CPU seconds; also
+		// require two seconds without a flash write and no host-originated control.
+		constexpr uint64_t minimumAge = g_ucClockHz * 10;
+		constexpr uint64_t quietPeriod = g_ucClockHz * 2;
+		return m_model == MachineModel::Machinedrum && m_uc.flashDirty()
+			&& m_uc.getCycles() >= minimumAge
+			&& m_uc.flashIdleCycles() >= quietPeriod
+			&& !m_externalInteraction.load(std::memory_order_relaxed);
+	}
+
 	void Hardware::mdLinkWindowFlushed()
 	{
 		if(!m_mdLinkRoeEngaged)
@@ -653,6 +666,7 @@ namespace md
 
 	bool Hardware::trySendPanelEvent(const uint8_t _cmd, const uint8_t _arg)
 	{
+		m_externalInteraction.store(true, std::memory_order_relaxed);
 		return m_panelIn.tryPush(_cmd, _arg);
 	}
 
@@ -1086,6 +1100,10 @@ namespace md
 
 	bool Hardware::sendMidi(const synthLib::SMidiEvent& _ev)
 	{
+		// Host-generated clock is tagged Internal by synthLib and does not contain
+		// project data. Real host/editor/physical/unknown events disqualify caching.
+		if(_ev.source != synthLib::MidiEventSource::Internal)
+			m_externalInteraction.store(true, std::memory_order_relaxed);
 		m_midiIn.push_back(_ev);
 		return true;
 	}
@@ -1203,6 +1221,7 @@ namespace md
 
 	bool Hardware::startMidiSysexTransfer(PreparedMidiSysexTransfer& _transfer)
 	{
+		m_externalInteraction.store(true, std::memory_order_relaxed);
 		return m_midiSysexTransfer.start(
 			_transfer, m_realtimeMidiIn.writePosition());
 	}

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -85,6 +85,14 @@ namespace md
 		return result;
 	}
 
+	dsp56k::TWord hostAudioInputSample(const synthLib::TAudioInputs& _inputs,
+		const uint32_t _frames, const uint32_t _cursor, const size_t _channel)
+	{
+		if(_channel >= 2 || _cursor >= _frames || !_inputs[_channel])
+			return 0;
+		return dsp56k::sample2dsp(_inputs[_channel][_cursor]);
+	}
+
 	Hardware::Hardware(const std::vector<uint8_t>& _romData, const std::string& _romName,
 		const MachineModel _model, const std::vector<uint8_t>& _initialPatchRam,
 		std::shared_ptr<FrontPanelPublisher> _frontPanelPublisher,
@@ -181,9 +189,8 @@ namespace md
 		// neither side of the FULL-DUPLEX link blocks at startup, and execTX runs before execRX
 		// each slot (esaiclock), so each DSP feeds its neighbour before it can block on its own
 		// RX - no deadlock, provided the two ESSI0 clock rates match (they do: same divider config
-		// on both DSPs). The codec ESSI1 RX inputs have NO producer (no audio-in modelled), so
-		// they stay NON-blocking silence - blocking those (which nothing feeds) was the cause of
-		// the earlier blocking-ring deadlock.
+		// on both DSPs). Codec ESSI1 RX is callback-fed and remains non-blocking: MD receives
+		// the current host input block, while MM and out-of-block reads receive silence.
 		const auto txToRx = [](const dsp56k::Audio::TxFrame& _tx, dsp56k::Audio::RxFrame& _rx)
 		{
 			_rx.resize(_tx.size());
@@ -385,6 +392,22 @@ namespace md
 			_frame.clear();
 			++_frameIndex;
 		};
+		const auto codecInput = [this](uint64_t& _frameIndex,
+			dsp56k::Audio::RxFrame& _frame)
+		{
+			const auto cursor = m_hostAudioInputCursor++;
+			const auto sample = [this, cursor](const size_t _channel)
+			{
+				return m_hostAudioInputActive
+					? hostAudioInputSample(m_hostAudioInputs,
+						m_hostAudioInputFrames, cursor, _channel)
+					: dsp56k::TWord{0};
+			};
+			_frame.resize(2);
+			_frame[0] = dsp56k::Audio::RxSlot{sample(0)};
+			_frame[1] = dsp56k::Audio::RxSlot{sample(1)};
+			++_frameIndex;
+		};
 
 		// ESSI0 inter-DSP ring, full-duplex: DSP2 TX -> DSP1 input and vice versa.
 		{
@@ -426,8 +449,13 @@ namespace md
 			m_dspMixer.getPeriph().getEssi0(), 0));
 		m_dspProducer.getPeriph().getEssi0().setReadRxCallback(blockingPop(
 			m_dspProducer.getPeriph().getEssi0(), 1));
-		// ESSI1 receivers = codec ADC inputs (no audio-in modelled): feed silence, NON-blocking.
-		m_dspMixer.getPeriph().getEssi1().setReadRxCallback(silence);
+		// The Machinedrum mixer's ESSI1 is connected to the stereo codec ADC. The
+		// producer has no independent host input path, and MM behavior remains the
+		// established silent-input model until its input machines are qualified.
+		if(isMonomachine())
+			m_dspMixer.getPeriph().getEssi1().setReadRxCallback(silence);
+		else
+			m_dspMixer.getPeriph().getEssi1().setReadRxCallback(codecInput);
 		m_dspProducer.getPeriph().getEssi1().setReadRxCallback(silence);
 
 		// Each mixer ESSI1 output frame advances the codec frame counter used by
@@ -785,6 +813,20 @@ namespace md
 			for(uint32_t i = 0; i < _frames; ++i)
 				_outputs[ch][i] = dsp56k::dsp2sample<float>(m_audioOutputs[ch][i]);
 		}
+	}
+
+	void Hardware::processAudio(const synthLib::TAudioInputs& _inputs,
+		const synthLib::TAudioOutputs& _outputs, const uint32_t _frames,
+		const uint32_t _latency)
+	{
+		m_hostAudioInputs = _inputs;
+		m_hostAudioInputFrames = _frames;
+		m_hostAudioInputCursor = 0;
+		m_hostAudioInputActive = true;
+		processAudio(_outputs, _frames, _latency);
+		m_hostAudioInputActive = false;
+		m_hostAudioInputFrames = 0;
+		m_hostAudioInputs.fill(nullptr);
 	}
 
 	// -------------------------------------------------------------------------------------------

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -122,9 +122,12 @@ namespace md
 			initMainRam(m_rom), _initialUserFlash)
 		, m_factoryFlashReady(!_factoryFlashCache.empty())
 		, m_factoryFlashCache(_factoryFlashCache)
+		, m_factoryFlashBaseline(_model == MachineModel::Machinedrum
+			&& _factoryFlashCache.empty() ? g_romSize : 0)
 		, m_pendingFlashOverlay(_pendingFlashOverlay)
 		, m_pendingPatchRam(_pendingFlashOverlay.valid
 			? _initialPatchRam : std::vector<uint8_t>{})
+		, m_pendingFlashRestoreActive(_pendingFlashOverlay.valid)
 		, m_frontPanelPublisher(_frontPanelPublisher
 			? std::move(_frontPanelPublisher)
 			: std::make_shared<FrontPanelPublisher>())
@@ -631,7 +634,7 @@ namespace md
 		{
 			std::vector<uint8_t> restored;
 			if(!applyFlashOverlay(restored, m_pendingFlashOverlay,
-				m_factoryFlashBaseline)
+				m_factoryFlashBaseline, m_rom.data())
 				|| !m_uc.replaceFlashData(restored, !m_pendingFlashOverlay.data.empty())
 				|| !m_uc.replacePatchRam(m_pendingPatchRam))
 			{
@@ -643,10 +646,102 @@ namespace md
 			}
 			m_pendingFlashOverlay = {};
 			m_pendingPatchRam.clear();
+			m_pendingFlashRestoreActive.store(false, std::memory_order_release);
 			m_externalInteraction.store(true, std::memory_order_relaxed);
 		}
 		m_factoryFlashReady.store(true, std::memory_order_release);
 		return true;
+	}
+
+	void Hardware::advanceFactoryFlashCapture()
+	{
+		if(m_model != MachineModel::Machinedrum
+			|| m_factoryFlashReady.load(std::memory_order_acquire)
+			|| m_pendingFlashRestoreFailed.load(std::memory_order_acquire)
+			|| m_externalInteraction.load(std::memory_order_relaxed))
+			return;
+
+		constexpr size_t sliceSize = g_uwFlashSectorSize;
+		if(!m_factoryFlashCaptureComplete)
+		{
+			constexpr uint64_t minimumAge = g_ucClockHz * 10;
+			constexpr uint64_t quietPeriod = g_ucClockHz * 2;
+			if(!m_uc.flashDirty() || m_uc.getCycles() < minimumAge
+				|| m_uc.flashIdleCycles() < quietPeriod)
+			{
+				m_factoryFlashCaptureOffset = 0;
+				m_factoryFlashCaptureFingerprint = 14695981039346656037ull;
+				return;
+			}
+
+			const auto remaining = m_factoryFlashBaseline.size()
+				- m_factoryFlashCaptureOffset;
+			const auto count = std::min(sliceSize, remaining);
+			auto* const destination = m_factoryFlashBaseline.data()
+				+ m_factoryFlashCaptureOffset;
+			if(!m_uc.copyFlashDataRangeRealtime(destination,
+				m_factoryFlashCaptureOffset, count))
+				return;
+			for(size_t i = 0; i < count; ++i)
+			{
+				m_factoryFlashCaptureFingerprint ^= destination[i];
+				m_factoryFlashCaptureFingerprint *= 1099511628211ull;
+			}
+			m_factoryFlashCaptureOffset += count;
+			if(m_factoryFlashCaptureOffset != m_factoryFlashBaseline.size())
+				return;
+			m_factoryFlashCaptureComplete = true;
+
+			if(m_pendingFlashOverlay.valid
+				&& m_pendingFlashOverlay.baselineFingerprint
+					!= m_factoryFlashCaptureFingerprint
+				&& m_pendingFlashOverlay.baselineFingerprint != fingerprintRom(m_rom.data()))
+			{
+				m_pendingFlashRestoreFailed.store(true, std::memory_order_release);
+				m_pendingFlashRestoreActive.store(false, std::memory_order_release);
+				m_externalInteraction.store(true, std::memory_order_relaxed);
+				std::fprintf(stderr,
+					"[MD] project flash does not match the initialized factory baseline\n");
+				return;
+			}
+		}
+
+		if(!m_pendingFlashOverlay.valid)
+		{
+			m_factoryFlashReady.store(true, std::memory_order_release);
+			return;
+		}
+
+		if(m_pendingFlashSectorIndex < m_pendingFlashOverlay.sectors.size())
+		{
+			const auto index = m_pendingFlashSectorIndex++;
+			const auto destination = static_cast<size_t>(
+				m_pendingFlashOverlay.sectors[index]) * g_uwFlashSectorSize;
+			const auto source = index * static_cast<size_t>(g_uwFlashSectorSize);
+			if(!m_uc.replaceFlashDataRangeRealtime(destination,
+				m_pendingFlashOverlay.data.data() + source, g_uwFlashSectorSize, true))
+				m_pendingFlashRestoreFailed.store(true, std::memory_order_release);
+			return;
+		}
+
+		if(m_pendingPatchRamOffset < m_pendingPatchRam.size())
+		{
+			const auto count = std::min(sliceSize,
+				m_pendingPatchRam.size() - m_pendingPatchRamOffset);
+			if(!m_uc.replacePatchRamRangeRealtime(m_pendingPatchRamOffset,
+				m_pendingPatchRam.data() + m_pendingPatchRamOffset, count))
+				m_pendingFlashRestoreFailed.store(true, std::memory_order_release);
+			m_pendingPatchRamOffset += count;
+			return;
+		}
+
+		// Retain the backing allocations until Hardware destruction; releasing a
+		// multi-megabyte overlay or patch image here would move allocator work back
+		// onto the audio callback we just made bounded.
+		m_pendingFlashOverlay.valid = false;
+		m_pendingFlashRestoreActive.store(false, std::memory_order_release);
+		m_externalInteraction.store(true, std::memory_order_relaxed);
+		m_factoryFlashReady.store(true, std::memory_order_release);
 	}
 
 	bool Hardware::factoryFlashCacheReady()
@@ -705,15 +800,10 @@ namespace md
 
 	void Hardware::registerExternalInteraction()
 	{
-		if(m_factoryFlashReady.load(std::memory_order_acquire))
-		{
-			m_externalInteraction.store(true, std::memory_order_relaxed);
-			return;
-		}
-		std::lock_guard lock(m_factoryFlashMutex);
-		if(finalizeFactoryFlashBaselineLocked())
-			m_externalInteraction.store(true, std::memory_order_relaxed);
-		else if(!m_pendingFlashOverlay.valid)
+		// Pending project data must be installed before external traffic can make
+		// the freshly initialized flash authoritative. This path is called from
+		// real-time MIDI ingress and therefore remains lock-free and bounded.
+		if(!m_pendingFlashRestoreActive.load(std::memory_order_acquire))
 			m_externalInteraction.store(true, std::memory_order_relaxed);
 	}
 
@@ -1209,8 +1299,7 @@ namespace md
 		}
 
 		schedDrainCodecOutput();					// final drain (also covers a UC-only advance window)
-		if(!m_factoryFlashReady.load(std::memory_order_relaxed))
-			factoryFlashCacheReady();
+		advanceFactoryFlashCapture();
 		// Never make the emulation/audio thread wait for a UI snapshot read. If the
 		// reader owns the short copy lock, the next machine interval republishes.
 		m_frontPanelPublisher->tryPublish(m_frontPanel);

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -24,6 +24,11 @@
 namespace md
 {
 	struct ProfileWorkloadAccess;
+	// Convert one stereo codec-ADC sample with the bounds/null behavior used by
+	// ESSI1. Free-standing so the host-to-codec mapping can be tested without a ROM.
+	dsp56k::TWord hostAudioInputSample(const synthLib::TAudioInputs& _inputs,
+		uint32_t _frames, uint32_t _cursor, size_t _channel);
+
 	inline const char* midiTurboSpeedLabel(const uint8_t _code)
 	{
 		switch(_code)
@@ -95,6 +100,8 @@ namespace md
 		void processUC();
 		void processAudio(uint32_t _frames, uint32_t _latency);
 		void processAudio(const synthLib::TAudioOutputs& _outputs, uint32_t _frames, uint32_t _latency);
+		void processAudio(const synthLib::TAudioInputs& _inputs,
+			const synthLib::TAudioOutputs& _outputs, uint32_t _frames, uint32_t _latency);
 
 		// Advance the whole machine by _machineFrames codec frames of shared
 		// machine time on the calling thread, with NO background threads. One frame = g_dsp1CyclesPer
@@ -212,6 +219,10 @@ namespace md
 		RealtimeHostAudioQueue m_schedHostAudio;
 		std::atomic<uint64_t> m_schedHostAudioOverflow{0};
 		bool     m_schedHostAudioActive = false;	// retain drained frames for a host callback
+		synthLib::TAudioInputs m_hostAudioInputs{};
+		uint32_t m_hostAudioInputFrames = 0;
+		uint32_t m_hostAudioInputCursor = 0;
+		bool m_hostAudioInputActive = false;
 		bool     m_schedInLinkDelivery = false;	// reentrancy guard for cross-DSP catch-up
 		bool     m_schedBoundedJit = false;		// experimental cycle-bounded background slices
 		double   m_schedFramesTotal   = 0.0;	// machine-time target, accumulated codec frames

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -92,6 +92,20 @@ namespace md
 		Microcontroller& getUC() { return m_uc; }
 		std::vector<uint8_t> copyPatchRam() const { return m_uc.copyPatchRam(); }
 		std::vector<uint8_t> copyUserFlash() const { return m_uc.copyUserFlash(); }
+		std::vector<uint8_t> copyFlashData() const { return m_uc.copyFlashData(); }
+		const std::vector<uint8_t>& flashBaseline() const { return m_rom.data(); }
+		bool flashDirty() const { return m_uc.flashDirty(); }
+		bool factoryFlashCacheReady() const;
+		void disqualifyFactoryFlashCache()
+		{
+			m_externalInteraction.store(true, std::memory_order_relaxed);
+		}
+		bool replaceFlashData(const std::vector<uint8_t>& _data, const bool _dirty)
+		{
+			if(_dirty)
+				m_externalInteraction.store(true, std::memory_order_relaxed);
+			return m_uc.replaceFlashData(_data, _dirty);
+		}
 
 		// Role accessors used by the HI08 bridge and scheduler.
 		Dsp& getDspProducer() { return m_dspProducer; }	// DSP2, index 1
@@ -126,6 +140,7 @@ namespace md
 		// commands. Unlike sendMidi(), this never allocates or waits for space.
 		bool trySendRealtimeMidi(const uint8_t* _bytes, size_t _count)
 		{
+			m_externalInteraction.store(true, std::memory_order_relaxed);
 			return m_realtimeMidiIn.tryPush(_bytes, _count);
 		}
 		template<size_t Count>
@@ -188,6 +203,7 @@ namespace md
 		uint64_t m_firmwareUpdateMainFingerprint = 0;
 		size_t m_firmwareUpdateMainSize = 0;
 		Microcontroller m_uc;
+		std::atomic<bool> m_externalInteraction{false};
 		FrontPanel m_frontPanel;	// writer-owned UART2 LCD/LED decoder
 		std::shared_ptr<FrontPanelPublisher> m_frontPanelPublisher;
 		TurboMidiTransfer m_midiSysexTransfer;

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -100,6 +100,14 @@ namespace md
 		const std::vector<uint8_t>& flashBaseline() const { return m_rom.data(); }
 		bool flashDirty() const { return m_uc.flashDirty(); }
 		bool factoryFlashCacheReady();
+		bool isFactoryFlashCacheReady() const
+		{
+			return m_factoryFlashReady.load(std::memory_order_acquire);
+		}
+		bool isProjectStateRestorePending() const
+		{
+			return m_pendingFlashRestoreActive.load(std::memory_order_acquire);
+		}
 		bool copyFactoryFlashBaseline(std::vector<uint8_t>& _baseline);
 		std::vector<uint8_t> copyFactoryFlashCache();
 		bool copyPendingFlashOverlay(FlashSectorOverlay& _overlay) const;
@@ -199,7 +207,6 @@ namespace md
 			const std::vector<uint8_t>& _factoryFlashCache,
 			const FlashSectorOverlay& _pendingFlashOverlay);
 		void ensureBufferSize(uint32_t _frames);
-		bool finalizeFactoryFlashBaselineLocked();
 		void advanceFactoryFlashCapture();
 		void registerExternalInteraction();
 		void pumpDsp2HostRequest();		// DSP2 HI08 HREQ -> ColdFire external IRQ4 (see .cpp)
@@ -219,6 +226,7 @@ namespace md
 		mutable std::mutex m_factoryFlashMutex;
 		std::vector<uint8_t> m_factoryFlashCache;
 		std::vector<uint8_t> m_factoryFlashBaseline;
+		std::vector<uint8_t> m_pendingFlashImage;
 		FlashSectorOverlay m_pendingFlashOverlay;
 		std::vector<uint8_t> m_pendingPatchRam;
 		std::atomic<bool> m_pendingFlashRestoreActive{false};
@@ -227,7 +235,6 @@ namespace md
 		uint64_t m_factoryFlashCaptureFingerprint = 14695981039346656037ull;
 		bool m_factoryFlashCaptureComplete = false;
 		size_t m_pendingFlashSectorIndex = 0;
-		size_t m_pendingPatchRamOffset = 0;
 		FrontPanel m_frontPanel;	// writer-owned UART2 LCD/LED decoder
 		std::shared_ptr<FrontPanelPublisher> m_frontPanelPublisher;
 		TurboMidiTransfer m_midiSysexTransfer;

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -145,12 +145,13 @@ namespace md
 		// commands. Unlike sendMidi(), this never allocates or waits for space.
 		bool trySendRealtimeMidi(const uint8_t* _bytes, size_t _count)
 		{
-			m_externalInteraction.store(true, std::memory_order_relaxed);
+			registerExternalInteraction();
 			return m_realtimeMidiIn.tryPush(_bytes, _count);
 		}
 		template<size_t Count>
 		bool trySendRealtimeMidi(const std::array<uint8_t, Count>& _bytes)
 		{
+			registerExternalInteraction();
 			return m_realtimeMidiIn.tryPush(_bytes);
 		}
 		void readMidiOut(std::vector<synthLib::SMidiEvent>& _midiOut)
@@ -199,6 +200,7 @@ namespace md
 			const FlashSectorOverlay& _pendingFlashOverlay);
 		void ensureBufferSize(uint32_t _frames);
 		bool finalizeFactoryFlashBaselineLocked();
+		void advanceFactoryFlashCapture();
 		void registerExternalInteraction();
 		void pumpDsp2HostRequest();		// DSP2 HI08 HREQ -> ColdFire external IRQ4 (see .cpp)
 		void onEssiCallbackMixer();		// master clock: advance the ESSI frame counter
@@ -219,7 +221,13 @@ namespace md
 		std::vector<uint8_t> m_factoryFlashBaseline;
 		FlashSectorOverlay m_pendingFlashOverlay;
 		std::vector<uint8_t> m_pendingPatchRam;
+		std::atomic<bool> m_pendingFlashRestoreActive{false};
 		std::atomic<bool> m_pendingFlashRestoreFailed{false};
+		size_t m_factoryFlashCaptureOffset = 0;
+		uint64_t m_factoryFlashCaptureFingerprint = 14695981039346656037ull;
+		bool m_factoryFlashCaptureComplete = false;
+		size_t m_pendingFlashSectorIndex = 0;
+		size_t m_pendingPatchRamOffset = 0;
 		FrontPanel m_frontPanel;	// writer-owned UART2 LCD/LED decoder
 		std::shared_ptr<FrontPanelPublisher> m_frontPanelPublisher;
 		TurboMidiTransfer m_midiSysexTransfer;

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -14,6 +15,7 @@
 #include "mdpanel.h"
 #include "mdrealtimemidiqueue.h"
 #include "mdrom.h"
+#include "mdstate.h"
 #include "mdsysextransfer.h"
 #include "mdturbomidi.h"
 #include "mdtypes.h"
@@ -61,7 +63,9 @@ namespace md
 			const std::vector<uint8_t>& _initialPatchRam = {},
 			std::shared_ptr<FrontPanelPublisher> _frontPanelPublisher = {},
 			std::shared_ptr<MidiSysexTransferProgressPublisher> _midiSysexProgressPublisher = {},
-			const std::vector<uint8_t>& _initialUserFlash = {});
+			const std::vector<uint8_t>& _initialUserFlash = {},
+			const std::vector<uint8_t>& _factoryFlashCache = {},
+			const FlashSectorOverlay& _pendingFlashOverlay = {});
 		~Hardware();
 
 		bool isValid() const;
@@ -90,20 +94,21 @@ namespace md
 		uint64_t midiRxConsumedCount() const { return m_uc.midiRxConsumedCount(); }
 
 		Microcontroller& getUC() { return m_uc; }
-		std::vector<uint8_t> copyPatchRam() const { return m_uc.copyPatchRam(); }
+		std::vector<uint8_t> copyPatchRam() const;
 		std::vector<uint8_t> copyUserFlash() const { return m_uc.copyUserFlash(); }
 		std::vector<uint8_t> copyFlashData() const { return m_uc.copyFlashData(); }
 		const std::vector<uint8_t>& flashBaseline() const { return m_rom.data(); }
 		bool flashDirty() const { return m_uc.flashDirty(); }
-		bool factoryFlashCacheReady() const;
-		void disqualifyFactoryFlashCache()
-		{
-			m_externalInteraction.store(true, std::memory_order_relaxed);
-		}
+		bool factoryFlashCacheReady();
+		bool copyFactoryFlashBaseline(std::vector<uint8_t>& _baseline);
+		std::vector<uint8_t> copyFactoryFlashCache();
+		bool copyPendingFlashOverlay(FlashSectorOverlay& _overlay) const;
+		void disqualifyFactoryFlashCache();
+		bool replaceFactoryFlashCache(const std::vector<uint8_t>& _cache);
 		bool replaceFlashData(const std::vector<uint8_t>& _data, const bool _dirty)
 		{
 			if(_dirty)
-				m_externalInteraction.store(true, std::memory_order_relaxed);
+				registerExternalInteraction();
 			return m_uc.replaceFlashData(_data, _dirty);
 		}
 
@@ -189,8 +194,12 @@ namespace md
 			const std::vector<uint8_t>& _initialPatchRam,
 			std::shared_ptr<FrontPanelPublisher> _frontPanelPublisher,
 			std::shared_ptr<MidiSysexTransferProgressPublisher> _midiSysexProgressPublisher,
-			const std::vector<uint8_t>& _initialUserFlash);
+			const std::vector<uint8_t>& _initialUserFlash,
+			const std::vector<uint8_t>& _factoryFlashCache,
+			const FlashSectorOverlay& _pendingFlashOverlay);
 		void ensureBufferSize(uint32_t _frames);
+		bool finalizeFactoryFlashBaselineLocked();
+		void registerExternalInteraction();
 		void pumpDsp2HostRequest();		// DSP2 HI08 HREQ -> ColdFire external IRQ4 (see .cpp)
 		void onEssiCallbackMixer();		// master clock: advance the ESSI frame counter
 		template<typename InactiveObserved>
@@ -204,6 +213,13 @@ namespace md
 		size_t m_firmwareUpdateMainSize = 0;
 		Microcontroller m_uc;
 		std::atomic<bool> m_externalInteraction{false};
+		std::atomic<bool> m_factoryFlashReady{false};
+		mutable std::mutex m_factoryFlashMutex;
+		std::vector<uint8_t> m_factoryFlashCache;
+		std::vector<uint8_t> m_factoryFlashBaseline;
+		FlashSectorOverlay m_pendingFlashOverlay;
+		std::vector<uint8_t> m_pendingPatchRam;
+		std::atomic<bool> m_pendingFlashRestoreFailed{false};
 		FrontPanel m_frontPanel;	// writer-owned UART2 LCD/LED decoder
 		std::shared_ptr<FrontPanelPublisher> m_frontPanelPublisher;
 		TurboMidiTransfer m_midiSysexTransfer;

--- a/source/elektron/md/mdLib/mdmc.cpp
+++ b/source/elektron/md/mdLib/mdmc.cpp
@@ -142,6 +142,15 @@ namespace md
 		return true;
 	}
 
+	bool Microcontroller::replacePatchRamRangeRealtime(const size_t _offset,
+		const uint8_t* const _data, const size_t _size)
+	{
+		if(!_data || _offset > m_patchRam.size() || _size > m_patchRam.size() - _offset)
+			return false;
+		std::copy_n(_data, _size, m_patchRam.begin() + _offset);
+		return true;
+	}
+
 	std::vector<uint8_t> Microcontroller::copyUserFlash() const
 	{
 		if(m_model != MachineModel::Monomachine
@@ -158,6 +167,16 @@ namespace md
 	{
 		std::shared_lock lock(m_flashMutex);
 		return m_flashData;
+	}
+
+	bool Microcontroller::copyFlashDataRangeRealtime(uint8_t* const _destination,
+		const size_t _offset, const size_t _size) const
+	{
+		if(!_destination || _offset > m_flashData.size()
+			|| _size > m_flashData.size() - _offset)
+			return false;
+		std::copy_n(m_flashData.begin() + _offset, _size, _destination);
+		return true;
 	}
 
 	uint64_t Microcontroller::flashIdleCycles() const
@@ -177,6 +196,21 @@ namespace md
 		m_immPageAddress = 0xffffffffu;
 		m_immPageData = nullptr;
 		m_flashDirty = _dirty;
+		m_lastFlashWriteCycle = getCycles();
+		return true;
+	}
+
+	bool Microcontroller::replaceFlashDataRangeRealtime(const size_t _offset,
+		const uint8_t* const _data, const size_t _size, const bool _dirty)
+	{
+		if(m_model != MachineModel::Machinedrum || !_data
+			|| _offset > m_flashData.size() || _size > m_flashData.size() - _offset)
+			return false;
+		std::copy_n(_data, _size, m_flashData.begin() + _offset);
+		m_flashCommands = {};
+		m_immPageAddress = 0xffffffffu;
+		m_immPageData = nullptr;
+		m_flashDirty = m_flashDirty || _dirty;
 		m_lastFlashWriteCycle = getCycles();
 		return true;
 	}

--- a/source/elektron/md/mdLib/mdmc.cpp
+++ b/source/elektron/md/mdLib/mdmc.cpp
@@ -80,6 +80,9 @@ namespace md
 		, m_loaderRam(memorymap::g_loaderRam.size(), 0)
 		, m_internalSram(memorymap::g_internalSram.size(), 0)
 	{
+		if(m_model == MachineModel::Machinedrum
+			&& _initialUserFlash.size() == m_flashData.size())
+			m_flashData = _initialUserFlash;
 		if(m_model == MachineModel::Monomachine
 			&& _initialUserFlash.size() == memorymap::g_mmUserFlash.size()
 			&& m_flashData.size() >= memorymap::g_flashFull.offset(
@@ -141,6 +144,33 @@ namespace md
 		const auto begin = m_flashData.begin() + memorymap::g_flashFull.offset(
 			memorymap::g_mmUserFlash.begin);
 		return {begin, begin + memorymap::g_mmUserFlash.size()};
+	}
+
+	std::vector<uint8_t> Microcontroller::copyFlashData() const
+	{
+		std::shared_lock lock(m_flashMutex);
+		return m_flashData;
+	}
+
+	uint64_t Microcontroller::flashIdleCycles() const
+	{
+		return m_flashDirty && getCycles() >= m_lastFlashWriteCycle
+			? getCycles() - m_lastFlashWriteCycle : 0;
+	}
+
+	bool Microcontroller::replaceFlashData(const std::vector<uint8_t>& _data,
+		const bool _dirty)
+	{
+		if(m_model != MachineModel::Machinedrum || _data.size() != m_flashData.size())
+			return false;
+		std::unique_lock flashLock(m_flashMutex);
+		m_flashData = _data;
+		m_flashCommands = {};
+		m_immPageAddress = 0xffffffffu;
+		m_immPageData = nullptr;
+		m_flashDirty = _dirty;
+		m_lastFlashWriteCycle = getCycles();
+		return true;
 	}
 
 	void Microcontroller::prepareFirmwareUpdateBoot(const uint32_t _factoryFlashAddress)
@@ -636,11 +666,15 @@ namespace md
 			{
 				if(const auto operation = m_flashCommands.write16(offset, _val))
 				{
+					std::unique_lock flashLock(m_flashMutex);
+					bool changed = false;
 					if(operation->type == FlashCommandDecoder::Operation::Type::ProgramWord
 						&& operation->offset + 1 < m_flashData.size())
 					{
+						// NOR programming can only clear bits; erasing restores them.
 						m_flashData[operation->offset] &= static_cast<uint8_t>(operation->value >> 8);
 						m_flashData[operation->offset + 1] &= static_cast<uint8_t>(operation->value);
+						changed = true;
 					}
 					else if(operation->type == FlashCommandDecoder::Operation::Type::EraseSector)
 					{
@@ -650,10 +684,19 @@ namespace md
 							+ FlashCommandDecoder::g_sectorSize,
 							static_cast<uint32_t>(m_flashData.size()));
 						if(begin < end)
+						{
 							std::fill(m_flashData.begin() + begin, m_flashData.begin() + end,
 								uint8_t{0xff});
+							changed = true;
+						}
 					}
-					m_immPageAddress = 0xffffffffu;
+					if(changed)
+					{
+						m_flashDirty = true;
+						m_lastFlashWriteCycle = getCycles();
+						m_immPageAddress = 0xffffffffu;
+						m_immPageData = nullptr;
+					}
 				}
 				return;
 			}

--- a/source/elektron/md/mdLib/mdmc.cpp
+++ b/source/elektron/md/mdLib/mdmc.cpp
@@ -93,9 +93,9 @@ namespace md
 		if(m_model == MachineModel::Monomachine && !m_flashData.empty())
 			m_flash = std::make_unique<MonomachineFlash>(m_flashData.data(), m_flashData.size());
 
-		// The current Monomachine target is the SFX-60 MKII motherboard. Its
-		// Monomachine MKII board identification uses an inverted Port A loopback.
-		m_sim.setMk2PortAInvertedLoopback(m_model == MachineModel::Monomachine);
+		// Both currently supported targets are MKII motherboards. The firmware
+		// identifies that revision through an inverted Port A loopback.
+		m_sim.setMk2PortAInvertedLoopback(true);
 
 		// The panel controller is not part of the emulator. Reproduce the public
 		// MAME driver's UART startup handshake here.

--- a/source/elektron/md/mdLib/mdmc.cpp
+++ b/source/elektron/md/mdLib/mdmc.cpp
@@ -96,8 +96,7 @@ namespace md
 		if(m_model == MachineModel::Monomachine && !m_flashData.empty())
 			m_flash = std::make_unique<MonomachineFlash>(m_flashData.data(), m_flashData.size());
 
-		// Both currently supported targets are MKII motherboards. The firmware
-		// identifies that revision through an inverted Port A loopback.
+		// Report the MKII board profile used by both supported targets.
 		m_sim.setMk2PortAInvertedLoopback(true);
 
 		// The panel controller is not part of the emulator. Reproduce the public
@@ -132,6 +131,15 @@ namespace md
 	{
 		std::shared_lock lock(m_patchRamMutex);
 		return m_patchRam;
+	}
+
+	bool Microcontroller::replacePatchRam(const std::vector<uint8_t>& _data)
+	{
+		if(_data.size() != m_patchRam.size())
+			return false;
+		std::unique_lock lock(m_patchRamMutex);
+		m_patchRam = _data;
+		return true;
 	}
 
 	std::vector<uint8_t> Microcontroller::copyUserFlash() const

--- a/source/elektron/md/mdLib/mdmc.cpp
+++ b/source/elektron/md/mdLib/mdmc.cpp
@@ -142,15 +142,6 @@ namespace md
 		return true;
 	}
 
-	bool Microcontroller::replacePatchRamRangeRealtime(const size_t _offset,
-		const uint8_t* const _data, const size_t _size)
-	{
-		if(!_data || _offset > m_patchRam.size() || _size > m_patchRam.size() - _offset)
-			return false;
-		std::copy_n(_data, _size, m_patchRam.begin() + _offset);
-		return true;
-	}
-
 	std::vector<uint8_t> Microcontroller::copyUserFlash() const
 	{
 		if(m_model != MachineModel::Monomachine
@@ -200,19 +191,31 @@ namespace md
 		return true;
 	}
 
-	bool Microcontroller::replaceFlashDataRangeRealtime(const size_t _offset,
-		const uint8_t* const _data, const size_t _size, const bool _dirty)
+	Microcontroller::StateImagePublishResult Microcontroller::publishStateImagesRealtime(
+		std::vector<uint8_t>& _flash, std::vector<uint8_t>& _patchRam,
+		const bool _dirty)
 	{
-		if(m_model != MachineModel::Machinedrum || !_data
-			|| _offset > m_flashData.size() || _size > m_flashData.size() - _offset)
-			return false;
-		std::copy_n(_data, _size, m_flashData.begin() + _offset);
+		if(m_model != MachineModel::Machinedrum
+			|| _flash.size() != m_flashData.size()
+			|| _patchRam.size() != m_patchRam.size())
+			return StateImagePublishResult::Invalid;
+		std::unique_lock flashLock(m_flashMutex, std::try_to_lock);
+		if(!flashLock.owns_lock())
+			return StateImagePublishResult::Busy;
+		std::unique_lock patchLock(m_patchRamMutex, std::try_to_lock);
+		if(!patchLock.owns_lock())
+			return StateImagePublishResult::Busy;
+		// This is called only by the scheduler owner between executed instructions.
+		// With both host snapshot locks held, every observer sees complete backing
+		// stores rather than an incrementally modified or concurrently exchanged one.
+		m_flashData.swap(_flash);
+		m_patchRam.swap(_patchRam);
 		m_flashCommands = {};
 		m_immPageAddress = 0xffffffffu;
 		m_immPageData = nullptr;
-		m_flashDirty = m_flashDirty || _dirty;
+		m_flashDirty = _dirty;
 		m_lastFlashWriteCycle = getCycles();
-		return true;
+		return StateImagePublishResult::Published;
 	}
 
 	void Microcontroller::prepareFirmwareUpdateBoot(const uint32_t _factoryFlashAddress)

--- a/source/elektron/md/mdLib/mdmc.h
+++ b/source/elektron/md/mdLib/mdmc.h
@@ -158,6 +158,7 @@ namespace md
 		}
 
 		std::vector<uint8_t> copyPatchRam() const;
+		bool replacePatchRam(const std::vector<uint8_t>& _data);
 		std::vector<uint8_t> copyUserFlash() const;
 		std::vector<uint8_t> copyFlashData() const;
 		bool flashDirty() const { return m_flashDirty; }

--- a/source/elektron/md/mdLib/mdmc.h
+++ b/source/elektron/md/mdLib/mdmc.h
@@ -159,6 +159,10 @@ namespace md
 
 		std::vector<uint8_t> copyPatchRam() const;
 		std::vector<uint8_t> copyUserFlash() const;
+		std::vector<uint8_t> copyFlashData() const;
+		bool flashDirty() const { return m_flashDirty; }
+		uint64_t flashIdleCycles() const;
+		bool replaceFlashData(const std::vector<uint8_t>& _data, bool _dirty);
 
 
 	private:
@@ -193,6 +197,8 @@ namespace md
 		std::vector<uint8_t> m_flashData;
 		std::unique_ptr<hwLib::Am29f> m_flash;
 		mutable std::shared_mutex m_flashMutex;
+		bool m_flashDirty = false;
+		uint64_t m_lastFlashWriteCycle = 0;
 
 		Sim m_sim;	// on-chip SIM peripheral window (MBAR base 0x300000)
 		struct MidiTxBuffer

--- a/source/elektron/md/mdLib/mdmc.h
+++ b/source/elektron/md/mdLib/mdmc.h
@@ -161,9 +161,17 @@ namespace md
 		bool replacePatchRam(const std::vector<uint8_t>& _data);
 		std::vector<uint8_t> copyUserFlash() const;
 		std::vector<uint8_t> copyFlashData() const;
+		// Scheduler-thread-only bounded state transfer. The containing Hardware is
+		// serialized by synthLib::Plugin, so these avoid taking a callback-time lock.
+		bool copyFlashDataRangeRealtime(uint8_t* _destination, size_t _offset,
+			size_t _size) const;
 		bool flashDirty() const { return m_flashDirty; }
 		uint64_t flashIdleCycles() const;
 		bool replaceFlashData(const std::vector<uint8_t>& _data, bool _dirty);
+		bool replaceFlashDataRangeRealtime(size_t _offset, const uint8_t* _data,
+			size_t _size, bool _dirty);
+		bool replacePatchRamRangeRealtime(size_t _offset, const uint8_t* _data,
+			size_t _size);
 
 
 	private:

--- a/source/elektron/md/mdLib/mdmc.h
+++ b/source/elektron/md/mdLib/mdmc.h
@@ -168,10 +168,16 @@ namespace md
 		bool flashDirty() const { return m_flashDirty; }
 		uint64_t flashIdleCycles() const;
 		bool replaceFlashData(const std::vector<uint8_t>& _data, bool _dirty);
-		bool replaceFlashDataRangeRealtime(size_t _offset, const uint8_t* _data,
-			size_t _size, bool _dirty);
-		bool replacePatchRamRangeRealtime(size_t _offset, const uint8_t* _data,
-			size_t _size);
+		enum class StateImagePublishResult
+		{
+			Published,
+			Busy,
+			Invalid
+		};
+		// Publish a fully prepared flash/RAM pair between scheduler intervals. Both
+		// vectors are exchanged without copying, allocating, freeing, or waiting.
+		StateImagePublishResult publishStateImagesRealtime(
+			std::vector<uint8_t>& _flash, std::vector<uint8_t>& _patchRam, bool _dirty);
 
 
 	private:

--- a/source/elektron/md/mdLib/mdstate.cpp
+++ b/source/elektron/md/mdLib/mdstate.cpp
@@ -133,7 +133,8 @@ namespace md
 		bool makeFlashOverlay(FlashSectorOverlay& _overlay,
 			const std::vector<uint8_t>& _flashData,
 			const std::vector<uint8_t>& _baseline,
-			const std::vector<uint8_t>& _romBaseline)
+			const std::vector<uint8_t>& _romBaseline,
+			const bool _includeUnchanged = false)
 		{
 			if(_flashData.size() != g_romSize || _baseline.size() != g_romSize
 				|| _romBaseline.size() != g_romSize)
@@ -147,7 +148,7 @@ namespace md
 				++sector)
 			{
 				const auto offset = sector * g_uwFlashSectorSize;
-				if(std::equal(_flashData.begin() + offset,
+				if(!_includeUnchanged && std::equal(_flashData.begin() + offset,
 					_flashData.begin() + offset + g_uwFlashSectorSize,
 					_baseline.begin() + offset))
 					continue;
@@ -260,7 +261,12 @@ namespace md
 		const MachineModel _model, const synthLib::StateType _type)
 	{
 		FlashSectorOverlay overlay;
-		if(!makeFlashOverlay(overlay, _flashData, _factoryFlashBaseline, _romBaseline))
+		// A ROM-relative fallback must describe every sector, including a sector the
+		// user erased back to its ROM bytes. Sparse factory-relative states remain the
+		// normal compact representation once the initialized baseline is known.
+		const bool completeImage = _factoryFlashBaseline == _romBaseline;
+		if(!makeFlashOverlay(overlay, _flashData, _factoryFlashBaseline,
+			_romBaseline, completeImage))
 			return false;
 		return encodeState(_state, _patchRam, overlay, _romBaseline, _model, _type);
 	}
@@ -432,15 +438,17 @@ namespace md
 	{
 		const bool factoryRelative = _factoryFlashBaseline.size() == _overlay.flashSize
 			&& _overlay.baselineFingerprint == fingerprint(_factoryFlashBaseline);
-		// A first-run fallback state is sparse relative to the ROM so it can retain
-		// user samples without embedding a partially initialized factory baseline.
-		// On restore, its changed sectors are overlaid on the newly initialized
-		// factory image. The ROM fingerprint still binds it to the exact firmware.
+		// Older first-run fallback states are sparse relative to the ROM. New fallback
+		// states carry every sector so ROM-equal deletions are explicit and the image
+		// can be materialized before firmware starts. The ROM fingerprint still binds
+		// either representation to the exact firmware during decode.
 		const bool romRelative = _romBaseline.size() == _overlay.flashSize
 			&& _overlay.romFingerprint == fingerprint(_romBaseline)
 			&& _overlay.baselineFingerprint == _overlay.romFingerprint;
+		const bool completeImage = _overlay.sectors.size()
+			== _overlay.flashSize / g_uwFlashSectorSize;
 		if(!_overlay.valid || _factoryFlashBaseline.size() != _overlay.flashSize
-			|| (!factoryRelative && !romRelative)
+			|| (!factoryRelative && !romRelative && !completeImage)
 			|| _overlay.sectors.size() * static_cast<size_t>(g_uwFlashSectorSize)
 				!= _overlay.data.size())
 			return false;

--- a/source/elektron/md/mdLib/mdstate.cpp
+++ b/source/elektron/md/mdLib/mdstate.cpp
@@ -427,10 +427,20 @@ namespace md
 
 	bool applyFlashOverlay(std::vector<uint8_t>& _flashData,
 		const FlashSectorOverlay& _overlay,
-		const std::vector<uint8_t>& _factoryFlashBaseline)
+		const std::vector<uint8_t>& _factoryFlashBaseline,
+		const std::vector<uint8_t>& _romBaseline)
 	{
+		const bool factoryRelative = _factoryFlashBaseline.size() == _overlay.flashSize
+			&& _overlay.baselineFingerprint == fingerprint(_factoryFlashBaseline);
+		// A first-run fallback state is sparse relative to the ROM so it can retain
+		// user samples without embedding a partially initialized factory baseline.
+		// On restore, its changed sectors are overlaid on the newly initialized
+		// factory image. The ROM fingerprint still binds it to the exact firmware.
+		const bool romRelative = _romBaseline.size() == _overlay.flashSize
+			&& _overlay.romFingerprint == fingerprint(_romBaseline)
+			&& _overlay.baselineFingerprint == _overlay.romFingerprint;
 		if(!_overlay.valid || _factoryFlashBaseline.size() != _overlay.flashSize
-			|| _overlay.baselineFingerprint != fingerprint(_factoryFlashBaseline)
+			|| (!factoryRelative && !romRelative)
 			|| _overlay.sectors.size() * static_cast<size_t>(g_uwFlashSectorSize)
 				!= _overlay.data.size())
 			return false;

--- a/source/elektron/md/mdLib/mdstate.cpp
+++ b/source/elektron/md/mdLib/mdstate.cpp
@@ -15,12 +15,12 @@ namespace md
 		constexpr uint16_t g_versionWithUserFlash = 2;
 		constexpr uint16_t g_versionWithUserFlashHeaderSize = 28;
 		constexpr uint16_t g_version3 = 3;
-		constexpr uint16_t g_version3HeaderSize = 44;
+		constexpr uint16_t g_version3HeaderSize = 52;
 		constexpr uint16_t g_version3FlashFlag = 1;
 		constexpr uint32_t g_sectorEntryHeaderSize = 8;
 		constexpr std::array<uint8_t, 4> g_cacheMagic = {'M', 'D', 'F', 'C'};
-		constexpr uint16_t g_cacheVersion = 1;
-		constexpr uint16_t g_cacheHeaderSize = 28;
+		constexpr uint16_t g_cacheVersion = 2;
+		constexpr uint16_t g_cacheHeaderSize = 36;
 
 		void appendU16(std::vector<uint8_t>& _dst, const uint16_t _value)
 		{
@@ -129,6 +129,94 @@ namespace md
 			_patchRam.swap(decoded);
 			return true;
 		}
+
+		bool makeFlashOverlay(FlashSectorOverlay& _overlay,
+			const std::vector<uint8_t>& _flashData,
+			const std::vector<uint8_t>& _baseline,
+			const std::vector<uint8_t>& _romBaseline)
+		{
+			if(_flashData.size() != g_romSize || _baseline.size() != g_romSize
+				|| _romBaseline.size() != g_romSize)
+				return false;
+
+			FlashSectorOverlay overlay;
+			overlay.romFingerprint = fingerprint(_romBaseline);
+			overlay.baselineFingerprint = fingerprint(_baseline);
+			overlay.flashSize = static_cast<uint32_t>(_flashData.size());
+			for(size_t sector = 0; sector < _flashData.size() / g_uwFlashSectorSize;
+				++sector)
+			{
+				const auto offset = sector * g_uwFlashSectorSize;
+				if(std::equal(_flashData.begin() + offset,
+					_flashData.begin() + offset + g_uwFlashSectorSize,
+					_baseline.begin() + offset))
+					continue;
+				overlay.sectors.push_back(static_cast<uint16_t>(sector));
+				overlay.data.insert(overlay.data.end(), _flashData.begin() + offset,
+					_flashData.begin() + offset + g_uwFlashSectorSize);
+			}
+			overlay.valid = true;
+			_overlay = std::move(overlay);
+			return true;
+		}
+
+		bool validFlashOverlay(const FlashSectorOverlay& _overlay,
+			const std::vector<uint8_t>& _romBaseline)
+		{
+			if(!_overlay.valid || _romBaseline.size() != g_romSize
+				|| _overlay.romFingerprint != fingerprint(_romBaseline)
+				|| _overlay.flashSize != g_romSize
+				|| _overlay.sectors.size() > g_romSize / g_uwFlashSectorSize
+				|| _overlay.data.size()
+					!= _overlay.sectors.size() * static_cast<size_t>(g_uwFlashSectorSize))
+				return false;
+			for(size_t i = 0; i < _overlay.sectors.size(); ++i)
+				if(_overlay.sectors[i] >= g_romSize / g_uwFlashSectorSize
+					|| (i && _overlay.sectors[i] <= _overlay.sectors[i - 1]))
+					return false;
+			return true;
+		}
+
+		void appendFlashEntries(std::vector<uint8_t>& _dst,
+			const FlashSectorOverlay& _overlay)
+		{
+			for(size_t i = 0; i < _overlay.sectors.size(); ++i)
+			{
+				const auto dataOffset = i * static_cast<size_t>(g_uwFlashSectorSize);
+				appendU16(_dst, _overlay.sectors[i]);
+				appendU16(_dst, 0);
+				appendU32(_dst, crc32(_overlay.data.data() + dataOffset,
+					g_uwFlashSectorSize));
+				_dst.insert(_dst.end(), _overlay.data.begin() + dataOffset,
+					_overlay.data.begin() + dataOffset + g_uwFlashSectorSize);
+			}
+		}
+
+		bool decodeFlashEntries(FlashSectorOverlay& _overlay,
+			const std::vector<uint8_t>& _src, size_t _offset,
+			const uint16_t _sectorCount)
+		{
+			FlashSectorOverlay overlay = _overlay;
+			overlay.sectors.reserve(_sectorCount);
+			overlay.data.reserve(static_cast<size_t>(_sectorCount) * g_uwFlashSectorSize);
+			for(uint16_t entry = 0; entry < _sectorCount; ++entry)
+			{
+				const auto sector = readU16(_src, _offset);
+				if(readU16(_src, _offset + 2) != 0
+					|| sector >= g_romSize / g_uwFlashSectorSize
+					|| (entry && sector <= overlay.sectors.back()))
+					return false;
+				const auto* const data = _src.data() + _offset + g_sectorEntryHeaderSize;
+				if(readU32(_src, _offset + 4) != crc32(data, g_uwFlashSectorSize))
+					return false;
+				overlay.sectors.push_back(sector);
+				overlay.data.insert(overlay.data.end(), data, data + g_uwFlashSectorSize);
+				_offset += g_sectorEntryHeaderSize + g_uwFlashSectorSize;
+			}
+			overlay.valid = true;
+			_overlay = std::move(overlay);
+			return true;
+		}
 	}
 
 	bool encodeState(std::vector<uint8_t>& _state, const std::vector<uint8_t>& _patchRam,
@@ -167,34 +255,33 @@ namespace md
 	bool encodeState(std::vector<uint8_t>& _state,
 		const std::vector<uint8_t>& _patchRam,
 		const std::vector<uint8_t>& _flashData,
-		const std::vector<uint8_t>& _flashBaseline,
+		const std::vector<uint8_t>& _factoryFlashBaseline,
+		const std::vector<uint8_t>& _romBaseline,
+		const MachineModel _model, const synthLib::StateType _type)
+	{
+		FlashSectorOverlay overlay;
+		if(!makeFlashOverlay(overlay, _flashData, _factoryFlashBaseline, _romBaseline))
+			return false;
+		return encodeState(_state, _patchRam, overlay, _romBaseline, _model, _type);
+	}
+
+	bool encodeState(std::vector<uint8_t>& _state,
+		const std::vector<uint8_t>& _patchRam,
+		const FlashSectorOverlay& _flashOverlay,
+		const std::vector<uint8_t>& _romBaseline,
 		const MachineModel _model, const synthLib::StateType _type)
 	{
 		if(_model != MachineModel::Machinedrum
 			|| _patchRam.size() != g_patchRamStateSize || !validStateType(_type)
-			|| _flashData.size() != _flashBaseline.size() || _flashData.empty()
-			|| (_flashData.size() % g_uwFlashSectorSize) != 0)
+			|| !validFlashOverlay(_flashOverlay, _romBaseline)
+			|| _flashOverlay.sectors.size() > std::numeric_limits<uint16_t>::max())
 			return false;
-
-		const auto totalSectors = _flashData.size() / g_uwFlashSectorSize;
-		if(totalSectors > std::numeric_limits<uint16_t>::max())
-			return false;
-		std::vector<uint16_t> changedSectors;
-		changedSectors.reserve(totalSectors);
-		for(size_t sector = 0; sector < totalSectors; ++sector)
-		{
-			const auto offset = sector * g_uwFlashSectorSize;
-			if(!std::equal(_flashData.begin() + offset,
-				_flashData.begin() + offset + g_uwFlashSectorSize,
-				_flashBaseline.begin() + offset))
-				changedSectors.push_back(static_cast<uint16_t>(sector));
-		}
 
 		const auto originalSize = _state.size();
 		const auto entrySize = static_cast<size_t>(g_sectorEntryHeaderSize)
 			+ g_uwFlashSectorSize;
 		_state.reserve(originalSize + g_version3HeaderSize + _patchRam.size()
-			+ changedSectors.size() * entrySize);
+			+ _flashOverlay.sectors.size() * entrySize);
 		_state.insert(_state.end(), g_magic.begin(), g_magic.end());
 		appendU16(_state, g_version3);
 		appendU16(_state, g_version3HeaderSize);
@@ -203,24 +290,17 @@ namespace md
 		appendU16(_state, g_version3FlashFlag);
 		appendU32(_state, static_cast<uint32_t>(_patchRam.size()));
 		appendU32(_state, crc32(_patchRam.data(), _patchRam.size()));
-		appendU64(_state, fingerprint(_flashBaseline));
-		appendU32(_state, static_cast<uint32_t>(_flashData.size()));
+		appendU64(_state, _flashOverlay.romFingerprint);
+		appendU64(_state, _flashOverlay.baselineFingerprint);
+		appendU32(_state, _flashOverlay.flashSize);
 		appendU32(_state, g_uwFlashSectorSize);
-		appendU16(_state, static_cast<uint16_t>(changedSectors.size()));
+		appendU16(_state, static_cast<uint16_t>(_flashOverlay.sectors.size()));
 		appendU16(_state, 0);
 		const auto overlayCrcOffset = _state.size();
 		appendU32(_state, 0);
 		_state.insert(_state.end(), _patchRam.begin(), _patchRam.end());
 		const auto overlayOffset = _state.size();
-		for(const auto sector : changedSectors)
-		{
-			const auto offset = static_cast<size_t>(sector) * g_uwFlashSectorSize;
-			appendU16(_state, sector);
-			appendU16(_state, 0);
-			appendU32(_state, crc32(_flashData.data() + offset, g_uwFlashSectorSize));
-			_state.insert(_state.end(), _flashData.begin() + offset,
-				_flashData.begin() + offset + g_uwFlashSectorSize);
-		}
+		appendFlashEntries(_state, _flashOverlay);
 		const auto overlayCrc = crc32(_state.data() + overlayOffset,
 			_state.size() - overlayOffset);
 		_state[overlayCrcOffset] = static_cast<uint8_t>(overlayCrc >> 24);
@@ -287,7 +367,7 @@ namespace md
 	}
 
 	bool decodeState(DecodedState& _decoded, const std::vector<uint8_t>& _state,
-		const std::vector<uint8_t>& _flashBaseline,
+		const std::vector<uint8_t>& _romBaseline,
 		const MachineModel _expectedModel, const synthLib::StateType _expectedType)
 	{
 		if(!validStateType(_expectedType) || _state.size() < 8 || !hasMagic(_state))
@@ -309,15 +389,15 @@ namespace md
 			return false;
 
 		const auto patchSize = readU32(_state, 12);
-		const auto flashSize = readU32(_state, 28);
-		const auto sectorSize = readU32(_state, 32);
-		const auto sectorCount = readU16(_state, 36);
-		if(patchSize != g_patchRamStateSize || readU16(_state, 38) != 0
-			|| flashSize != _flashBaseline.size() || flashSize == 0
+		const auto flashSize = readU32(_state, 36);
+		const auto sectorSize = readU32(_state, 40);
+		const auto sectorCount = readU16(_state, 44);
+		if(patchSize != g_patchRamStateSize || readU16(_state, 46) != 0
+			|| _romBaseline.size() != g_romSize || flashSize != g_romSize
 			|| sectorSize != g_uwFlashSectorSize
 			|| (flashSize % sectorSize) != 0
 			|| sectorCount > flashSize / sectorSize
-			|| readU64(_state, 20) != fingerprint(_flashBaseline))
+			|| readU64(_state, 20) != fingerprint(_romBaseline))
 			return false;
 
 		const auto entrySize = static_cast<size_t>(g_sectorEntryHeaderSize) + sectorSize;
@@ -329,32 +409,44 @@ namespace md
 		if(readU32(_state, 16) != crc32(patch, patchSize))
 			return false;
 		const auto overlayOffset = static_cast<size_t>(g_version3HeaderSize) + patchSize;
-		if(readU32(_state, 40) != crc32(_state.data() + overlayOffset,
+		if(readU32(_state, 48) != crc32(_state.data() + overlayOffset,
 			_state.size() - overlayOffset))
 			return false;
 
 		DecodedState decoded;
 		decoded.patchRam.assign(patch, patch + patchSize);
-		decoded.flashData = _flashBaseline;
+		decoded.flashOverlay.romFingerprint = readU64(_state, 20);
+		decoded.flashOverlay.baselineFingerprint = readU64(_state, 28);
+		decoded.flashOverlay.flashSize = flashSize;
 		decoded.containsFlash = true;
-		size_t offset = overlayOffset;
-		uint16_t previousSector = 0;
-		for(uint16_t entry = 0; entry < sectorCount; ++entry)
-		{
-			const auto sector = readU16(_state, offset);
-			if(readU16(_state, offset + 2) != 0
-				|| sector >= flashSize / sectorSize
-				|| (entry > 0 && sector <= previousSector))
-				return false;
-			const auto* const data = _state.data() + offset + g_sectorEntryHeaderSize;
-			if(readU32(_state, offset + 4) != crc32(data, sectorSize))
-				return false;
-			std::copy_n(data, sectorSize,
-				decoded.flashData.begin() + static_cast<size_t>(sector) * sectorSize);
-			previousSector = sector;
-			offset += entrySize;
-		}
+		if(!decodeFlashEntries(decoded.flashOverlay, _state, overlayOffset, sectorCount))
+			return false;
 		_decoded = std::move(decoded);
+		return true;
+	}
+
+	bool applyFlashOverlay(std::vector<uint8_t>& _flashData,
+		const FlashSectorOverlay& _overlay,
+		const std::vector<uint8_t>& _factoryFlashBaseline)
+	{
+		if(!_overlay.valid || _factoryFlashBaseline.size() != _overlay.flashSize
+			|| _overlay.baselineFingerprint != fingerprint(_factoryFlashBaseline)
+			|| _overlay.sectors.size() * static_cast<size_t>(g_uwFlashSectorSize)
+				!= _overlay.data.size())
+			return false;
+		auto flash = _factoryFlashBaseline;
+		for(size_t i = 0; i < _overlay.sectors.size(); ++i)
+		{
+			const auto sector = _overlay.sectors[i];
+			if(sector >= flash.size() / g_uwFlashSectorSize
+				|| (i && sector <= _overlay.sectors[i - 1]))
+				return false;
+			const auto destination = static_cast<size_t>(sector) * g_uwFlashSectorSize;
+			const auto source = i * static_cast<size_t>(g_uwFlashSectorSize);
+			std::copy_n(_overlay.data.begin() + source, g_uwFlashSectorSize,
+				flash.begin() + destination);
+		}
+		_flashData.swap(flash);
 		return true;
 	}
 
@@ -362,18 +454,22 @@ namespace md
 		const std::vector<uint8_t>& _flashData,
 		const std::vector<uint8_t>& _romBaseline)
 	{
-		if(_flashData.size() != g_romSize || _romBaseline.size() != g_romSize)
+		FlashSectorOverlay overlay;
+		if(!makeFlashOverlay(overlay, _flashData, _romBaseline, _romBaseline))
 			return false;
 		const auto originalSize = _cache.size();
-		_cache.reserve(originalSize + g_cacheHeaderSize + _flashData.size());
+		_cache.reserve(originalSize + g_cacheHeaderSize + overlay.data.size()
+			+ overlay.sectors.size() * g_sectorEntryHeaderSize);
 		_cache.insert(_cache.end(), g_cacheMagic.begin(), g_cacheMagic.end());
 		appendU16(_cache, g_cacheVersion);
 		appendU16(_cache, g_cacheHeaderSize);
-		appendU64(_cache, fingerprint(_romBaseline));
+		appendU64(_cache, overlay.romFingerprint);
+		appendU64(_cache, fingerprint(_flashData));
 		appendU32(_cache, static_cast<uint32_t>(_flashData.size()));
-		appendU32(_cache, crc32(_flashData.data(), _flashData.size()));
-		appendU32(_cache, 0);
-		_cache.insert(_cache.end(), _flashData.begin(), _flashData.end());
+		appendU32(_cache, g_uwFlashSectorSize);
+		appendU16(_cache, static_cast<uint16_t>(overlay.sectors.size()));
+		appendU16(_cache, 0);
+		appendFlashEntries(_cache, overlay);
 		return true;
 	}
 
@@ -381,18 +477,32 @@ namespace md
 		const std::vector<uint8_t>& _cache,
 		const std::vector<uint8_t>& _romBaseline)
 	{
-		if(_romBaseline.size() != g_romSize
-			|| _cache.size() != static_cast<size_t>(g_cacheHeaderSize) + g_romSize
+		if(_romBaseline.size() != g_romSize || _cache.size() < g_cacheHeaderSize
 			|| !std::equal(g_cacheMagic.begin(), g_cacheMagic.end(), _cache.begin())
 			|| readU16(_cache, 4) != g_cacheVersion
 			|| readU16(_cache, 6) != g_cacheHeaderSize
 			|| readU64(_cache, 8) != fingerprint(_romBaseline)
-			|| readU32(_cache, 16) != g_romSize || readU32(_cache, 24) != 0)
+			|| readU32(_cache, 24) != g_romSize
+			|| readU32(_cache, 28) != g_uwFlashSectorSize
+			|| readU16(_cache, 34) != 0)
 			return false;
-		const auto* const payload = _cache.data() + g_cacheHeaderSize;
-		if(readU32(_cache, 20) != crc32(payload, g_romSize))
+		const auto sectorCount = readU16(_cache, 32);
+		const auto entrySize = static_cast<size_t>(g_sectorEntryHeaderSize)
+			+ g_uwFlashSectorSize;
+		if(sectorCount > g_romSize / g_uwFlashSectorSize
+			|| _cache.size() != static_cast<size_t>(g_cacheHeaderSize)
+				+ static_cast<size_t>(sectorCount) * entrySize)
 			return false;
-		std::vector<uint8_t> decoded(payload, payload + g_romSize);
+		FlashSectorOverlay overlay;
+		overlay.romFingerprint = readU64(_cache, 8);
+		overlay.baselineFingerprint = overlay.romFingerprint;
+		overlay.flashSize = g_romSize;
+		if(!decodeFlashEntries(overlay, _cache, g_cacheHeaderSize, sectorCount))
+			return false;
+		std::vector<uint8_t> decoded;
+		if(!applyFlashOverlay(decoded, overlay, _romBaseline)
+			|| fingerprint(decoded) != readU64(_cache, 16))
+			return false;
 		_flashData.swap(decoded);
 		return true;
 	}

--- a/source/elektron/md/mdLib/mdstate.cpp
+++ b/source/elektron/md/mdLib/mdstate.cpp
@@ -1,17 +1,26 @@
 #include "mdstate.h"
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
+#include <limits>
 
 namespace md
 {
 	namespace
 	{
 		constexpr std::array<uint8_t, 4> g_magic = {'M', 'D', 'S', 'T'};
-		constexpr uint16_t g_versionPatchOnly = 1;
+		constexpr uint16_t g_version1 = 1;
+		constexpr uint16_t g_version1HeaderSize = 20;
 		constexpr uint16_t g_versionWithUserFlash = 2;
-		constexpr uint16_t g_headerSizePatchOnly = 20;
-		constexpr uint16_t g_headerSizeWithUserFlash = 28;
+		constexpr uint16_t g_versionWithUserFlashHeaderSize = 28;
+		constexpr uint16_t g_version3 = 3;
+		constexpr uint16_t g_version3HeaderSize = 44;
+		constexpr uint16_t g_version3FlashFlag = 1;
+		constexpr uint32_t g_sectorEntryHeaderSize = 8;
+		constexpr std::array<uint8_t, 4> g_cacheMagic = {'M', 'D', 'F', 'C'};
+		constexpr uint16_t g_cacheVersion = 1;
+		constexpr uint16_t g_cacheHeaderSize = 28;
 
 		void appendU16(std::vector<uint8_t>& _dst, const uint16_t _value)
 		{
@@ -25,6 +34,12 @@ namespace md
 			_dst.push_back(static_cast<uint8_t>(_value >> 16));
 			_dst.push_back(static_cast<uint8_t>(_value >> 8));
 			_dst.push_back(static_cast<uint8_t>(_value));
+		}
+
+		void appendU64(std::vector<uint8_t>& _dst, const uint64_t _value)
+		{
+			appendU32(_dst, static_cast<uint32_t>(_value >> 32));
+			appendU32(_dst, static_cast<uint32_t>(_value));
 		}
 
 		uint16_t readU16(const std::vector<uint8_t>& _src, const size_t _offset)
@@ -41,6 +56,12 @@ namespace md
 				(static_cast<uint32_t>(_src[_offset + 1]) << 16) |
 				(static_cast<uint32_t>(_src[_offset + 2]) << 8) |
 				static_cast<uint32_t>(_src[_offset + 3]);
+		}
+
+		uint64_t readU64(const std::vector<uint8_t>& _src, const size_t _offset)
+		{
+			return (static_cast<uint64_t>(readU32(_src, _offset)) << 32)
+				| readU32(_src, _offset + 4);
 		}
 
 		uint32_t crc32(const uint8_t* const _data, const size_t _size)
@@ -60,10 +81,53 @@ namespace md
 			return _model == MachineModel::Monomachine ? 1 : 0;
 		}
 
+		uint64_t fingerprint(const std::vector<uint8_t>& _data)
+		{
+			uint64_t result = 14695981039346656037ull;
+			for(const auto byte : _data)
+			{
+				result ^= byte;
+				result *= 1099511628211ull;
+			}
+			return result;
+		}
+
 		bool validStateType(const synthLib::StateType _type)
 		{
 			return _type == synthLib::StateTypeGlobal ||
 				_type == synthLib::StateTypeCurrentProgram;
+		}
+
+		bool hasMagic(const std::vector<uint8_t>& _state)
+		{
+			return _state.size() >= g_magic.size()
+				&& std::equal(g_magic.begin(), g_magic.end(), _state.begin());
+		}
+
+		bool decodeVersion1(std::vector<uint8_t>& _patchRam,
+			const std::vector<uint8_t>& _state, const MachineModel _expectedModel,
+			const synthLib::StateType _expectedType)
+		{
+			if(_state.size() < g_version1HeaderSize || !hasMagic(_state)
+				|| readU16(_state, 4) != g_version1
+				|| readU16(_state, 6) != g_version1HeaderSize)
+				return false;
+			if(_state[8] != modelTag(_expectedModel)
+				|| _state[9] != static_cast<uint8_t>(_expectedType)
+				|| readU16(_state, 10) != 0)
+				return false;
+
+			const auto payloadSize = readU32(_state, 12);
+			if(payloadSize != g_patchRamStateSize
+				|| _state.size() != static_cast<size_t>(g_version1HeaderSize) + payloadSize)
+				return false;
+			const auto* const payload = _state.data() + g_version1HeaderSize;
+			if(readU32(_state, 16) != crc32(payload, payloadSize))
+				return false;
+
+			std::vector<uint8_t> decoded(payload, payload + payloadSize);
+			_patchRam.swap(decoded);
+			return true;
 		}
 	}
 
@@ -80,10 +144,10 @@ namespace md
 
 		const auto originalSize = _state.size();
 		const auto headerSize = hasUserFlash
-			? g_headerSizeWithUserFlash : g_headerSizePatchOnly;
+			? g_versionWithUserFlashHeaderSize : g_version1HeaderSize;
 		_state.reserve(originalSize + headerSize + _patchRam.size() + _userFlash.size());
 		_state.insert(_state.end(), g_magic.begin(), g_magic.end());
-		appendU16(_state, hasUserFlash ? g_versionWithUserFlash : g_versionPatchOnly);
+		appendU16(_state, hasUserFlash ? g_versionWithUserFlash : g_version1);
 		appendU16(_state, headerSize);
 		_state.push_back(modelTag(_model));
 		_state.push_back(static_cast<uint8_t>(_type));
@@ -100,6 +164,72 @@ namespace md
 		return true;
 	}
 
+	bool encodeState(std::vector<uint8_t>& _state,
+		const std::vector<uint8_t>& _patchRam,
+		const std::vector<uint8_t>& _flashData,
+		const std::vector<uint8_t>& _flashBaseline,
+		const MachineModel _model, const synthLib::StateType _type)
+	{
+		if(_model != MachineModel::Machinedrum
+			|| _patchRam.size() != g_patchRamStateSize || !validStateType(_type)
+			|| _flashData.size() != _flashBaseline.size() || _flashData.empty()
+			|| (_flashData.size() % g_uwFlashSectorSize) != 0)
+			return false;
+
+		const auto totalSectors = _flashData.size() / g_uwFlashSectorSize;
+		if(totalSectors > std::numeric_limits<uint16_t>::max())
+			return false;
+		std::vector<uint16_t> changedSectors;
+		changedSectors.reserve(totalSectors);
+		for(size_t sector = 0; sector < totalSectors; ++sector)
+		{
+			const auto offset = sector * g_uwFlashSectorSize;
+			if(!std::equal(_flashData.begin() + offset,
+				_flashData.begin() + offset + g_uwFlashSectorSize,
+				_flashBaseline.begin() + offset))
+				changedSectors.push_back(static_cast<uint16_t>(sector));
+		}
+
+		const auto originalSize = _state.size();
+		const auto entrySize = static_cast<size_t>(g_sectorEntryHeaderSize)
+			+ g_uwFlashSectorSize;
+		_state.reserve(originalSize + g_version3HeaderSize + _patchRam.size()
+			+ changedSectors.size() * entrySize);
+		_state.insert(_state.end(), g_magic.begin(), g_magic.end());
+		appendU16(_state, g_version3);
+		appendU16(_state, g_version3HeaderSize);
+		_state.push_back(modelTag(_model));
+		_state.push_back(static_cast<uint8_t>(_type));
+		appendU16(_state, g_version3FlashFlag);
+		appendU32(_state, static_cast<uint32_t>(_patchRam.size()));
+		appendU32(_state, crc32(_patchRam.data(), _patchRam.size()));
+		appendU64(_state, fingerprint(_flashBaseline));
+		appendU32(_state, static_cast<uint32_t>(_flashData.size()));
+		appendU32(_state, g_uwFlashSectorSize);
+		appendU16(_state, static_cast<uint16_t>(changedSectors.size()));
+		appendU16(_state, 0);
+		const auto overlayCrcOffset = _state.size();
+		appendU32(_state, 0);
+		_state.insert(_state.end(), _patchRam.begin(), _patchRam.end());
+		const auto overlayOffset = _state.size();
+		for(const auto sector : changedSectors)
+		{
+			const auto offset = static_cast<size_t>(sector) * g_uwFlashSectorSize;
+			appendU16(_state, sector);
+			appendU16(_state, 0);
+			appendU32(_state, crc32(_flashData.data() + offset, g_uwFlashSectorSize));
+			_state.insert(_state.end(), _flashData.begin() + offset,
+				_flashData.begin() + offset + g_uwFlashSectorSize);
+		}
+		const auto overlayCrc = crc32(_state.data() + overlayOffset,
+			_state.size() - overlayOffset);
+		_state[overlayCrcOffset] = static_cast<uint8_t>(overlayCrc >> 24);
+		_state[overlayCrcOffset + 1] = static_cast<uint8_t>(overlayCrc >> 16);
+		_state[overlayCrcOffset + 2] = static_cast<uint8_t>(overlayCrc >> 8);
+		_state[overlayCrcOffset + 3] = static_cast<uint8_t>(overlayCrc);
+		return true;
+	}
+
 	bool decodeState(std::vector<uint8_t>& _patchRam, const std::vector<uint8_t>& _state,
 		const MachineModel _expectedModel, const synthLib::StateType _expectedType)
 	{
@@ -112,21 +242,20 @@ namespace md
 		const std::vector<uint8_t>& _state, const MachineModel _expectedModel,
 		const synthLib::StateType _expectedType)
 	{
-		if(!validStateType(_expectedType) || _state.size() < g_headerSizePatchOnly)
+		if(!validStateType(_expectedType) || _state.size() < g_version1HeaderSize
+			|| !hasMagic(_state))
 			return false;
-		for(size_t i = 0; i < g_magic.size(); ++i)
-			if(_state[i] != g_magic[i])
-				return false;
+
 		const auto version = readU16(_state, 4);
 		const auto headerSize = readU16(_state, 6);
-		if((version == g_versionPatchOnly && headerSize != g_headerSizePatchOnly)
+		if((version == g_version1 && headerSize != g_version1HeaderSize)
 			|| (version == g_versionWithUserFlash
-				&& headerSize != g_headerSizeWithUserFlash)
-			|| (version != g_versionPatchOnly && version != g_versionWithUserFlash))
+				&& headerSize != g_versionWithUserFlashHeaderSize)
+			|| (version != g_version1 && version != g_versionWithUserFlash))
 			return false;
-		if(_state[8] != modelTag(_expectedModel) ||
-			_state[9] != static_cast<uint8_t>(_expectedType) ||
-			readU16(_state, 10) != 0)
+		if(_state[8] != modelTag(_expectedModel)
+			|| _state[9] != static_cast<uint8_t>(_expectedType)
+			|| readU16(_state, 10) != 0)
 			return false;
 
 		const auto patchSize = readU32(_state, 12);
@@ -154,6 +283,117 @@ namespace md
 		std::vector<uint8_t> decodedUserFlash(userFlash, userFlash + userFlashSize);
 		_patchRam.swap(decodedPatch);
 		_userFlash.swap(decodedUserFlash);
+		return true;
+	}
+
+	bool decodeState(DecodedState& _decoded, const std::vector<uint8_t>& _state,
+		const std::vector<uint8_t>& _flashBaseline,
+		const MachineModel _expectedModel, const synthLib::StateType _expectedType)
+	{
+		if(!validStateType(_expectedType) || _state.size() < 8 || !hasMagic(_state))
+			return false;
+		if(readU16(_state, 4) == g_version1)
+		{
+			DecodedState decoded;
+			if(!decodeVersion1(decoded.patchRam, _state, _expectedModel, _expectedType))
+				return false;
+			_decoded = std::move(decoded);
+			return true;
+		}
+		if(readU16(_state, 4) != g_version3 || _state.size() < g_version3HeaderSize
+			|| readU16(_state, 6) != g_version3HeaderSize
+			|| _expectedModel != MachineModel::Machinedrum
+			|| _state[8] != modelTag(_expectedModel)
+			|| _state[9] != static_cast<uint8_t>(_expectedType)
+			|| readU16(_state, 10) != g_version3FlashFlag)
+			return false;
+
+		const auto patchSize = readU32(_state, 12);
+		const auto flashSize = readU32(_state, 28);
+		const auto sectorSize = readU32(_state, 32);
+		const auto sectorCount = readU16(_state, 36);
+		if(patchSize != g_patchRamStateSize || readU16(_state, 38) != 0
+			|| flashSize != _flashBaseline.size() || flashSize == 0
+			|| sectorSize != g_uwFlashSectorSize
+			|| (flashSize % sectorSize) != 0
+			|| sectorCount > flashSize / sectorSize
+			|| readU64(_state, 20) != fingerprint(_flashBaseline))
+			return false;
+
+		const auto entrySize = static_cast<size_t>(g_sectorEntryHeaderSize) + sectorSize;
+		const auto expectedSize = static_cast<size_t>(g_version3HeaderSize) + patchSize
+			+ static_cast<size_t>(sectorCount) * entrySize;
+		if(_state.size() != expectedSize)
+			return false;
+		const auto* const patch = _state.data() + g_version3HeaderSize;
+		if(readU32(_state, 16) != crc32(patch, patchSize))
+			return false;
+		const auto overlayOffset = static_cast<size_t>(g_version3HeaderSize) + patchSize;
+		if(readU32(_state, 40) != crc32(_state.data() + overlayOffset,
+			_state.size() - overlayOffset))
+			return false;
+
+		DecodedState decoded;
+		decoded.patchRam.assign(patch, patch + patchSize);
+		decoded.flashData = _flashBaseline;
+		decoded.containsFlash = true;
+		size_t offset = overlayOffset;
+		uint16_t previousSector = 0;
+		for(uint16_t entry = 0; entry < sectorCount; ++entry)
+		{
+			const auto sector = readU16(_state, offset);
+			if(readU16(_state, offset + 2) != 0
+				|| sector >= flashSize / sectorSize
+				|| (entry > 0 && sector <= previousSector))
+				return false;
+			const auto* const data = _state.data() + offset + g_sectorEntryHeaderSize;
+			if(readU32(_state, offset + 4) != crc32(data, sectorSize))
+				return false;
+			std::copy_n(data, sectorSize,
+				decoded.flashData.begin() + static_cast<size_t>(sector) * sectorSize);
+			previousSector = sector;
+			offset += entrySize;
+		}
+		_decoded = std::move(decoded);
+		return true;
+	}
+
+	bool encodeFactoryFlashCache(std::vector<uint8_t>& _cache,
+		const std::vector<uint8_t>& _flashData,
+		const std::vector<uint8_t>& _romBaseline)
+	{
+		if(_flashData.size() != g_romSize || _romBaseline.size() != g_romSize)
+			return false;
+		const auto originalSize = _cache.size();
+		_cache.reserve(originalSize + g_cacheHeaderSize + _flashData.size());
+		_cache.insert(_cache.end(), g_cacheMagic.begin(), g_cacheMagic.end());
+		appendU16(_cache, g_cacheVersion);
+		appendU16(_cache, g_cacheHeaderSize);
+		appendU64(_cache, fingerprint(_romBaseline));
+		appendU32(_cache, static_cast<uint32_t>(_flashData.size()));
+		appendU32(_cache, crc32(_flashData.data(), _flashData.size()));
+		appendU32(_cache, 0);
+		_cache.insert(_cache.end(), _flashData.begin(), _flashData.end());
+		return true;
+	}
+
+	bool decodeFactoryFlashCache(std::vector<uint8_t>& _flashData,
+		const std::vector<uint8_t>& _cache,
+		const std::vector<uint8_t>& _romBaseline)
+	{
+		if(_romBaseline.size() != g_romSize
+			|| _cache.size() != static_cast<size_t>(g_cacheHeaderSize) + g_romSize
+			|| !std::equal(g_cacheMagic.begin(), g_cacheMagic.end(), _cache.begin())
+			|| readU16(_cache, 4) != g_cacheVersion
+			|| readU16(_cache, 6) != g_cacheHeaderSize
+			|| readU64(_cache, 8) != fingerprint(_romBaseline)
+			|| readU32(_cache, 16) != g_romSize || readU32(_cache, 24) != 0)
+			return false;
+		const auto* const payload = _cache.data() + g_cacheHeaderSize;
+		if(readU32(_cache, 20) != crc32(payload, g_romSize))
+			return false;
+		std::vector<uint8_t> decoded(payload, payload + g_romSize);
+		_flashData.swap(decoded);
 		return true;
 	}
 }

--- a/source/elektron/md/mdLib/mdstate.h
+++ b/source/elektron/md/mdLib/mdstate.h
@@ -11,6 +11,14 @@ namespace md
 {
 	constexpr uint32_t g_patchRamStateSize = 0x100000;
 	constexpr uint32_t g_mmUserFlashStateSize = 0x200000;
+	constexpr uint32_t g_uwFlashSectorSize = 0x10000;
+
+	struct DecodedState
+	{
+		std::vector<uint8_t> patchRam;
+		std::vector<uint8_t> flashData;
+		bool containsFlash = false;
+	};
 
 	// Append a self-describing patch-RAM image to _state. The synthLib plugin wrapper may
 	// already have placed its own two-byte envelope in the vector, so this function does
@@ -19,10 +27,37 @@ namespace md
 		MachineModel _model, synthLib::StateType _type,
 		const std::vector<uint8_t>& _userFlash = {});
 
+	// Machinedrum UW state extends the patch-RAM snapshot with complete changed
+	// flash sectors relative to the immutable firmware image. Keeping the baseline
+	// outside the state avoids embedding copyrighted firmware while making every
+	// user-programmed sector project-owned and independent of machine-local caches.
+	// DSP RAM-machine recordings remain volatile, matching the hardware: users can
+	// copy a recording to a ROM slot when it must survive a reboot/project reload.
+	bool encodeState(std::vector<uint8_t>& _state, const std::vector<uint8_t>& _patchRam,
+		const std::vector<uint8_t>& _flashData,
+		const std::vector<uint8_t>& _flashBaseline,
+		MachineModel _model, synthLib::StateType _type);
+
 	// Validate and decode a device payload. No output is changed on failure.
 	bool decodeState(std::vector<uint8_t>& _patchRam, const std::vector<uint8_t>& _state,
 		MachineModel _expectedModel, synthLib::StateType _expectedType);
 	bool decodeState(std::vector<uint8_t>& _patchRam, std::vector<uint8_t>& _userFlash,
 		const std::vector<uint8_t>& _state, MachineModel _expectedModel,
 		synthLib::StateType _expectedType);
+
+	// Decode either the legacy version-1 patch-RAM format or version 3. Version 3
+	// reconstructs flash from _flashBaseline plus its validated sparse sector set.
+	// No output is changed on failure.
+	bool decodeState(DecodedState& _decoded, const std::vector<uint8_t>& _state,
+		const std::vector<uint8_t>& _flashBaseline,
+		MachineModel _expectedModel, synthLib::StateType _expectedType);
+
+	// A machine-local full-flash cache is only a boot optimization. Its format is
+	// deliberately separate from the project-owned sparse MDST v3 payload.
+	bool encodeFactoryFlashCache(std::vector<uint8_t>& _cache,
+		const std::vector<uint8_t>& _flashData,
+		const std::vector<uint8_t>& _romBaseline);
+	bool decodeFactoryFlashCache(std::vector<uint8_t>& _flashData,
+		const std::vector<uint8_t>& _cache,
+		const std::vector<uint8_t>& _romBaseline);
 }

--- a/source/elektron/md/mdLib/mdstate.h
+++ b/source/elektron/md/mdLib/mdstate.h
@@ -13,10 +13,20 @@ namespace md
 	constexpr uint32_t g_mmUserFlashStateSize = 0x200000;
 	constexpr uint32_t g_uwFlashSectorSize = 0x10000;
 
+	struct FlashSectorOverlay
+	{
+		uint64_t romFingerprint = 0;
+		uint64_t baselineFingerprint = 0;
+		uint32_t flashSize = 0;
+		std::vector<uint16_t> sectors;
+		std::vector<uint8_t> data;
+		bool valid = false;
+	};
+
 	struct DecodedState
 	{
 		std::vector<uint8_t> patchRam;
-		std::vector<uint8_t> flashData;
+		FlashSectorOverlay flashOverlay;
 		bool containsFlash = false;
 	};
 
@@ -27,15 +37,19 @@ namespace md
 		MachineModel _model, synthLib::StateType _type,
 		const std::vector<uint8_t>& _userFlash = {});
 
-	// Machinedrum UW state extends the patch-RAM snapshot with complete changed
-	// flash sectors relative to the immutable firmware image. Keeping the baseline
-	// outside the state avoids embedding copyrighted firmware while making every
-	// user-programmed sector project-owned and independent of machine-local caches.
+	// Machinedrum UW state extends the patch-RAM snapshot with sectors that differ
+	// from the initialized factory-flash baseline. The matching ROM and factory
+	// baseline are identified by fingerprints and remain outside project state.
 	// DSP RAM-machine recordings remain volatile, matching the hardware: users can
 	// copy a recording to a ROM slot when it must survive a reboot/project reload.
 	bool encodeState(std::vector<uint8_t>& _state, const std::vector<uint8_t>& _patchRam,
 		const std::vector<uint8_t>& _flashData,
-		const std::vector<uint8_t>& _flashBaseline,
+		const std::vector<uint8_t>& _factoryFlashBaseline,
+		const std::vector<uint8_t>& _romBaseline,
+		MachineModel _model, synthLib::StateType _type);
+	bool encodeState(std::vector<uint8_t>& _state, const std::vector<uint8_t>& _patchRam,
+		const FlashSectorOverlay& _flashOverlay,
+		const std::vector<uint8_t>& _romBaseline,
 		MachineModel _model, synthLib::StateType _type);
 
 	// Validate and decode a device payload. No output is changed on failure.
@@ -46,14 +60,17 @@ namespace md
 		synthLib::StateType _expectedType);
 
 	// Decode either the legacy version-1 patch-RAM format or version 3. Version 3
-	// reconstructs flash from _flashBaseline plus its validated sparse sector set.
+	// retains a validated sparse overlay until its factory baseline is available.
 	// No output is changed on failure.
 	bool decodeState(DecodedState& _decoded, const std::vector<uint8_t>& _state,
-		const std::vector<uint8_t>& _flashBaseline,
+		const std::vector<uint8_t>& _romBaseline,
 		MachineModel _expectedModel, synthLib::StateType _expectedType);
+	bool applyFlashOverlay(std::vector<uint8_t>& _flashData,
+		const FlashSectorOverlay& _overlay,
+		const std::vector<uint8_t>& _factoryFlashBaseline);
 
-	// A machine-local full-flash cache is only a boot optimization. Its format is
-	// deliberately separate from the project-owned sparse MDST v3 payload.
+	// The machine-local factory cache stores only initialized sectors that differ
+	// from the matching ROM. Its format is separate from project state.
 	bool encodeFactoryFlashCache(std::vector<uint8_t>& _cache,
 		const std::vector<uint8_t>& _flashData,
 		const std::vector<uint8_t>& _romBaseline);

--- a/source/elektron/md/mdLib/mdstate.h
+++ b/source/elektron/md/mdLib/mdstate.h
@@ -40,6 +40,8 @@ namespace md
 	// Machinedrum UW state extends the patch-RAM snapshot with sectors that differ
 	// from the initialized factory-flash baseline. The matching ROM and factory
 	// baseline are identified by fingerprints and remain outside project state.
+	// Before a local factory baseline exists, state may instead carry all sectors
+	// that differ from the ROM; restore overlays them after factory initialization.
 	// DSP RAM-machine recordings remain volatile, matching the hardware: users can
 	// copy a recording to a ROM slot when it must survive a reboot/project reload.
 	bool encodeState(std::vector<uint8_t>& _state, const std::vector<uint8_t>& _patchRam,
@@ -67,7 +69,8 @@ namespace md
 		MachineModel _expectedModel, synthLib::StateType _expectedType);
 	bool applyFlashOverlay(std::vector<uint8_t>& _flashData,
 		const FlashSectorOverlay& _overlay,
-		const std::vector<uint8_t>& _factoryFlashBaseline);
+		const std::vector<uint8_t>& _factoryFlashBaseline,
+		const std::vector<uint8_t>& _romBaseline = {});
 
 	// The machine-local factory cache stores only initialized sectors that differ
 	// from the matching ROM. Its format is separate from project state.

--- a/source/elektron/md/mdLib/mdstate.h
+++ b/source/elektron/md/mdLib/mdstate.h
@@ -40,8 +40,9 @@ namespace md
 	// Machinedrum UW state extends the patch-RAM snapshot with sectors that differ
 	// from the initialized factory-flash baseline. The matching ROM and factory
 	// baseline are identified by fingerprints and remain outside project state.
-	// Before a local factory baseline exists, state may instead carry all sectors
-	// that differ from the ROM; restore overlays them after factory initialization.
+	// Before a local factory baseline exists, state carries a complete sector image.
+	// This also represents sectors erased back to ROM bytes and can restore without
+	// waiting for a new machine to repeat factory initialization.
 	// DSP RAM-machine recordings remain volatile, matching the hardware: users can
 	// copy a recording to a ROM slot when it must survive a reboot/project reload.
 	bool encodeState(std::vector<uint8_t>& _state, const std::vector<uint8_t>& _patchRam,

--- a/source/elektron/md/mdLib/mdsysexautomation.cpp
+++ b/source/elektron/md/mdLib/mdsysexautomation.cpp
@@ -113,6 +113,25 @@ namespace md::automation::sysex
 		return request(_model, g_kitRequest, _slot);
 	}
 
+	bool isReadOnlyRequest(const MachineModel _model, const MessageView _message)
+	{
+		if(_message.size() != 9 || _message[7] > 0x7f)
+			return false;
+		switch(_message[6])
+		{
+		case g_globalRequest:
+		case g_kitRequest:
+			return hasHeader(_model, _message, _message[6]);
+		case g_statusRequest:
+			return hasHeader(_model, _message, g_statusRequest)
+				&& (_message[7] == static_cast<uint8_t>(StatusParameter::Global)
+					|| _message[7] == static_cast<uint8_t>(StatusParameter::Kit)
+					|| _message[7] == static_cast<uint8_t>(StatusParameter::Pattern));
+		default:
+			return false;
+		}
+	}
+
 	std::optional<StatusResponse> parseStatusResponse(const MachineModel _model,
 		const MessageView _message)
 	{

--- a/source/elektron/md/mdLib/mdsysexautomation.h
+++ b/source/elektron/md/mdLib/mdsysexautomation.h
@@ -43,6 +43,9 @@ namespace md::automation::sysex
 	Message statusRequest(MachineModel _model, StatusParameter _parameter);
 	Message globalRequest(MachineModel _model, uint8_t _slot);
 	Message kitRequest(MachineModel _model, uint8_t _slot);
+	// These requests only inspect firmware state. They may be sent while the UW
+	// factory image is being learned without making that image user-modified.
+	bool isReadOnlyRequest(MachineModel _model, MessageView _message);
 
 	std::optional<StatusResponse> parseStatusResponse(MachineModel _model,
 		MessageView _message);

--- a/source/elektron/md/mdLib/profile/mdprofileaccess.h
+++ b/source/elektron/md/mdLib/profile/mdprofileaccess.h
@@ -16,7 +16,8 @@ namespace md
 			const std::vector<uint8_t>& _image, const MachineModel _model)
 		{
 			return std::unique_ptr<Hardware>(
-				new Hardware(true, _image, "generated-profile-input", _model, {}, {}, {}, {}));
+				new Hardware(true, _image, "generated-profile-input", _model,
+					{}, {}, {}, {}, {}, {}));
 		}
 	};
 }

--- a/source/elektron/md/mdLibTest/CMakeLists.txt
+++ b/source/elektron/md/mdLibTest/CMakeLists.txt
@@ -41,3 +41,7 @@ target_link_libraries(mdAutomationMidiTest PRIVATE mdLib)
 add_test(NAME mdAutomationMidiTest COMMAND mdAutomationMidiTest)
 set_tests_properties(mdAutomationMidiTest PROPERTIES LABELS "UnitTest")
 set_property(TARGET mdAutomationMidiTest PROPERTY FOLDER "Elektron")
+
+add_executable(mdUwFirmwareTest mdUwFirmwareTest.cpp)
+target_link_libraries(mdUwFirmwareTest PRIVATE mdLib)
+set_property(TARGET mdUwFirmwareTest PROPERTY FOLDER "Elektron")

--- a/source/elektron/md/mdLibTest/automationMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/automationMidiTest.cpp
@@ -1,6 +1,7 @@
 #include "mdLib/mdautomation.h"
 #include "mdLib/mdsysexautomation.h"
 #include "synthLib/midiBufferParser.h"
+#include "synthLib/midiRoutingMatrix.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -225,6 +226,27 @@ namespace
 			&& parsed->value == 0x37, "could not parse status response");
 		require(!parseStatusResponse(md::MachineModel::Machinedrum, response),
 			"accepted status response for the wrong product");
+
+		for(const auto& request : {
+			statusRequest(md::MachineModel::Machinedrum, StatusParameter::Global),
+			globalRequest(md::MachineModel::Machinedrum, 3),
+			kitRequest(md::MachineModel::Machinedrum, 12)})
+		{
+			require(isReadOnlyRequest(md::MachineModel::Machinedrum, request),
+				"controller query was not classified as read-only");
+			synthLib::SMidiEvent routed(synthLib::MidiEventSource::Editor);
+			routed.sysex.assign(request.begin(), request.end());
+			require(synthLib::MidiRoutingMatrix().enabled(routed,
+				synthLib::MidiEventSource::Device),
+				"controller query is not routed to the device by default");
+		}
+		const Message setStatus{0xf0, 0x00, 0x20, 0x3c, 0x02, 0x00,
+			0x71, 0x02, 0x01, 0xf7};
+		require(!isReadOnlyRequest(md::MachineModel::Machinedrum, setStatus),
+			"state-changing status message was classified as read-only");
+		require(!isReadOnlyRequest(md::MachineModel::Monomachine,
+			statusRequest(md::MachineModel::Machinedrum, StatusParameter::Kit)),
+			"wrong-product query was classified as read-only");
 	}
 
 	void testMidiRunningStatus()

--- a/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
+++ b/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
@@ -99,8 +99,17 @@ int main(const int argc, const char* const* argv)
 		initializer.processUC();
 	if(!initializer.flashDirty())
 		return fail("firmware did not initialize UW flash");
+	for(uint32_t instruction = 0;
+		instruction < 100'000'000 && !initializer.factoryFlashCacheReady();
+		++instruction)
+		initializer.processUC();
+	if(!initializer.factoryFlashCacheReady())
+		return fail("completed UW initializer was not eligible for the factory cache");
 
 	const auto initializedFlash = initializer.copyFlashData();
+	initializer.sendPanelEvent(0x20, 0);
+	if(initializer.factoryFlashCacheReady())
+		return fail("host interaction did not disqualify the factory cache snapshot");
 	md::Hardware hardware(rom, argv[1], md::MachineModel::Machinedrum,
 		{}, {}, {}, initializedFlash);
 	advance(hardware, md::g_samplerate * 20);

--- a/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
+++ b/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <cstdint>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <iterator>
 #include <vector>
@@ -40,20 +41,32 @@ namespace
 		return true;
 	}
 
-	bool initializeUwFlash(md::Hardware& _hardware)
+	bool initializeUwFlash(md::Hardware& _hardware,
+		const std::function<void(md::Hardware&)>& _observe = {},
+		const std::function<void(md::Hardware&)>& _beforeCapture = {})
 	{
 		advance(_hardware, md::g_samplerate * 5);
-		if(_hardware.factoryFlashCacheReady())
+		if(_hardware.isFactoryFlashCacheReady())
 			return true;
 		for(uint32_t instruction = 0; instruction < 200'000'000; ++instruction)
 			_hardware.processUC();
 		for(uint32_t instruction = 0; instruction < 100'000'000; ++instruction)
 		{
 			_hardware.processUC();
-			if((instruction & 1023u) == 0 && _hardware.factoryFlashCacheReady())
-				return true;
+			if((instruction & 1023u) == 0)
+			{
+				if(_beforeCapture)
+					_beforeCapture(_hardware);
+				// Zero-frame advances still run the bounded capture/publication tail,
+				// exercising the same state machine used by an audio callback.
+				_hardware.advance(0);
+				if(_observe)
+					_observe(_hardware);
+				if(_hardware.isFactoryFlashCacheReady())
+					return true;
+			}
 		}
-		return _hardware.factoryFlashCacheReady();
+		return _hardware.isFactoryFlashCacheReady();
 	}
 
 	void sendSysex(md::Hardware& _hardware,
@@ -125,8 +138,12 @@ int main(const int argc, const char* const* argv)
 	// allowing them into the factory cache.
 	auto projectFlash = initializedFlash;
 	projectFlash[6 * md::g_uwFlashSectorSize + 123] ^= 0x5a;
+	projectFlash[10 * md::g_uwFlashSectorSize + 321] ^= 0x33;
+	auto projectPatch = initializer.copyPatchRam();
+	projectPatch.front() ^= 0x6d;
+	projectPatch.back() ^= 0x27;
 	std::vector<uint8_t> projectState;
-	if(!md::encodeState(projectState, initializer.copyPatchRam(), projectFlash,
+	if(!md::encodeState(projectState, projectPatch, projectFlash,
 		initializedFlash, rom, md::MachineModel::Machinedrum,
 		synthLib::StateTypeGlobal))
 		return fail("could not encode deferred UW project flash");
@@ -140,7 +157,32 @@ int main(const int argc, const char* const* argv)
 	if(!deferred.copyPendingFlashOverlay(pendingCheck)
 		|| pendingCheck.data != decodedProject.flashOverlay.data)
 		return fail("deferred UW project flash was not queued");
-	const auto deferredInitialized = initializeUwFlash(deferred);
+	bool partialStateObserved = false;
+	bool synchronousRestoreObserved = false;
+	std::vector<uint8_t> preRestorePatch;
+	constexpr uint64_t ucClockHz = 40'000'000;
+	const auto deferredInitialized = initializeUwFlash(deferred,
+		[&](md::Hardware& _current)
+		{
+			const auto& uc = _current.getUC();
+			if(uc.getCycles() < ucClockHz * 10
+				|| uc.flashIdleCycles() < ucClockHz * 2)
+				return;
+			const auto flash = _current.copyFlashData();
+			if(flash != initializedFlash && flash != projectFlash)
+				partialStateObserved = true;
+			const auto livePatch = uc.copyPatchRam();
+			if(preRestorePatch.empty())
+				preRestorePatch = livePatch;
+			else if(livePatch != preRestorePatch && livePatch != projectPatch)
+				partialStateObserved = true;
+		},
+		[&](md::Hardware& _current)
+		{
+			// Queries must not revive the old synchronous full-image restore path.
+			if(_current.factoryFlashCacheReady())
+				synchronousRestoreObserved = true;
+		});
 	const auto deferredFlash = deferred.copyFlashData();
 	if(deferredFlash != projectFlash)
 	{
@@ -153,7 +195,10 @@ int main(const int argc, const char* const* argv)
 				break;
 			}
 	}
-	if(!deferredInitialized || !deferred.isValid() || deferredFlash != projectFlash)
+	if(!deferredInitialized || !deferred.isValid() || partialStateObserved
+		|| synchronousRestoreObserved
+		|| deferredFlash != projectFlash
+		|| deferred.getUC().copyPatchRam() != projectPatch)
 		return fail("deferred UW project flash was not restored after initialization");
 	std::vector<uint8_t> deferredFactory;
 	const auto deferredCache = deferred.copyFactoryFlashCache();

--- a/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
+++ b/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
@@ -40,6 +40,22 @@ namespace
 		return true;
 	}
 
+	bool initializeUwFlash(md::Hardware& _hardware)
+	{
+		advance(_hardware, md::g_samplerate * 5);
+		if(_hardware.factoryFlashCacheReady())
+			return true;
+		for(uint32_t instruction = 0; instruction < 200'000'000; ++instruction)
+			_hardware.processUC();
+		for(uint32_t instruction = 0; instruction < 100'000'000; ++instruction)
+		{
+			_hardware.processUC();
+			if((instruction & 1023u) == 0 && _hardware.factoryFlashCacheReady())
+				return true;
+		}
+		return _hardware.factoryFlashCacheReady();
+	}
+
 	void sendSysex(md::Hardware& _hardware,
 		const std::initializer_list<uint8_t> _bytes)
 	{
@@ -90,28 +106,63 @@ int main(const int argc, const char* const* argv)
 	if(!initializer.isValid())
 		return fail("firmware is not the supported Machinedrum OS 1.63 image");
 
-	// A pristine MAME-compatible dump contains the compressed factory bank and
-	// blank UW sample sectors. Run the firmware's one-time initializer without
-	// real-time DSP background slices, then verify the persisted result on a
-	// normal, freshly booted machine.
-	advance(initializer, md::g_samplerate * 5);
-	for(uint32_t instruction = 0; instruction < 200'000'000; ++instruction)
-		initializer.processUC();
+	// Boot once to let the firmware prepare UW flash, then verify the resulting
+	// factory baseline on a normal, freshly booted machine.
+	const auto initialized = initializeUwFlash(initializer);
 	if(!initializer.flashDirty())
 		return fail("firmware did not initialize UW flash");
-	for(uint32_t instruction = 0;
-		instruction < 100'000'000 && !initializer.factoryFlashCacheReady();
-		++instruction)
-		initializer.processUC();
-	if(!initializer.factoryFlashCacheReady())
+	if(!initialized)
 		return fail("completed UW initializer was not eligible for the factory cache");
 
 	const auto initializedFlash = initializer.copyFlashData();
-	initializer.sendPanelEvent(0x20, 0);
-	if(initializer.factoryFlashCacheReady())
-		return fail("host interaction did not disqualify the factory cache snapshot");
+	std::vector<uint8_t> factoryCache;
+	if(!md::encodeFactoryFlashCache(factoryCache, initializedFlash, rom)
+		|| factoryCache.size() >= rom.size())
+		return fail("UW factory cache was not sparse");
+
+	// A project may arrive before this machine has a local factory cache. Keep its
+	// user sectors pending until initialization completes, then apply them without
+	// allowing them into the factory cache.
+	auto projectFlash = initializedFlash;
+	projectFlash[6 * md::g_uwFlashSectorSize + 123] ^= 0x5a;
+	std::vector<uint8_t> projectState;
+	if(!md::encodeState(projectState, initializer.copyPatchRam(), projectFlash,
+		initializedFlash, rom, md::MachineModel::Machinedrum,
+		synthLib::StateTypeGlobal))
+		return fail("could not encode deferred UW project flash");
+	md::DecodedState decodedProject;
+	if(!md::decodeState(decodedProject, projectState, rom,
+		md::MachineModel::Machinedrum, synthLib::StateTypeGlobal))
+		return fail("could not decode deferred UW project flash");
+	md::Hardware deferred(rom, argv[1], md::MachineModel::Machinedrum,
+		decodedProject.patchRam, {}, {}, {}, {}, decodedProject.flashOverlay);
+	md::FlashSectorOverlay pendingCheck;
+	if(!deferred.copyPendingFlashOverlay(pendingCheck)
+		|| pendingCheck.data != decodedProject.flashOverlay.data)
+		return fail("deferred UW project flash was not queued");
+	const auto deferredInitialized = initializeUwFlash(deferred);
+	const auto deferredFlash = deferred.copyFlashData();
+	if(deferredFlash != projectFlash)
+	{
+		for(size_t i = 0; i < deferredFlash.size(); ++i)
+			if(deferredFlash[i] != projectFlash[i])
+			{
+				std::cerr << "first deferred flash mismatch at " << i
+					<< ": got " << static_cast<uint32_t>(deferredFlash[i])
+					<< ", expected " << static_cast<uint32_t>(projectFlash[i]) << '\n';
+				break;
+			}
+	}
+	if(!deferredInitialized || !deferred.isValid() || deferredFlash != projectFlash)
+		return fail("deferred UW project flash was not restored after initialization");
+	std::vector<uint8_t> deferredFactory;
+	const auto deferredCache = deferred.copyFactoryFlashCache();
+	if(!md::decodeFactoryFlashCache(deferredFactory, deferredCache, rom)
+		|| deferredFactory != initializedFlash)
+		return fail("deferred project data contaminated the UW factory cache");
+
 	md::Hardware hardware(rom, argv[1], md::MachineModel::Machinedrum,
-		{}, {}, {}, initializedFlash);
+		{}, {}, {}, initializedFlash, factoryCache);
 	advance(hardware, md::g_samplerate * 20);
 
 	if(!tap(hardware, md::PanelControl::Kit)

--- a/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
+++ b/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
@@ -1,0 +1,132 @@
+#include "mdLib/mdhardware.h"
+#include "mdLib/mdpanel.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <vector>
+
+namespace
+{
+	void advance(md::Hardware& _hardware, const uint32_t _frames)
+	{
+		constexpr uint32_t block = 128;
+		for(uint32_t frames = 0; frames < _frames; frames += block)
+			_hardware.advance(std::min(block, _frames - frames));
+	}
+
+	bool tap(md::Hardware& _hardware, const md::PanelControl _control)
+	{
+		const auto packet = md::panelPacket(md::MachineModel::Machinedrum, _control);
+		if(!packet)
+			return false;
+		_hardware.sendPanelEvent(packet->row, packet->mask);
+		advance(_hardware, 2048);
+		_hardware.sendPanelEvent(packet->row, 0);
+		advance(_hardware, 4096);
+		return true;
+	}
+
+	bool sameLcd(const md::FrontPanel& _a, const md::FrontPanel& _b)
+	{
+		for(uint32_t y = 0; y < md::FrontPanel::g_lcdHeight; ++y)
+			for(uint32_t x = 0; x < md::FrontPanel::g_lcdWidth; ++x)
+				if(_a.getLcdPixel(x, y) != _b.getLcdPixel(x, y))
+					return false;
+		return true;
+	}
+
+	int fail(const char* const _message)
+	{
+		std::cerr << _message << '\n';
+		return 1;
+	}
+}
+
+int main(const int argc, const char* const* argv)
+{
+	if(argc != 2)
+	{
+		std::cerr << "usage: mdUwFirmwareTest <elektron_sps1-1uw_os1.63.bin>\n";
+		return 2;
+	}
+
+	std::ifstream input(argv[1], std::ios::binary);
+	const std::vector<uint8_t> rom{
+		std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+	md::Hardware initializer(rom, argv[1], md::MachineModel::Machinedrum);
+	if(!initializer.isValid())
+		return fail("firmware is not the supported Machinedrum OS 1.63 image");
+
+	// A pristine MAME-compatible dump contains the compressed factory bank and
+	// blank UW sample sectors. Run the firmware's one-time initializer without
+	// real-time DSP background slices, then verify the persisted result on a
+	// normal, freshly booted machine.
+	advance(initializer, md::g_samplerate * 5);
+	for(uint32_t instruction = 0; instruction < 200'000'000; ++instruction)
+		initializer.processUC();
+	if(!initializer.flashDirty())
+		return fail("firmware did not initialize UW flash");
+
+	const auto initializedFlash = initializer.copyFlashData();
+	md::Hardware hardware(rom, argv[1], md::MachineModel::Machinedrum,
+		{}, {}, {}, initializedFlash);
+	advance(hardware, md::g_samplerate * 20);
+
+	if(!tap(hardware, md::PanelControl::Kit)
+		|| !tap(hardware, md::PanelControl::Down)
+		|| !tap(hardware, md::PanelControl::Enter))
+		return fail("failed to enter the machine picker");
+
+	for(uint32_t family = 0; family < 6; ++family)
+		if(!tap(hardware, md::PanelControl::Down))
+			return fail("failed to navigate to CTR");
+	const auto ctr = hardware.getFrontPanelSnapshot();
+
+	tap(hardware, md::PanelControl::Down);
+	const auto romFamily = hardware.getFrontPanelSnapshot();
+	tap(hardware, md::PanelControl::Down);
+	const auto ramFamily = hardware.getFrontPanelSnapshot();
+	tap(hardware, md::PanelControl::Down);
+	const auto afterRam = hardware.getFrontPanelSnapshot();
+	if(sameLcd(ctr, romFamily) || sameLcd(romFamily, ramFamily)
+		|| !sameLcd(ramFamily, afterRam))
+		return fail("ROM/RAM machine families were not exposed in the expected order");
+
+	// Return to ROM, select its current factory sample, assign it to track 1,
+	// and prove that the resulting machine reaches the audio output.
+	tap(hardware, md::PanelControl::Up);
+	tap(hardware, md::PanelControl::Right);
+	tap(hardware, md::PanelControl::Enter);
+	const auto trigger = md::panelPacket(md::MachineModel::Machinedrum,
+		md::PanelControl::Trigger1);
+	if(!trigger)
+		return fail("trigger 1 has no panel mapping");
+
+	std::array<std::vector<float>, 2> rendered{
+		std::vector<float>(8192), std::vector<float>(8192)};
+	synthLib::TAudioOutputs outputs{};
+	outputs[0] = rendered[0].data();
+	outputs[1] = rendered[1].data();
+	hardware.sendPanelEvent(trigger->row, trigger->mask);
+	hardware.processAudio(outputs, 4096, 0);
+	hardware.sendPanelEvent(trigger->row, 0);
+	outputs[0] += 4096;
+	outputs[1] += 4096;
+	hardware.processAudio(outputs, 4096, 0);
+
+	float peak = 0.0f;
+	for(const auto& channel : rendered)
+		for(const auto sample : channel)
+			peak = std::max(peak, std::abs(sample));
+	if(peak < 0.001f)
+		return fail("factory ROM machine produced no audible output");
+
+	std::cout << "Machinedrum UW ROM/RAM firmware test passed; ROM peak="
+		<< peak << '\n';
+	return 0;
+}

--- a/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
+++ b/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
@@ -40,6 +40,34 @@ namespace
 		return true;
 	}
 
+	void sendSysex(md::Hardware& _hardware,
+		const std::initializer_list<uint8_t> _bytes)
+	{
+		synthLib::SMidiEvent event(synthLib::MidiEventSource::Host);
+		event.sysex.assign(_bytes.begin(), _bytes.end());
+		_hardware.sendMidi(event);
+		advance(_hardware, 8192);
+	}
+
+	void assignUwMachine(md::Hardware& _hardware, const uint8_t _track,
+		const uint8_t _machine)
+	{
+		// Machinedrum OS 1.63 manual, Appendix C: assign machine. The final
+		// argument selects the SPS-1UW machine table (ROM/RAM IDs 0..63).
+		sendSysex(_hardware,
+			{0xf0, 0x00, 0x20, 0x3c, 0x02, 0x00, 0x5b,
+				_track, _machine, 0x01, 0xf7});
+	}
+
+	void setTrack1Parameter(md::Hardware& _hardware, const uint8_t _parameter,
+		const uint8_t _value)
+	{
+		_hardware.sendMidi({synthLib::MidiEventSource::Host,
+			synthLib::M_CONTROLCHANGE, static_cast<uint8_t>(0x10 + _parameter),
+			_value});
+		advance(_hardware, 4096);
+	}
+
 	int fail(const char* const _message)
 	{
 		std::cerr << _message << '\n';
@@ -102,6 +130,7 @@ int main(const int argc, const char* const* argv)
 	tap(hardware, md::PanelControl::Up);
 	tap(hardware, md::PanelControl::Right);
 	tap(hardware, md::PanelControl::Enter);
+	tap(hardware, md::PanelControl::Exit);
 	const auto trigger = md::panelPacket(md::MachineModel::Machinedrum,
 		md::PanelControl::Trigger1);
 	if(!trigger)
@@ -126,7 +155,90 @@ int main(const int argc, const char* const* argv)
 	if(peak < 0.001f)
 		return fail("factory ROM machine produced no audible output");
 
+	// Assign the paired RAM recorder/player from the OS 1.63 UW machine table.
+	// RAM-R1 records the external inputs only, for one sequencer step, at full
+	// rate. RAM-P1 then proves that the captured samples reached DSP memory.
+	assignUwMachine(hardware, 0, 32);
+	assignUwMachine(hardware, 1, 34);
+	setTrack1Parameter(hardware, 0, 0);   // MLEV -64: no internal feedback
+	setTrack1Parameter(hardware, 1, 64);  // MBAL centered
+	setTrack1Parameter(hardware, 2, 64);  // ILEV 0: unity external input
+	setTrack1Parameter(hardware, 3, 64);  // IBAL centered
+	setTrack1Parameter(hardware, 4, 0);   // CUE1 off
+	setTrack1Parameter(hardware, 5, 0);   // CUE2 off
+	setTrack1Parameter(hardware, 6, 4);   // LEN: one sequencer step
+	setTrack1Parameter(hardware, 7, 127); // RATE: maximum quality
+	constexpr uint32_t uwMemoryBegin = 0x180000;
+	constexpr uint32_t uwMemoryEnd = 0x200000;
+	std::vector<dsp56k::TWord> uwMemoryBefore(uwMemoryEnd - uwMemoryBegin);
+	auto& producerMemory = hardware.getDspProducer().dsp().memory();
+	for(uint32_t address = uwMemoryBegin; address < uwMemoryEnd; ++address)
+		uwMemoryBefore[address - uwMemoryBegin] =
+			producerMemory.get(dsp56k::MemArea_X, address);
+
+	constexpr uint32_t captureFrames = 16384;
+	std::array<std::vector<float>, 2> captureInput{
+		std::vector<float>(captureFrames), std::vector<float>(captureFrames)};
+	for(uint32_t i = 0; i < captureFrames; ++i)
+	{
+		const auto phase = static_cast<float>(i % 97) / 97.0f;
+		captureInput[0][i] = phase * 1.0f - 0.5f;
+		captureInput[1][i] = captureInput[0][i];
+	}
+	synthLib::TAudioInputs inputs{};
+	inputs[0] = captureInput[0].data();
+	inputs[1] = captureInput[1].data();
+	std::array<std::vector<float>, 2> captureOutput{
+		std::vector<float>(captureFrames), std::vector<float>(captureFrames)};
+	synthLib::TAudioOutputs recordingOutputs{};
+	recordingOutputs[0] = captureOutput[0].data();
+	recordingOutputs[1] = captureOutput[1].data();
+	hardware.sendPanelEvent(trigger->row, trigger->mask);
+	constexpr uint32_t hostBlockFrames = 256;
+	for(uint32_t offset = 0; offset < captureFrames; offset += hostBlockFrames)
+	{
+		hardware.processAudio(inputs, recordingOutputs, hostBlockFrames, 0);
+		for(auto& input : inputs)
+			if(input)
+				input += hostBlockFrames;
+		for(auto& output : recordingOutputs)
+			if(output)
+				output += hostBlockFrames;
+	}
+	hardware.sendPanelEvent(trigger->row, 0);
+	advance(hardware, 4096);
+	size_t changedUwWords = 0;
+	for(uint32_t address = uwMemoryBegin; address < uwMemoryEnd; ++address)
+		if(uwMemoryBefore[address - uwMemoryBegin]
+			!= producerMemory.get(dsp56k::MemArea_X, address))
+			++changedUwWords;
+	if(changedUwWords < 100)
+		return fail("RAM-R1 did not write a recording into UW sample memory");
+
+	const auto player = md::panelPacket(md::MachineModel::Machinedrum,
+		md::PanelControl::Trigger2);
+	if(!player)
+		return fail("trigger 2 has no panel mapping");
+	std::array<std::vector<float>, 2> ramRendered{
+		std::vector<float>(captureFrames), std::vector<float>(captureFrames)};
+	synthLib::TAudioOutputs ramOutputs{};
+	ramOutputs[0] = ramRendered[0].data();
+	ramOutputs[1] = ramRendered[1].data();
+	hardware.sendPanelEvent(player->row, player->mask);
+	hardware.processAudio(ramOutputs, captureFrames / 2, 0);
+	hardware.sendPanelEvent(player->row, 0);
+	ramOutputs[0] += captureFrames / 2;
+	ramOutputs[1] += captureFrames / 2;
+	hardware.processAudio(ramOutputs, captureFrames / 2, 0);
+
+	float ramPeak = 0.0f;
+	for(const auto& channel : ramRendered)
+		for(const auto sample : channel)
+			ramPeak = std::max(ramPeak, std::abs(sample));
+	if(ramPeak < 0.001f)
+		return fail("RAM-P1 produced no audible recording from the external input");
+
 	std::cout << "Machinedrum UW ROM/RAM firmware test passed; ROM peak="
-		<< peak << '\n';
+		<< peak << ", RAM peak=" << ramPeak << '\n';
 	return 0;
 }

--- a/source/elektron/md/mdLibTest/turboMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/turboMidiTest.cpp
@@ -1,5 +1,6 @@
 #include "mdLib/mdfrontpanel.h"
 #include "mdLib/mdrealtimemidiqueue.h"
+#include "mdLib/mdhardware.h"
 #include "mdLib/mdsim.h"
 #include "mdLib/mdturbomidi.h"
 #include "dsp56kEmu/memory.h"

--- a/source/elektron/md/mdLibTest/turboMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/turboMidiTest.cpp
@@ -334,22 +334,32 @@ namespace
 		std::vector<uint8_t> patchRam(md::g_patchRamStateSize);
 		for(size_t i = 0; i < patchRam.size(); ++i)
 			patchRam[i] = static_cast<uint8_t>((i * 17u + 3u) & 0xffu);
-		std::vector<uint8_t> baseline(md::g_romSize, 0xff);
-		for(size_t i = 0; i < baseline.size(); i += 4093)
-			baseline[i] = static_cast<uint8_t>(i >> 8);
+		std::vector<uint8_t> rom(md::g_romSize, 0xff);
+		for(size_t i = 0; i < rom.size(); i += 4093)
+			rom[i] = static_cast<uint8_t>(i >> 8);
+		auto factoryBaseline = rom;
+		factoryBaseline[md::g_uwFlashSectorSize + 7] = 0x61;
 
-		auto flashA = baseline;
-		flashA[5] = 0x42;
+		std::vector<uint8_t> factoryState;
+		if(!check(md::encodeState(factoryState, patchRam, factoryBaseline,
+			factoryBaseline, rom, md::MachineModel::Machinedrum,
+			synthLib::StateTypeGlobal),
+			"factory-only UW state could not be encoded")
+			|| !check(factoryState.size() == 52 + patchRam.size(),
+				"factory initialization leaked into project state"))
+			return false;
+
+		auto flashA = factoryBaseline;
 		flashA[3 * md::g_uwFlashSectorSize + 19] = 0x18;
 		flashA.back() = 0x00;
 		std::vector<uint8_t> encodedA;
-		if(!check(md::encodeState(encodedA, patchRam, flashA, baseline,
+		if(!check(md::encodeState(encodedA, patchRam, flashA, factoryBaseline, rom,
 			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
 			"UW sparse state could not be encoded"))
 			return false;
 
-		constexpr size_t expectedChangedSectors = 3;
-		constexpr size_t stateHeaderSize = 44;
+		constexpr size_t expectedChangedSectors = 2;
+		constexpr size_t stateHeaderSize = 52;
 		constexpr size_t sectorEntryHeaderSize = 8;
 		const auto expectedSize = stateHeaderSize + patchRam.size()
 			+ expectedChangedSectors
@@ -359,43 +369,54 @@ namespace
 			return false;
 
 		md::DecodedState decodedA;
-		if(!check(md::decodeState(decodedA, encodedA, baseline,
+		std::vector<uint8_t> restoredA;
+		if(!check(md::decodeState(decodedA, encodedA, rom,
 			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
 			"UW sparse state could not be decoded")
 			|| !check(decodedA.containsFlash, "UW state lost its flash marker")
 			|| !check(decodedA.patchRam == patchRam, "UW state changed patch RAM")
-			|| !check(decodedA.flashData == flashA, "UW state changed flash data"))
+			|| !check(md::applyFlashOverlay(restoredA, decodedA.flashOverlay,
+				factoryBaseline), "UW sparse state could not be applied")
+			|| !check(restoredA == flashA, "UW state changed flash data"))
 			return false;
 
 		// A second instance must reconstruct its own flash, not inherit A's sectors.
-		auto flashB = baseline;
+		auto flashB = factoryBaseline;
 		flashB[7 * md::g_uwFlashSectorSize + 11] = 0x77;
 		std::vector<uint8_t> encodedB;
 		md::DecodedState decodedB;
-		if(!check(md::encodeState(encodedB, patchRam, flashB, baseline,
+		std::vector<uint8_t> restoredB;
+		if(!check(md::encodeState(encodedB, patchRam, flashB, factoryBaseline, rom,
 			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
 			"second UW state could not be encoded")
-			|| !check(md::decodeState(decodedB, encodedB, baseline,
+			|| !check(md::decodeState(decodedB, encodedB, rom,
 				md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
 				"second UW state could not be decoded")
-			|| !check(decodedB.flashData == flashB && decodedB.flashData != decodedA.flashData,
+			|| !check(md::applyFlashOverlay(restoredB, decodedB.flashOverlay,
+				factoryBaseline), "second UW state could not be applied")
+			|| !check(restoredB == flashB && restoredB != restoredA,
 				"UW instances did not retain isolated flash images"))
 			return false;
 
-		auto wrongBaseline = baseline;
-		wrongBaseline[123] ^= 1;
+		auto wrongRom = rom;
+		wrongRom[123] ^= 1;
 		md::DecodedState unchanged;
 		unchanged.patchRam = {1, 2, 3};
-		if(!check(!md::decodeState(unchanged, encodedA, wrongBaseline,
+		if(!check(!md::decodeState(unchanged, encodedA, wrongRom,
 			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
-			"UW state accepted the wrong firmware baseline")
+			"UW state accepted the wrong ROM")
 			|| !check(unchanged.patchRam == std::vector<uint8_t>({1, 2, 3}),
 				"failed UW decode modified its destination"))
+			return false;
+		auto wrongFactory = factoryBaseline;
+		wrongFactory[456] ^= 1;
+		if(!check(!md::applyFlashOverlay(restoredA, decodedA.flashOverlay, wrongFactory),
+			"UW state accepted the wrong factory baseline"))
 			return false;
 
 		auto corrupt = encodedA;
 		corrupt.back() ^= 1;
-		if(!check(!md::decodeState(unchanged, corrupt, baseline,
+		if(!check(!md::decodeState(unchanged, corrupt, rom,
 			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
 			"UW state accepted corrupt flash data"))
 			return false;
@@ -406,7 +427,7 @@ namespace
 		return check(md::encodeState(legacy, patchRam,
 			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
 			"legacy MD state could not be encoded")
-			&& check(md::decodeState(decodedLegacy, legacy, baseline,
+			&& check(md::decodeState(decodedLegacy, legacy, rom,
 				md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
 				"legacy MD state could not be decoded")
 			&& check(!decodedLegacy.containsFlash && decodedLegacy.patchRam == patchRam,
@@ -442,6 +463,10 @@ namespace
 		std::vector<uint8_t> decoded;
 		if(!check(md::encodeFactoryFlashCache(cache, initialized, baseline),
 			"UW factory cache could not be encoded")
+			|| !check(cache.size() == 36 + 8 + md::g_uwFlashSectorSize,
+				"UW factory cache did not contain exactly one sparse sector")
+			|| !check(cache.size() < md::g_romSize,
+				"UW factory cache copied the complete ROM image")
 			|| !check(md::decodeFactoryFlashCache(decoded, cache, baseline),
 				"UW factory cache could not be decoded")
 			|| !check(decoded == initialized, "UW factory cache changed flash data"))

--- a/source/elektron/md/mdLibTest/turboMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/turboMidiTest.cpp
@@ -414,10 +414,13 @@ namespace
 			"UW state accepted the wrong factory baseline"))
 			return false;
 
-		// Before a machine-local factory cache exists, state falls back to sectors
-		// relative to the ROM. Those sectors must be applicable after a fresh
-		// machine has completed its deterministic factory initialization.
+		// Before a machine-local factory cache exists, state carries every sector.
+		// In particular, a factory-populated sector erased back to ROM bytes is an
+		// intentional deletion and must override a fresh factory initialization.
 		auto firstRunFlash = factoryBaseline;
+		std::copy_n(rom.begin() + md::g_uwFlashSectorSize,
+			md::g_uwFlashSectorSize,
+			firstRunFlash.begin() + md::g_uwFlashSectorSize);
 		firstRunFlash[9 * md::g_uwFlashSectorSize + 31] = 0x27;
 		std::vector<uint8_t> firstRunState;
 		md::DecodedState decodedFirstRun;
@@ -425,17 +428,18 @@ namespace
 		if(!check(md::encodeState(firstRunState, patchRam, firstRunFlash, rom, rom,
 			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
 			"first-run UW fallback state could not be encoded")
+			|| !check(firstRunState.size() == stateHeaderSize + patchRam.size()
+				+ (md::g_romSize / md::g_uwFlashSectorSize)
+					* (sectorEntryHeaderSize + md::g_uwFlashSectorSize),
+				"first-run UW fallback did not contain a complete flash image")
 			|| !check(md::decodeState(decodedFirstRun, firstRunState, rom,
 				md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
 				"first-run UW fallback state could not be decoded")
-			|| !check(!md::applyFlashOverlay(restoredFirstRun,
-				decodedFirstRun.flashOverlay, factoryBaseline),
-				"ROM-relative UW state bypassed explicit fallback validation")
 			|| !check(md::applyFlashOverlay(restoredFirstRun,
-				decodedFirstRun.flashOverlay, factoryBaseline, rom),
-				"ROM-relative UW state could not be applied after initialization")
+				decodedFirstRun.flashOverlay, factoryBaseline),
+				"complete UW fallback was not baseline-independent")
 			|| !check(restoredFirstRun == firstRunFlash,
-				"first-run UW fallback changed flash data"))
+				"first-run UW fallback lost a ROM-equal deletion"))
 			return false;
 
 		auto corrupt = encodedA;

--- a/source/elektron/md/mdLibTest/turboMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/turboMidiTest.cpp
@@ -414,6 +414,30 @@ namespace
 			"UW state accepted the wrong factory baseline"))
 			return false;
 
+		// Before a machine-local factory cache exists, state falls back to sectors
+		// relative to the ROM. Those sectors must be applicable after a fresh
+		// machine has completed its deterministic factory initialization.
+		auto firstRunFlash = factoryBaseline;
+		firstRunFlash[9 * md::g_uwFlashSectorSize + 31] = 0x27;
+		std::vector<uint8_t> firstRunState;
+		md::DecodedState decodedFirstRun;
+		std::vector<uint8_t> restoredFirstRun;
+		if(!check(md::encodeState(firstRunState, patchRam, firstRunFlash, rom, rom,
+			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+			"first-run UW fallback state could not be encoded")
+			|| !check(md::decodeState(decodedFirstRun, firstRunState, rom,
+				md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+				"first-run UW fallback state could not be decoded")
+			|| !check(!md::applyFlashOverlay(restoredFirstRun,
+				decodedFirstRun.flashOverlay, factoryBaseline),
+				"ROM-relative UW state bypassed explicit fallback validation")
+			|| !check(md::applyFlashOverlay(restoredFirstRun,
+				decodedFirstRun.flashOverlay, factoryBaseline, rom),
+				"ROM-relative UW state could not be applied after initialization")
+			|| !check(restoredFirstRun == firstRunFlash,
+				"first-run UW fallback changed flash data"))
+			return false;
+
 		auto corrupt = encodedA;
 		corrupt.back() ^= 1;
 		if(!check(!md::decodeState(unchanged, corrupt, rom,
@@ -487,21 +511,25 @@ namespace
 			"UW factory cache accepted corrupt flash data");
 	}
 
-	bool testImmutableCachePromotion()
+	bool testCachePromotionAndRecovery()
 	{
 		const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
 		const auto filename = baseLib::filesystem::getCurrentDirectory()
 			+ ".md-cache-exclusive-test-" + std::to_string(nonce);
 		const std::vector<uint8_t> first{1, 2, 3, 4};
 		const std::vector<uint8_t> second{9, 8, 7};
+		const std::vector<uint8_t> recovered{5, 6, 7, 8, 9};
 		std::vector<uint8_t> readback;
 		const bool firstCreated = baseLib::filesystem::writeFileExclusive(filename, first);
 		const bool secondRejected = !baseLib::filesystem::writeFileExclusive(filename, second);
+		const bool invalidReplaced = baseLib::filesystem::writeFileAtomic(filename, recovered);
 		const bool read = baseLib::filesystem::readFile(readback, filename);
 		baseLib::filesystem::remove(filename);
 		return check(firstCreated, "immutable cache was not created")
 			&& check(secondRejected, "immutable cache was replaced")
-			&& check(read && readback == first, "immutable cache promotion changed data");
+			&& check(invalidReplaced, "invalid cache could not be replaced atomically")
+			&& check(read && readback == recovered,
+				"atomic cache recovery changed replacement data");
 	}
 }
 
@@ -514,7 +542,7 @@ int main()
 		|| !testFirmwareUpdateHandoff()
 		|| !testUwHostAudioInputMapping()
 		|| !testUwSparseProjectState()
-		|| !testUwFactoryFlashCache() || !testImmutableCachePromotion())
+		|| !testUwFactoryFlashCache() || !testCachePromotionAndRecovery())
 		return 1;
 	std::cout << "mdLib tests passed\n";
 	return 0;

--- a/source/elektron/md/mdLibTest/turboMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/turboMidiTest.cpp
@@ -3,9 +3,12 @@
 #include "mdLib/mdhardware.h"
 #include "mdLib/mdsim.h"
 #include "mdLib/mdturbomidi.h"
+#include "mdLib/mdstate.h"
+#include "baseLib/filesystem.h"
 #include "dsp56kEmu/memory.h"
 
 #include <array>
+#include <chrono>
 #include <cstdint>
 #include <initializer_list>
 #include <iostream>
@@ -325,6 +328,156 @@ namespace
 			&& mmHandoff.getParallelData() == 0xfe,
 			"Monomachine update handoff did not restore SIM/UART/GPIO state");
 	}
+
+	bool testUwSparseProjectState()
+	{
+		std::vector<uint8_t> patchRam(md::g_patchRamStateSize);
+		for(size_t i = 0; i < patchRam.size(); ++i)
+			patchRam[i] = static_cast<uint8_t>((i * 17u + 3u) & 0xffu);
+		std::vector<uint8_t> baseline(md::g_romSize, 0xff);
+		for(size_t i = 0; i < baseline.size(); i += 4093)
+			baseline[i] = static_cast<uint8_t>(i >> 8);
+
+		auto flashA = baseline;
+		flashA[5] = 0x42;
+		flashA[3 * md::g_uwFlashSectorSize + 19] = 0x18;
+		flashA.back() = 0x00;
+		std::vector<uint8_t> encodedA;
+		if(!check(md::encodeState(encodedA, patchRam, flashA, baseline,
+			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+			"UW sparse state could not be encoded"))
+			return false;
+
+		constexpr size_t expectedChangedSectors = 3;
+		constexpr size_t stateHeaderSize = 44;
+		constexpr size_t sectorEntryHeaderSize = 8;
+		const auto expectedSize = stateHeaderSize + patchRam.size()
+			+ expectedChangedSectors
+				* (sectorEntryHeaderSize + md::g_uwFlashSectorSize);
+		if(!check(encodedA.size() == expectedSize,
+			"UW sparse state did not contain exactly the changed sectors"))
+			return false;
+
+		md::DecodedState decodedA;
+		if(!check(md::decodeState(decodedA, encodedA, baseline,
+			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+			"UW sparse state could not be decoded")
+			|| !check(decodedA.containsFlash, "UW state lost its flash marker")
+			|| !check(decodedA.patchRam == patchRam, "UW state changed patch RAM")
+			|| !check(decodedA.flashData == flashA, "UW state changed flash data"))
+			return false;
+
+		// A second instance must reconstruct its own flash, not inherit A's sectors.
+		auto flashB = baseline;
+		flashB[7 * md::g_uwFlashSectorSize + 11] = 0x77;
+		std::vector<uint8_t> encodedB;
+		md::DecodedState decodedB;
+		if(!check(md::encodeState(encodedB, patchRam, flashB, baseline,
+			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+			"second UW state could not be encoded")
+			|| !check(md::decodeState(decodedB, encodedB, baseline,
+				md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+				"second UW state could not be decoded")
+			|| !check(decodedB.flashData == flashB && decodedB.flashData != decodedA.flashData,
+				"UW instances did not retain isolated flash images"))
+			return false;
+
+		auto wrongBaseline = baseline;
+		wrongBaseline[123] ^= 1;
+		md::DecodedState unchanged;
+		unchanged.patchRam = {1, 2, 3};
+		if(!check(!md::decodeState(unchanged, encodedA, wrongBaseline,
+			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+			"UW state accepted the wrong firmware baseline")
+			|| !check(unchanged.patchRam == std::vector<uint8_t>({1, 2, 3}),
+				"failed UW decode modified its destination"))
+			return false;
+
+		auto corrupt = encodedA;
+		corrupt.back() ^= 1;
+		if(!check(!md::decodeState(unchanged, corrupt, baseline,
+			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+			"UW state accepted corrupt flash data"))
+			return false;
+
+		// Version-1 states remain valid and intentionally inherit the live flash.
+		std::vector<uint8_t> legacy;
+		md::DecodedState decodedLegacy;
+		return check(md::encodeState(legacy, patchRam,
+			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+			"legacy MD state could not be encoded")
+			&& check(md::decodeState(decodedLegacy, legacy, baseline,
+				md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+				"legacy MD state could not be decoded")
+			&& check(!decodedLegacy.containsFlash && decodedLegacy.patchRam == patchRam,
+				"legacy MD state unexpectedly replaced flash");
+	}
+
+	bool testUwHostAudioInputMapping()
+	{
+		const float left[] = {0.25f, -0.5f};
+		const float right[] = {-0.75f, 0.125f};
+		synthLib::TAudioInputs inputs{};
+		inputs[0] = left;
+		inputs[1] = right;
+		return check(md::hostAudioInputSample(inputs, 2, 0, 0)
+				== dsp56k::sample2dsp(left[0]), "UW codec input changed the left channel")
+			&& check(md::hostAudioInputSample(inputs, 2, 1, 1)
+				== dsp56k::sample2dsp(right[1]), "UW codec input changed the right channel")
+			&& check(md::hostAudioInputSample(inputs, 2, 2, 0) == 0,
+				"UW codec input read beyond the host block")
+			&& check(md::hostAudioInputSample(inputs, 2, 0, 2) == 0,
+				"UW codec input accepted a non-codec channel");
+	}
+
+	bool testUwFactoryFlashCache()
+	{
+		std::vector<uint8_t> baseline(md::g_romSize, 0xff);
+		baseline[0] = 0x12;
+		baseline[md::g_romSize - 1] = 0x34;
+		auto initialized = baseline;
+		initialized[2 * md::g_uwFlashSectorSize + 9] = 0x56;
+
+		std::vector<uint8_t> cache;
+		std::vector<uint8_t> decoded;
+		if(!check(md::encodeFactoryFlashCache(cache, initialized, baseline),
+			"UW factory cache could not be encoded")
+			|| !check(md::decodeFactoryFlashCache(decoded, cache, baseline),
+				"UW factory cache could not be decoded")
+			|| !check(decoded == initialized, "UW factory cache changed flash data"))
+			return false;
+
+		auto wrongRom = baseline;
+		wrongRom[1234] ^= 1;
+		decoded = {1, 2, 3};
+		if(!check(!md::decodeFactoryFlashCache(decoded, cache, wrongRom),
+			"UW factory cache accepted the wrong ROM")
+			|| !check(decoded == std::vector<uint8_t>({1, 2, 3}),
+				"failed factory-cache decode modified its destination"))
+			return false;
+
+		auto corrupt = cache;
+		corrupt.back() ^= 1;
+		return check(!md::decodeFactoryFlashCache(decoded, corrupt, baseline),
+			"UW factory cache accepted corrupt flash data");
+	}
+
+	bool testImmutableCachePromotion()
+	{
+		const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+		const auto filename = baseLib::filesystem::getCurrentDirectory()
+			+ ".md-cache-exclusive-test-" + std::to_string(nonce);
+		const std::vector<uint8_t> first{1, 2, 3, 4};
+		const std::vector<uint8_t> second{9, 8, 7};
+		std::vector<uint8_t> readback;
+		const bool firstCreated = baseLib::filesystem::writeFileExclusive(filename, first);
+		const bool secondRejected = !baseLib::filesystem::writeFileExclusive(filename, second);
+		const bool read = baseLib::filesystem::readFile(readback, filename);
+		baseLib::filesystem::remove(filename);
+		return check(firstCreated, "immutable cache was not created")
+			&& check(secondRejected, "immutable cache was replaced")
+			&& check(read && readback == first, "immutable cache promotion changed data");
+	}
 }
 
 int main()
@@ -333,7 +486,10 @@ int main()
 		|| !testDspMemoryFallback() || !testMk2PortAInvertedLoopback()
 		|| !testRealtimeMidiPendingState() || !testFrontPanelStepLeds()
 		|| !testFrontPanelLedTransitions()
-		|| !testFirmwareUpdateHandoff())
+		|| !testFirmwareUpdateHandoff()
+		|| !testUwHostAudioInputMapping()
+		|| !testUwSparseProjectState()
+		|| !testUwFactoryFlashCache() || !testImmutableCachePromotion())
 		return 1;
 	std::cout << "mdLib tests passed\n";
 	return 0;

--- a/source/framework/baseLib/filesystem.cpp
+++ b/source/framework/baseLib/filesystem.cpp
@@ -1,6 +1,7 @@
 #include "filesystem.h"
 
 #include <array>
+#include <chrono>
 #include <iostream>
 #include <cstdio>
 
@@ -25,6 +26,7 @@
 #define NOMINMAX
 #define NOSERVICE
 #include <Windows.h>
+#include <io.h>
 #include <shlobj_core.h>
 #else
 #include <dlfcn.h>
@@ -276,6 +278,54 @@ namespace baseLib::filesystem
         fclose(hFile);
         return written == _size;
     }
+
+	bool writeFileExclusive(const std::string& _filename, const uint8_t* _data,
+		const size_t _size)
+	{
+		// Populate a uniquely-created sibling first, then promote it without replace
+		// semantics. Readers therefore see either no cache or one complete cache.
+		const auto nonce = static_cast<uint64_t>(
+			std::chrono::steady_clock::now().time_since_epoch().count())
+			^ static_cast<uint64_t>(reinterpret_cast<uintptr_t>(_data));
+		std::string temporary;
+		FILE* file = nullptr;
+		for(uint32_t attempt = 0; attempt < 8 && !file; ++attempt)
+		{
+			temporary = _filename + ".tmp." + std::to_string(nonce)
+				+ "." + std::to_string(attempt);
+			file = openFile(temporary, "wbx");
+		}
+		if(!file)
+			return false;
+
+		const auto written = _size == 0 ? size_t{0} : fwrite(_data, 1, _size, file);
+		const bool flushed = written == _size && fflush(file) == 0 && ferror(file) == 0;
+#ifdef _WIN32
+		const bool synced = flushed && _commit(_fileno(file)) == 0;
+#else
+		const bool synced = flushed && fsync(fileno(file)) == 0;
+#endif
+		fclose(file);
+		if(!synced)
+		{
+#ifdef _WIN32
+			DeleteFileW(utf8ToWide(temporary).c_str());
+#else
+			::unlink(temporary.c_str());
+#endif
+			return false;
+		}
+
+#ifdef _WIN32
+		const bool promoted = MoveFileW(utf8ToWide(temporary).c_str(),
+			utf8ToWide(_filename).c_str()) != FALSE;
+		DeleteFileW(utf8ToWide(temporary).c_str());
+#else
+		const bool promoted = ::link(temporary.c_str(), _filename.c_str()) == 0;
+		::unlink(temporary.c_str());
+#endif
+		return promoted;
+	}
 
     bool readFile(std::vector<uint8_t>& _data, const std::string& _filename)
     {

--- a/source/framework/baseLib/filesystem.cpp
+++ b/source/framework/baseLib/filesystem.cpp
@@ -279,11 +279,11 @@ namespace baseLib::filesystem
         return written == _size;
     }
 
-	bool writeFileExclusive(const std::string& _filename, const uint8_t* _data,
-		const size_t _size)
+	static bool writeFilePromoted(const std::string& _filename, const uint8_t* _data,
+		const size_t _size, const bool _replace)
 	{
-		// Populate a uniquely-created sibling first, then promote it without replace
-		// semantics. Readers therefore see either no cache or one complete cache.
+		// Populate a uniquely-created sibling first, then promote it atomically.
+		// Readers therefore see either the previous complete file or the new one.
 		const auto nonce = static_cast<uint64_t>(
 			std::chrono::steady_clock::now().time_since_epoch().count())
 			^ static_cast<uint64_t>(reinterpret_cast<uintptr_t>(_data));
@@ -317,14 +317,31 @@ namespace baseLib::filesystem
 		}
 
 #ifdef _WIN32
-		const bool promoted = MoveFileW(utf8ToWide(temporary).c_str(),
-			utf8ToWide(_filename).c_str()) != FALSE;
+		const bool promoted = _replace
+			? MoveFileExW(utf8ToWide(temporary).c_str(), utf8ToWide(_filename).c_str(),
+				MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) != FALSE
+			: MoveFileW(utf8ToWide(temporary).c_str(),
+				utf8ToWide(_filename).c_str()) != FALSE;
 		DeleteFileW(utf8ToWide(temporary).c_str());
 #else
-		const bool promoted = ::link(temporary.c_str(), _filename.c_str()) == 0;
+		const bool promoted = _replace
+			? ::rename(temporary.c_str(), _filename.c_str()) == 0
+			: ::link(temporary.c_str(), _filename.c_str()) == 0;
 		::unlink(temporary.c_str());
 #endif
 		return promoted;
+	}
+
+	bool writeFileExclusive(const std::string& _filename, const uint8_t* _data,
+		const size_t _size)
+	{
+		return writeFilePromoted(_filename, _data, _size, false);
+	}
+
+	bool writeFileAtomic(const std::string& _filename, const uint8_t* _data,
+		const size_t _size)
+	{
+		return writeFilePromoted(_filename, _data, _size, true);
 	}
 
     bool readFile(std::vector<uint8_t>& _data, const std::string& _filename)

--- a/source/framework/baseLib/filesystem.h
+++ b/source/framework/baseLib/filesystem.h
@@ -32,12 +32,23 @@ namespace baseLib
 		bool isDirectory(const std::string& _path);
 
 		bool writeFile(const std::string& _filename, const uint8_t* _data, size_t _size);
+		// Create without replacing an existing file. Intended for immutable caches
+		// where concurrent writers must never clobber the first complete result.
+		bool writeFileExclusive(const std::string& _filename, const uint8_t* _data,
+			size_t _size);
 
 		template<typename Alloc>
 	    bool writeFile(const std::string& _filename, const std::vector<uint8_t, Alloc>& _data)
 	    {
 	        return writeFile(_filename, _data.data(), _data.size());
 	    }
+
+		template<typename Alloc>
+		bool writeFileExclusive(const std::string& _filename,
+			const std::vector<uint8_t, Alloc>& _data)
+		{
+			return writeFileExclusive(_filename, _data.data(), _data.size());
+		}
 
 		template<size_t Size> bool writeFile(const std::string& _filename, const std::array<uint8_t, Size>& _data)
 		{

--- a/source/framework/baseLib/filesystem.h
+++ b/source/framework/baseLib/filesystem.h
@@ -36,6 +36,10 @@ namespace baseLib
 		// where concurrent writers must never clobber the first complete result.
 		bool writeFileExclusive(const std::string& _filename, const uint8_t* _data,
 			size_t _size);
+		// Atomically replace the destination after a complete sibling file has been
+		// flushed. Readers see either the old complete file or the new one.
+		bool writeFileAtomic(const std::string& _filename, const uint8_t* _data,
+			size_t _size);
 
 		template<typename Alloc>
 	    bool writeFile(const std::string& _filename, const std::vector<uint8_t, Alloc>& _data)
@@ -48,6 +52,13 @@ namespace baseLib
 			const std::vector<uint8_t, Alloc>& _data)
 		{
 			return writeFileExclusive(_filename, _data.data(), _data.size());
+		}
+
+		template<typename Alloc>
+		bool writeFileAtomic(const std::string& _filename,
+			const std::vector<uint8_t, Alloc>& _data)
+		{
+			return writeFileAtomic(_filename, _data.data(), _data.size());
 		}
 
 		template<size_t Size> bool writeFile(const std::string& _filename, const std::array<uint8_t, Size>& _data)


### PR DESCRIPTION
## Summary

- expose Machinedrum UW ROM and RAM machines under the 1.63 UW firmware
- route the plug-in stereo input to the emulated codec so RAM-R machines can record and RAM-P machines can play the result
- persist user ROM-slot flash sparsely in project state, isolated per plug-in instance
- derive project flash only from the initialized factory baseline, so first-boot factory sample data is not copied into project state
- store the machine-local factory cache as a sparse, ROM-bound overlay instead of a complete 8 MiB flash image
- restore cacheless projects safely by letting 1.63 initialize clean flash first, then applying saved patch RAM and user flash
- preserve legacy MD state plus Monomachine version-2 DigiPRO storage compatibility; UW sparse flash uses state version 3

RAM-machine recordings remain volatile like the hardware; copying them to a ROM slot makes them part of project state. +Drive support is intentionally outside this PR.

## Validation

- state/cache tests cover ROM mismatch, factory-baseline mismatch, corruption, sparse size, instance isolation, and legacy state compatibility
- `mdLibTest`, `mdFirmwareUpdateTest`, `mdStateTest`, and `mdFlashTest`
- `mdUwFirmwareTest` with Machinedrum UW OS 1.63, including ROM/RAM playback and cacheless deferred project restore
- `mdJucePlugin` and `mmJucePlugin` shared-code builds
