### PR TITLE
Fix MD tempo and MM Master Tune decimal handling

### DIFF
--- a/.github/workflows/mdmm-core.yml
+++ b/.github/workflows/mdmm-core.yml
@@ -68,10 +68,22 @@ jobs:
           cmake --build build --config Release --parallel 3
           --target dsp56kTestRunner mdLibTest mdProfileWorkload
 
+      - name: Build ColdFire divide regression test
+        if: runner.os != 'Windows'
+        run: >-
+          cmake --build build --config Release --parallel 3
+          --target mc68kColdFireDivideTest
+
+      - name: Build ColdFire divide regression test (Windows)
+        if: runner.os == 'Windows'
+        run: >-
+          cmake --build build --config Release --parallel 3
+          --target source/cpu/mc68k/mc68kColdFireDivideTest
+
       - name: Run asset-free core tests
         run: >-
           ctest --test-dir build -C Release --output-on-failure
-          --tests-regex "^(dsp56300_unitTests|mdLibTests|mdProfileWorkload(Bounded)?Tests)$"
+          --tests-regex "^(dsp56300_unitTests|mc68kColdFireDivideTest|mdLibTests|mdProfileWorkload(Bounded)?Tests)$"
 
   apple-pgo:
     name: Apple PGO generate and use


### PR DESCRIPTION
Advances the mc68k submodule to joelanders/mc68k-md-mm#2, which implements the correct ColdFire REMS/REMU writeback semantics.

The previous 68020-style writeback divided firmware decimal values twice, causing:

- Machinedrum tempo to render as 12.0 instead of 120.0.
- Monomachine Master Tune to collapse from 440.0 through 44.0 to 40.0 and then appear locked.

Verified locally with both firmware paths and the complete UnitTest label set (9/9 passed).

Depends on: https://github.com/joelanders/mc68k-md-mm/pull/2