### PR TITLE
Generalize Shift-held MD/MM panel controls

### DIFF
--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -27,6 +27,7 @@
 #include "juceRmlUi/rmlElemComboBox.h"
 #include "juceRmlUi/rmlElemKnob.h"
 #include "juceRmlUi/rmlEventListener.h"
+#include "juceRmlUi/rmlHelper.h"
 #include "juceRmlUi/juceRmlComponent.h"
 
 #include "RmlUi/Core/Element.h"
@@ -139,15 +140,14 @@ namespace mdJucePlugin
 		, m_controller(dynamic_cast<Controller&>(_processor.getController()))
 		, m_model(dynamic_cast<const AudioPluginAudioProcessor&>(_processor).getModel())
 	{
+		juce::Desktop::getInstance().addFocusChangeListener(this);
 	}
 
 	Editor::~Editor()
 	{
+		juce::Desktop::getInstance().removeFocusChangeListener(this);
 		m_panelSteps.clear();
-		endPanelGesture();
-		releaseShiftHeldTriggers();
-		releasePatternBankLatch();
-		releaseAllPanelInputs();
+		cancelPanelInputGestures();
 		stopTimer();
 	}
 
@@ -222,7 +222,8 @@ namespace mdJucePlugin
 
 	void Editor::createButtons()
 	{
-		releaseShiftHeldTriggers();
+		releaseActivePanelButtons();
+		releaseShiftHeldPanelControls();
 		releasePatternBankLatch();
 		m_panelRows.reset();
 		const auto model = getModel();
@@ -241,65 +242,139 @@ namespace mdJucePlugin
 			}
 
 			// On the hardware, A/E through D/H are held while a trig key chooses the
-			// pattern number. A mouse cannot hold one momentary button while clicking
-			// another, so an MM bank click latches until the next trig.
+			// pattern number. A normal MM bank click therefore keeps its existing latch.
+			// When another Shift-held control is already active, the bank instead acts as
+			// an ordinary momentary target so chords such as FUNCTION + BANK are exact.
 			if(model == md::MachineModel::Monomachine && isPatternBank(pb.control))
 			{
-				juceRmlUi::EventListener::Add(b, Rml::EventId::Click, [this, b, packet](Rml::Event&)
+				b->SetAttribute("title",
+					"Click to hold this bank; choose a trig to release it");
+				juceRmlUi::EventListener::Add(b, Rml::EventId::Mousedown,
+					[this, b, packet, control = pb.control](Rml::Event& _event)
 				{
-					togglePatternBankLatch(b, *packet);
+					const bool shiftDown = _event.GetParameter<int>("shift_key", 0) != 0;
+					if(!shiftDown && !m_shiftPanelLatch.empty())
+						releaseShiftHeldPanelControls();
+					if(m_shiftPanelLatch.empty())
+						togglePatternBankLatch(b, *packet);
+					else
+						pressPanelButton(b, control, *packet, shiftDown);
 				});
+				const auto release = [this, b, packet, control = pb.control](Rml::Event&)
+				{
+					releasePanelButton(b, control, *packet);
+				};
+				juceRmlUi::EventListener::Add(b, Rml::EventId::Mouseup, release);
+				juceRmlUi::EventListener::Add(b, Rml::EventId::Mouseout, release);
 				continue;
 			}
 
 			if(isTrigger(pb.control))
 				b->SetAttribute("title",
 					"Shift-click to hold this trig; release Shift to let go");
+			else
+				b->SetAttribute("title",
+					"Shift-click to hold; use another control; release Shift to let go");
 
 			juceRmlUi::EventListener::Add(b, Rml::EventId::Mousedown,
-				[this, b, packet, model, control = pb.control](Rml::Event& _event)
+				[this, b, packet, control = pb.control](Rml::Event& _event)
 			{
-				const bool shiftLatch = isTrigger(control)
-					&& _event.GetParameter<int>("shift_key", 0) != 0;
-				if(shiftLatch && !m_shiftTriggerLatch.latch(control))
-					return;
-				if(model == md::MachineModel::Monomachine && !isTrigger(control))
-					releasePatternBankLatch();
-				juceRmlUi::ElemButton::setChecked(b, true);
-				if(auto* hw = getHardware())
-				{
-					const auto combined = m_panelRows.press(*packet);
-					hw->sendPanelEvent(combined.row, combined.mask);
-				}
+				pressPanelButton(b, control, *packet,
+					_event.GetParameter<int>("shift_key", 0) != 0);
 			});
 
 			// Mouseout releases too, otherwise dragging off a button leaves it held.
-			const auto release = [this, b, packet, model, control = pb.control](Rml::Event&)
+			const auto release = [this, b, packet, control = pb.control](Rml::Event&)
 			{
-				if(m_shiftTriggerLatch.contains(control))
-					return;
-				if(!b->isChecked())
-					return;
-				juceRmlUi::ElemButton::setChecked(b, false);
-				if(auto* hw = getHardware())
-				{
-					const auto combined = m_panelRows.release(*packet);
-					hw->sendPanelEvent(combined.row, combined.mask);
-				}
-				if(model == md::MachineModel::Monomachine && isTrigger(control))
-					releasePatternBankLatch();
+				releasePanelButton(b, control, *packet);
 			};
 			juceRmlUi::EventListener::Add(b, Rml::EventId::Mouseup, release);
 			juceRmlUi::EventListener::Add(b, Rml::EventId::Mouseout, release);
 		}
 
 		if(auto* const document = getDocument())
+		{
 			juceRmlUi::EventListener::Add(document, Rml::EventId::Keyup,
 				[this](const Rml::Event& _event)
 				{
-					if(_event.GetParameter<int>("shift_key", 0) == 0)
-						releaseShiftHeldTriggers();
+					if(_event.GetParameter<int>("shift_key", 0) == 0 && !m_shiftPanelLatch.empty())
+						releaseShiftHeldPanelControls();
 				});
+			juceRmlUi::EventListener::Add(document, Rml::EventId::Keydown,
+				[this](Rml::Event& _event)
+				{
+					if(juceRmlUi::helper::getKeyIdentifier(_event) != Rml::Input::KI_ESCAPE
+						|| (m_shiftPanelLatch.empty() && m_activePanelButtons.empty()))
+						return;
+					_event.StopPropagation();
+					cancelPanelInputGestures();
+				});
+		}
+	}
+
+	void Editor::pressPanelButton(juceRmlUi::ElemButton* const _button,
+		const md::PanelControl _control, const md::PanelPacket& _packet, const bool _shiftDown)
+	{
+		if(!_button || _button->isChecked())
+			return;
+
+		// A missing native key-up must never let an earlier hold leak into a new,
+		// unmodified click before the timer fail-safe gets its next turn.
+		if(!_shiftDown && !m_shiftPanelLatch.empty())
+			releaseShiftHeldPanelControls();
+
+		const auto action = m_shiftPanelLatch.press(_control, _shiftDown);
+		if(action == panelAffordances::ShiftPanelLatch::PressAction::Ignored)
+			return;
+
+		if(getModel() == md::MachineModel::Monomachine && !isTrigger(_control))
+			releasePatternBankLatch();
+
+		juceRmlUi::ElemButton::setChecked(_button, true);
+		if(action == panelAffordances::ShiftPanelLatch::PressAction::Momentary)
+			m_activePanelButtons.push_back({ _button, _packet });
+
+		if(auto* hw = getHardware())
+		{
+			const auto combined = m_panelRows.press(_packet);
+			hw->sendPanelEvent(combined.row, combined.mask);
+		}
+	}
+
+	void Editor::releasePanelButton(juceRmlUi::ElemButton* const _button,
+		const md::PanelControl _control, const md::PanelPacket& _packet)
+	{
+		if(m_shiftPanelLatch.contains(_control))
+			return;
+
+		const auto it = std::find_if(m_activePanelButtons.begin(), m_activePanelButtons.end(),
+			[_button](const ActivePanelButton& _active) { return _active.button == _button; });
+		if(it == m_activePanelButtons.end())
+			return;
+
+		m_activePanelButtons.erase(it);
+		juceRmlUi::ElemButton::setChecked(_button, false);
+		if(auto* hw = getHardware())
+		{
+			const auto combined = m_panelRows.release(_packet);
+			hw->sendPanelEvent(combined.row, combined.mask);
+		}
+		if(getModel() == md::MachineModel::Monomachine && isTrigger(_control))
+			releasePatternBankLatch();
+	}
+
+	void Editor::releaseActivePanelButtons()
+	{
+		while(!m_activePanelButtons.empty())
+		{
+			const auto active = m_activePanelButtons.back();
+			m_activePanelButtons.pop_back();
+			if(active.button)
+				juceRmlUi::ElemButton::setChecked(active.button, false);
+			const auto combined = m_panelRows.release(active.packet);
+			if(auto* hw = getHardware())
+				hw->sendPanelEvent(combined.row, combined.mask);
+		}
 	}
 
 	void Editor::createPanelAffordances()
@@ -316,8 +391,9 @@ namespace mdJucePlugin
 			if(!element)
 				return;
 			element->SetClass(panelAffordances::g_affordanceClass, true);
-			juceRmlUi::EventListener::Add(element, Rml::EventId::Click, [_select](Rml::Event&)
+			juceRmlUi::EventListener::Add(element, Rml::EventId::Click, [this, _select](Rml::Event&)
 			{
+				releaseShiftHeldPanelControls();
 				_select();
 			});
 		};
@@ -401,6 +477,10 @@ namespace mdJucePlugin
 	void Editor::beginPanelGesture(Rml::Element* const _element,
 		const std::initializer_list<md::PanelControl> _controls)
 	{
+		// Direct labels own their complete gesture. Ending an existing Shift hold
+		// avoids duplicate row bits and prevents a label from silently creating a
+		// three-control chord.
+		releaseShiftHeldPanelControls();
 		endPanelGesture();
 		releasePatternBankLatch();
 
@@ -439,16 +519,22 @@ namespace mdJucePlugin
 		m_panelGestureElement = nullptr;
 	}
 
-	void Editor::releaseShiftHeldTriggers()
+	void Editor::releaseShiftHeldPanelControls()
 	{
-		m_shiftTriggerLatch.releaseAll([this](const md::PanelControl _control)
+		// If Shift is released while an action button is still physically down, end
+		// that action before its held modifier. Later mouse-up is then a harmless no-op.
+		releaseActivePanelButtons();
+
+		m_shiftPanelLatch.releaseAll([this](const md::PanelControl _control)
 		{
-			const auto trigger = static_cast<size_t>(static_cast<int>(_control)
-				- static_cast<int>(md::PanelControl::Trigger1));
-			if(trigger < 16)
-				if(auto* const button = findChild<juceRmlUi::ElemButton>(
-					("trigKey" + std::to_string(trigger)).c_str(), false))
+			for(const auto& panelButton : g_panelButtons)
+			{
+				if(panelButton.control != _control)
+					continue;
+				if(auto* const button = findChild<juceRmlUi::ElemButton>(panelButton.id, false))
 					juceRmlUi::ElemButton::setChecked(button, false);
+				break;
+			}
 
 			if(const auto packet = md::panelPacket(getModel(), _control))
 			{
@@ -462,6 +548,28 @@ namespace mdJucePlugin
 		// of every target trig before releasing that modifier.
 		if(getModel() == md::MachineModel::Monomachine)
 			releasePatternBankLatch();
+	}
+
+	void Editor::cancelPanelInputGestures()
+	{
+		releaseActivePanelButtons();
+		endPanelGesture();
+		releaseShiftHeldPanelControls();
+		releasePatternBankLatch();
+		releaseAllPanelInputs();
+	}
+
+	void Editor::globalFocusChanged(juce::Component* const _focusedComponent)
+	{
+		if(m_shiftPanelLatch.empty() && m_activePanelButtons.empty())
+			return;
+
+		auto* const panel = getRmlComponent();
+		if(panel && _focusedComponent
+			&& (_focusedComponent == panel || panel->isParentOf(_focusedComponent)))
+			return;
+
+		cancelPanelInputGestures();
 	}
 
 	void Editor::releaseAllPanelInputs()
@@ -1301,9 +1409,9 @@ namespace mdJucePlugin
 		// Some plugin hosts can lose the modifier key-up when focus moves to
 		// another window. Poll the native state as a fail-safe so no panel row can
 		// remain held indefinitely.
-		if(!m_shiftTriggerLatch.empty()
+		if(!m_shiftPanelLatch.empty()
 			&& !juce::ModifierKeys::getCurrentModifiersRealtime().isShiftDown())
-			releaseShiftHeldTriggers();
+			releaseShiftHeldPanelControls();
 
 		m_frontPanelSnapshotValid = refreshFrontPanelSnapshot();
 		servicePanelQueue();

--- a/source/elektron/md/mdJucePlugin/mdEditor.h
+++ b/source/elektron/md/mdJucePlugin/mdEditor.h
@@ -42,7 +42,8 @@ namespace mdJucePlugin
 	class Controller;
 	struct EditorIdentityTestAccess;
 
-	class Editor final : public jucePluginEditorLib::Editor, juce::Timer
+	class Editor final : public jucePluginEditorLib::Editor, juce::Timer,
+		private juce::FocusChangeListener
 	{
 	public:
 		Editor(jucePluginEditorLib::Processor& _processor, const jucePluginEditorLib::Skin& _skin);
@@ -86,11 +87,18 @@ namespace mdJucePlugin
 		void createPanelAffordances();
 		void bindPanelTarget(const char* _id, md::PanelControl _control);
 		void bindPanelChord(const char* _id, md::PanelControl _control);
+		void pressPanelButton(juceRmlUi::ElemButton* _button, md::PanelControl _control,
+			const md::PanelPacket& _packet, bool _shiftDown);
+		void releasePanelButton(juceRmlUi::ElemButton* _button, md::PanelControl _control,
+			const md::PanelPacket& _packet);
+		void releaseActivePanelButtons();
 		void beginPanelGesture(Rml::Element* _element,
 			std::initializer_list<md::PanelControl> _controls);
 		void endPanelGesture();
-		void releaseShiftHeldTriggers();
+		void releaseShiftHeldPanelControls();
+		void cancelPanelInputGestures();
 		void releaseAllPanelInputs();
+		void globalFocusChanged(juce::Component* _focusedComponent) override;
 		void queuePanelPulse(md::PanelControl _control, int _count = 1);
 		void servicePanelQueue();
 		void servicePanelNavigation();
@@ -143,7 +151,14 @@ namespace mdJucePlugin
 		std::optional<md::PanelPacket> m_patternBankPacket;
 		Rml::Element* m_panelGestureElement = nullptr;
 		std::vector<md::PanelPacket> m_panelGesturePackets;
-		panelAffordances::ShiftTriggerLatch m_shiftTriggerLatch;
+		panelAffordances::ShiftPanelLatch m_shiftPanelLatch;
+
+		struct ActivePanelButton
+		{
+			juceRmlUi::ElemButton* button = nullptr;
+			md::PanelPacket packet;
+		};
+		std::vector<ActivePanelButton> m_activePanelButtons;
 
 		struct PanelStep
 		{

--- a/source/elektron/md/mdJucePlugin/mdPanelAffordances.h
+++ b/source/elektron/md/mdJucePlugin/mdPanelAffordances.h
@@ -33,30 +33,42 @@ namespace mdJucePlugin::panelAffordances
 		int count;
 	};
 
-	// Tracks trigs pinned by Shift-click independently of the panel row masks.
-	// The editor owns the actual press/release edges and visible button state;
-	// keeping this policy JUCE-free makes duplicate suppression and release order
-	// straightforward to verify.
-	class ShiftTriggerLatch
+	// Classifies panel presses while Shift is down. The first control is held until
+	// Shift is released; subsequent controls remain ordinary momentary actions. The
+	// one exception preserves the established parameter-lock workflow: a gesture
+	// that starts with a trig may collect more trigs, but never a second non-trig
+	// modifier. Keeping this policy JUCE-free makes the interaction deterministic
+	// and independently testable.
+	class ShiftPanelLatch
 	{
 	public:
-		static constexpr size_t g_triggerCount = 16;
-
-		bool latch(const md::PanelControl _control)
+		enum class PressAction
 		{
-			const auto index = triggerIndex(_control);
-			if(!index || m_held[*index])
-				return false;
+			Momentary,
+			Latched,
+			Ignored,
+		};
 
-			m_held[*index] = true;
+		PressAction press(const md::PanelControl _control, const bool _shiftDown)
+		{
+			const auto index = controlIndex(_control);
+			if(m_held[index])
+				return PressAction::Ignored;
+			if(!_shiftDown)
+				return PressAction::Momentary;
+			if(m_size != 0 && (!m_triggerSet || !isTrigger(_control)))
+				return PressAction::Momentary;
+
+			if(m_size == 0)
+				m_triggerSet = isTrigger(_control);
+			m_held[index] = true;
 			m_order[m_size++] = _control;
-			return true;
+			return PressAction::Latched;
 		}
 
 		bool contains(const md::PanelControl _control) const
 		{
-			const auto index = triggerIndex(_control);
-			return index && m_held[*index];
+			return m_held[controlIndex(_control)];
 		}
 
 		bool empty() const
@@ -75,27 +87,31 @@ namespace mdJucePlugin::panelAffordances
 			while(m_size != 0)
 			{
 				const auto control = m_order[--m_size];
-				const auto index = triggerIndex(control);
-				if(index)
-					m_held[*index] = false;
+				m_held[controlIndex(control)] = false;
 				_release(control);
 			}
+			m_triggerSet = false;
 		}
 
 	private:
-		static std::optional<size_t> triggerIndex(const md::PanelControl _control)
-		{
-			if(_control < md::PanelControl::Trigger1
-				|| _control > md::PanelControl::Trigger16)
-				return std::nullopt;
+		static constexpr size_t g_controlCount =
+			static_cast<size_t>(md::PanelControl::ClassicExtended) + 1;
 
-			return static_cast<size_t>(static_cast<int>(_control)
-				- static_cast<int>(md::PanelControl::Trigger1));
+		static constexpr bool isTrigger(const md::PanelControl _control)
+		{
+			return _control >= md::PanelControl::Trigger1
+				&& _control <= md::PanelControl::Trigger16;
 		}
 
-		std::array<bool, g_triggerCount> m_held{};
-		std::array<md::PanelControl, g_triggerCount> m_order{};
+		static constexpr size_t controlIndex(const md::PanelControl _control)
+		{
+			return static_cast<size_t>(_control);
+		}
+
+		std::array<bool, g_controlCount> m_held{};
+		std::array<md::PanelControl, g_controlCount> m_order{};
 		size_t m_size = 0;
+		bool m_triggerSet = false;
 	};
 
 	// A direct-selection target is replaced, rather than appended, when the user

--- a/source/elektron/md/mdJucePlugin/mdShiftTriggerLatchTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdShiftTriggerLatchTest.cpp
@@ -7,7 +7,8 @@
 
 namespace
 {
-	using mdJucePlugin::panelAffordances::ShiftTriggerLatch;
+	using mdJucePlugin::panelAffordances::ShiftPanelLatch;
+	using PressAction = ShiftPanelLatch::PressAction;
 
 	void expect(const bool _condition, const char* const _message)
 	{
@@ -20,15 +21,18 @@ namespace
 
 	void checkLatchPolicy()
 	{
-		ShiftTriggerLatch latch;
+		ShiftPanelLatch latch;
 		expect(latch.empty() && latch.size() == 0, "new latch is not empty");
-		expect(!latch.latch(md::PanelControl::Function),
-			"non-trig control was accepted");
-		expect(latch.latch(md::PanelControl::Trigger1), "first trig was rejected");
-		expect(!latch.latch(md::PanelControl::Trigger1),
+		expect(latch.press(md::PanelControl::Trigger1, true) == PressAction::Latched,
+			"first trig was rejected");
+		expect(latch.press(md::PanelControl::Trigger1, true) == PressAction::Ignored,
 			"duplicate trig was accepted");
-		expect(latch.latch(md::PanelControl::Trigger8), "second trig was rejected");
-		expect(latch.latch(md::PanelControl::Trigger16), "last trig was rejected");
+		expect(latch.press(md::PanelControl::Trigger8, true) == PressAction::Latched,
+			"second trig was rejected");
+		expect(latch.press(md::PanelControl::Trigger16, true) == PressAction::Latched,
+			"last trig was rejected");
+		expect(latch.press(md::PanelControl::Play, true) == PressAction::Momentary,
+			"action after held trigs was not momentary");
 		expect(latch.size() == 3, "latch size is wrong");
 		expect(latch.contains(md::PanelControl::Trigger1)
 			&& latch.contains(md::PanelControl::Trigger8)
@@ -52,9 +56,74 @@ namespace
 			"release did not clear latch state");
 	}
 
+	void checkSingleModifierPolicy()
+	{
+		ShiftPanelLatch latch;
+		expect(latch.press(md::PanelControl::Function, false) == PressAction::Momentary,
+			"unmodified press was not momentary");
+		expect(latch.empty(), "unmodified press changed latch state");
+		expect(latch.press(md::PanelControl::Function, true) == PressAction::Latched,
+			"non-trig modifier was not latched");
+		expect(latch.contains(md::PanelControl::Function) && latch.size() == 1,
+			"held modifier state is wrong");
+		expect(latch.press(md::PanelControl::Tempo, true) == PressAction::Momentary,
+			"target after held modifier was also latched");
+		expect(latch.press(md::PanelControl::Trigger4, true) == PressAction::Momentary,
+			"trig target after held modifier was also latched");
+		expect(latch.press(md::PanelControl::Function, true) == PressAction::Ignored,
+			"duplicate held modifier was not ignored");
+
+		std::vector<md::PanelControl> released;
+		latch.releaseAll([&released](const auto control) { released.push_back(control); });
+		expect(released == std::vector<md::PanelControl>{md::PanelControl::Function},
+			"single modifier release was not exact");
+		expect(latch.empty(), "single modifier release left state behind");
+	}
+
+	void checkChordRows(const md::MachineModel _model,
+		const md::PanelControl _held, const md::PanelControl _target)
+	{
+		ShiftPanelLatch latch;
+		md::PanelRowState rows;
+		const auto heldPacket = md::panelPacket(_model, _held);
+		const auto targetPacket = md::panelPacket(_model, _target);
+		expect(heldPacket.has_value() && targetPacket.has_value(),
+			"chord control has no panel packet");
+		expect(latch.press(_held, true) == PressAction::Latched,
+			"chord modifier was not latched");
+		rows.press(*heldPacket);
+		expect(latch.press(_target, true) == PressAction::Momentary,
+			"chord target was not momentary");
+		rows.press(*targetPacket);
+		const auto combinedMask = heldPacket->row == targetPacket->row
+			? static_cast<uint8_t>(heldPacket->mask | targetPacket->mask)
+			: heldPacket->mask;
+		expect(rows.mask(heldPacket->row) == combinedMask,
+			"chord press did not preserve the held control");
+		if(heldPacket->row != targetPacket->row)
+			expect(rows.mask(targetPacket->row) == targetPacket->mask,
+				"chord target was not present in its row");
+
+		// Action first, modifier second: this is the editor's forced-release order.
+		rows.release(*targetPacket);
+		expect(rows.mask(heldPacket->row) == heldPacket->mask,
+			"releasing the chord target also released its modifier");
+		if(heldPacket->row != targetPacket->row)
+			expect(rows.mask(targetPacket->row) == 0,
+				"releasing the chord target left its row held");
+		latch.releaseAll([&](const auto control)
+		{
+			const auto packet = md::panelPacket(_model, control);
+			expect(packet.has_value(), "held chord control lost its packet");
+			rows.release(*packet);
+		});
+		for(uint8_t row = 0x20; row <= 0x25; ++row)
+			expect(rows.mask(row) == 0, "chord release left a panel row held");
+	}
+
 	void checkPanelRows(const md::MachineModel _model)
 	{
-		ShiftTriggerLatch latch;
+		ShiftPanelLatch latch;
 		md::PanelRowState rows;
 		constexpr std::array controls
 		{
@@ -68,7 +137,8 @@ namespace
 		{
 			const auto packet = md::panelPacket(_model, control);
 			expect(packet.has_value(), "trig has no panel packet");
-			expect(latch.latch(control), "unique trig was rejected");
+			expect(latch.press(control, true) == PressAction::Latched,
+				"unique trig was rejected");
 			rows.press(*packet);
 		}
 
@@ -90,8 +160,17 @@ namespace
 int main()
 {
 	checkLatchPolicy();
+	checkSingleModifierPolicy();
 	checkPanelRows(md::MachineModel::Machinedrum);
 	checkPanelRows(md::MachineModel::Monomachine);
+	checkChordRows(md::MachineModel::Machinedrum,
+		md::PanelControl::Record, md::PanelControl::Play);
+	checkChordRows(md::MachineModel::Machinedrum,
+		md::PanelControl::Scale, md::PanelControl::Stop);
+	checkChordRows(md::MachineModel::Monomachine,
+		md::PanelControl::Stop, md::PanelControl::Record);
+	checkChordRows(md::MachineModel::Monomachine,
+		md::PanelControl::DataPageBackward, md::PanelControl::DataPageForward);
 
 	std::cout << "mdShiftTriggerLatchTest: PASS\n";
 	return 0;


### PR DESCRIPTION
## Summary

- let Shift-click hold the first MD/MM panel control while a second control is used momentarily
- preserve the existing multi-trigger parameter-lock workflow and Monomachine bank behavior
- release held panel state deterministically on Shift release, Escape, focus loss, editor teardown, and direct-label gestures
- add row-level tests for representative MD and MM chords and release ordering

## Testing

- `mdShiftTriggerLatchTest` passes via CTest
- `mdEditor.cpp` passes syntax compilation for both `mdJucePlugin` and `mmJucePlugin` using their generated project flags
- `git diff --check` passes