### PR TITLE
Add macOS setup helper to MD/MM releases

### DIFF
--- a/.github/workflows/elektron-macos.yml
+++ b/.github/workflows/elektron-macos.yml
@@ -3,6 +3,10 @@ name: Elektron macOS universal artifacts
 on:
   workflow_call:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/elektron-macos.yml"
+      - "scripts/macos/**"
 
 permissions:
   contents: read

--- a/.github/workflows/elektron-windows.yml
+++ b/.github/workflows/elektron-windows.yml
@@ -3,6 +3,10 @@ name: Elektron Windows artifacts
 on:
   workflow_call:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/elektron-windows.yml"
+      - "scripts/windows/**"
 
 permissions:
   contents: read

--- a/scripts/macos/INSTALL-macOS.txt
+++ b/scripts/macos/INSTALL-macOS.txt
@@ -1,0 +1,27 @@
+Gearmulator MD/MM for macOS
+===========================
+
+This alpha is ad-hoc signed and is not notarized by Apple. macOS may quarantine
+the applications and VST3 plug-ins when you download them.
+
+Installation
+------------
+
+1. Fully extract the downloaded ZIP archive.
+2. Double-click macsetup_Gearmulator-Elektron.command in the extracted folder.
+   Terminal will open, prepare both products, and print "Done" when successful.
+3. Copy the VST3 plug-ins you want to use to:
+
+       ~/Library/Audio/Plug-Ins/VST3
+
+   Create that folder if it does not already exist.
+4. Optionally copy the standalone applications to /Applications or another
+   location of your choice.
+5. Restart your DAW or ask it to rescan plug-ins.
+
+Run the setup command again whenever you install an updated download. The
+command only clears extended attributes from the Gearmulator MD/MM bundles in
+the extracted folder; it does not copy or delete plug-ins.
+
+Firmware is not included. Each application or plug-in will ask you to select a
+firmware image that you are entitled to use.

--- a/scripts/macos/build_mdmm.sh
+++ b/scripts/macos/build_mdmm.sh
@@ -16,6 +16,10 @@ if [[ "${build_dir}" == "${source_dir}" || "${output_dir}" == "${source_dir}" ]]
   exit 2
 fi
 
+python3 "${script_dir}/write_mdmm_receipt.py" \
+  --source "${source_dir}" \
+  --check-source-only
+
 rm -rf "${build_dir}" "${output_dir}"
 mkdir -p "${build_dir}" "${output_dir}"
 

--- a/scripts/macos/build_mdmm.sh
+++ b/scripts/macos/build_mdmm.sh
@@ -110,20 +110,21 @@ mkdir -p "${package_dir}"
 /usr/bin/ditto "${script_dir}/INSTALL-macOS.txt" \
   "${package_dir}/INSTALL-macOS.txt"
 
+archive="${output_dir}/Gearmulator-Elektron-macOS-Universal.zip"
+/usr/bin/ditto -c -k --sequesterRsrc --keepParent "${package_dir}" "${archive}"
+"${script_dir}/verify_mdmm_package.sh" "${archive}"
+
 receipt="${output_dir}/Gearmulator-Elektron-macOS-Universal-receipt.json"
 python3 "${script_dir}/write_mdmm_receipt.py" \
   --source "${source_dir}" \
   --output "${receipt}" \
+  --archive "${archive}" \
   --artifact "${package_dir}/Gearmulator MD.app" \
   --artifact "${package_dir}/Gearmulator MM.app" \
   --artifact "${package_dir}/Gearmulator MD.vst3" \
   --artifact "${package_dir}/Gearmulator MM.vst3" \
   --package-file "${package_dir}/macsetup_Gearmulator-Elektron.command" \
   --package-file "${package_dir}/INSTALL-macOS.txt"
-
-archive="${output_dir}/Gearmulator-Elektron-macOS-Universal.zip"
-/usr/bin/ditto -c -k --sequesterRsrc --keepParent "${package_dir}" "${archive}"
-"${script_dir}/verify_mdmm_package.sh" "${archive}"
 
 echo "MACOS_MDMM_ZIP=${archive}"
 echo "MACOS_MDMM_RECEIPT=${receipt}"

--- a/scripts/macos/build_mdmm.sh
+++ b/scripts/macos/build_mdmm.sh
@@ -101,6 +101,10 @@ mkdir -p "${package_dir}"
 /usr/bin/ditto "${md_vst3}" "${package_dir}/Gearmulator MD.vst3"
 /usr/bin/ditto "${mm_vst3}" "${package_dir}/Gearmulator MM.vst3"
 /usr/bin/ditto "${source_dir}/LICENSE.md" "${package_dir}/LICENSE.md"
+/usr/bin/ditto "${script_dir}/macsetup_Gearmulator-Elektron.command" \
+  "${package_dir}/macsetup_Gearmulator-Elektron.command"
+/usr/bin/ditto "${script_dir}/INSTALL-macOS.txt" \
+  "${package_dir}/INSTALL-macOS.txt"
 
 receipt="${output_dir}/Gearmulator-Elektron-macOS-Universal-receipt.json"
 python3 "${script_dir}/write_mdmm_receipt.py" \
@@ -109,10 +113,13 @@ python3 "${script_dir}/write_mdmm_receipt.py" \
   --artifact "${package_dir}/Gearmulator MD.app" \
   --artifact "${package_dir}/Gearmulator MM.app" \
   --artifact "${package_dir}/Gearmulator MD.vst3" \
-  --artifact "${package_dir}/Gearmulator MM.vst3"
+  --artifact "${package_dir}/Gearmulator MM.vst3" \
+  --package-file "${package_dir}/macsetup_Gearmulator-Elektron.command" \
+  --package-file "${package_dir}/INSTALL-macOS.txt"
 
 archive="${output_dir}/Gearmulator-Elektron-macOS-Universal.zip"
 /usr/bin/ditto -c -k --sequesterRsrc --keepParent "${package_dir}" "${archive}"
+"${script_dir}/verify_mdmm_package.sh" "${archive}"
 
 echo "MACOS_MDMM_ZIP=${archive}"
 echo "MACOS_MDMM_RECEIPT=${receipt}"

--- a/scripts/macos/macsetup_Gearmulator-Elektron.command
+++ b/scripts/macos/macsetup_Gearmulator-Elektron.command
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -u
+
+# A browser download may quarantine this script along with the plug-in bundles.
+/usr/bin/xattr -d com.apple.quarantine "$0" >/dev/null 2>&1 || true
+
+current_location="$(cd "$(dirname "$0")" && pwd)"
+products=("Gearmulator MD" "Gearmulator MM")
+formats=("app" "vst3")
+found=0
+failed=0
+
+echo
+echo "Clearing extended attributes for Gearmulator MD/MM"
+echo "Location: ${current_location}"
+echo
+
+for product in "${products[@]}"; do
+    for format in "${formats[@]}"; do
+        target="${current_location}/${product}.${format}"
+        if [[ ! -e "${target}" ]]; then
+            continue
+        fi
+
+        found=1
+        echo "Clearing attributes for: ${target}"
+        if ! /usr/bin/xattr -cr "${target}"; then
+            failed=1
+        fi
+    done
+done
+
+echo
+if [[ ${found} -eq 0 ]]; then
+    echo "No Gearmulator MD/MM applications or VST3 plug-ins were found beside this script."
+    exit 1
+fi
+if [[ ${failed} -ne 0 ]]; then
+    echo "One or more bundles could not be prepared."
+    exit 1
+fi
+
+echo "Done. You can now copy the applications and VST3 plug-ins to their destinations."

--- a/scripts/macos/verify_mdmm_package.sh
+++ b/scripts/macos/verify_mdmm_package.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euo pipefail
+
+archive="${1:?usage: verify_mdmm_package.sh ARCHIVE}"
+if [[ ! -f "${archive}" ]]; then
+  echo "Package archive does not exist: ${archive}" >&2
+  exit 2
+fi
+
+verification_root="$(mktemp -d "${TMPDIR:-/tmp}/gearmulator-mdmm-package.XXXXXX")"
+trap 'rm -rf "${verification_root}"' EXIT
+
+/usr/bin/ditto -x -k "${archive}" "${verification_root}"
+package_dir="$(find "${verification_root}" -mindepth 1 -maxdepth 1 -type d -name 'Gearmulator-Elektron-macOS-*' -print -quit)"
+if [[ -z "${package_dir}" ]]; then
+  echo "Extracted package directory was not found" >&2
+  exit 3
+fi
+
+setup_command="${package_dir}/macsetup_Gearmulator-Elektron.command"
+install_guide="${package_dir}/INSTALL-macOS.txt"
+bundles=(
+  "${package_dir}/Gearmulator MD.app"
+  "${package_dir}/Gearmulator MM.app"
+  "${package_dir}/Gearmulator MD.vst3"
+  "${package_dir}/Gearmulator MM.vst3"
+)
+
+if [[ ! -x "${setup_command}" ]]; then
+  echo "Setup command is missing or is not executable: ${setup_command}" >&2
+  exit 3
+fi
+if [[ ! -f "${install_guide}" ]]; then
+  echo "Installation guide is missing: ${install_guide}" >&2
+  exit 3
+fi
+
+quarantined_paths=("${setup_command}")
+for bundle in "${bundles[@]}"; do
+  if [[ ! -d "${bundle}" ]]; then
+    echo "Expected bundle is missing from extracted package: ${bundle}" >&2
+    exit 3
+  fi
+  executable="${bundle}/Contents/MacOS/$(basename "${bundle}" | sed -E 's/\.(app|vst3)$//')"
+  if [[ ! -f "${executable}" ]]; then
+    echo "Expected bundle executable is missing: ${executable}" >&2
+    exit 3
+  fi
+  quarantined_paths+=("${bundle}" "${executable}")
+done
+
+for path in "${quarantined_paths[@]}"; do
+  /usr/bin/xattr -w com.apple.quarantine "0081;00000000;GearmulatorPackageTest;" "${path}"
+done
+
+"${setup_command}"
+
+for path in "${quarantined_paths[@]}"; do
+  if /usr/bin/xattr -p com.apple.quarantine "${path}" >/dev/null 2>&1; then
+    echo "Setup command left quarantine metadata on: ${path}" >&2
+    exit 4
+  fi
+done
+
+for bundle in "${bundles[@]}"; do
+  /usr/bin/codesign --verify --deep --strict "${bundle}"
+done
+
+echo "Verified extracted MD/MM package setup flow: ${archive}"

--- a/scripts/macos/write_mdmm_receipt.py
+++ b/scripts/macos/write_mdmm_receipt.py
@@ -34,6 +34,7 @@ def main() -> None:
     parser.add_argument("--source", type=pathlib.Path, required=True)
     parser.add_argument("--output", type=pathlib.Path, required=True)
     parser.add_argument("--artifact", type=pathlib.Path, action="append", required=True)
+    parser.add_argument("--package-file", type=pathlib.Path, action="append", default=[])
     args = parser.parse_args()
 
     source = args.source.resolve()
@@ -46,6 +47,17 @@ def main() -> None:
                 "module": module.name,
                 "bytes": module.stat().st_size,
                 "sha256": sha256(module),
+            }
+        )
+
+    package_files = []
+    for package_file in args.package_file:
+        package_file = package_file.resolve()
+        package_files.append(
+            {
+                "name": package_file.name,
+                "bytes": package_file.stat().st_size,
+                "sha256": sha256(package_file),
             }
         )
 
@@ -62,6 +74,7 @@ def main() -> None:
         "firmware_included": False,
         "tests_run": True,
         "artifacts": artifacts,
+        "package_files": package_files,
     }
     args.output.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
 

--- a/scripts/macos/write_mdmm_receipt.py
+++ b/scripts/macos/write_mdmm_receipt.py
@@ -73,6 +73,7 @@ def main() -> None:
     parser.add_argument("--output", type=pathlib.Path)
     parser.add_argument("--artifact", type=pathlib.Path, action="append", default=[])
     parser.add_argument("--package-file", type=pathlib.Path, action="append", default=[])
+    parser.add_argument("--archive", type=pathlib.Path)
     parser.add_argument("--check-source-only", action="store_true")
     args = parser.parse_args()
 
@@ -81,8 +82,10 @@ def main() -> None:
     if args.check_source_only:
         print(json.dumps(commits, sort_keys=True))
         return
-    if args.output is None or not args.artifact:
-        parser.error("--output and at least one --artifact are required when writing a receipt")
+    if args.output is None or not args.artifact or args.archive is None:
+        parser.error(
+            "--output, --archive, and at least one --artifact are required when writing a receipt"
+        )
 
     artifacts = []
     for bundle in args.artifact:
@@ -107,6 +110,7 @@ def main() -> None:
             }
         )
 
+    archive = args.archive.resolve()
     receipt = {
         "schema": "gearmulator-elektron-macos-build-v1",
         "created_utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
@@ -117,6 +121,11 @@ def main() -> None:
         **commits,
         "firmware_included": False,
         "tests_run": True,
+        "archive": {
+            "name": archive.name,
+            "bytes": archive.stat().st_size,
+            "sha256": sha256(archive),
+        },
         "artifacts": artifacts,
         "package_files": package_files,
     }

--- a/scripts/macos/write_mdmm_receipt.py
+++ b/scripts/macos/write_mdmm_receipt.py
@@ -14,6 +14,44 @@ def git(repo: pathlib.Path, *args: str) -> str:
     return subprocess.check_output(["git", "-C", str(repo), *args], text=True).strip()
 
 
+def submodule_commit(source: pathlib.Path, name: str) -> str:
+    relative = pathlib.PurePosixPath(
+        git(source, "config", "-f", ".gitmodules", "--get", f"submodule.{name}.path")
+    )
+    if relative.is_absolute() or ".." in relative.parts:
+        raise RuntimeError(f"unsafe path for submodule {name}: {relative}")
+
+    checkout = (source / pathlib.Path(*relative.parts)).resolve()
+    try:
+        checkout.relative_to(source)
+    except ValueError as error:
+        raise RuntimeError(f"submodule {name} resolves outside the source tree: {checkout}") from error
+
+    expected = git(source, "rev-parse", f"HEAD:{relative.as_posix()}")
+    actual_root = pathlib.Path(git(checkout, "rev-parse", "--show-toplevel")).resolve()
+    if actual_root != checkout:
+        raise RuntimeError(
+            f"submodule {name} is not initialized at {relative} "
+            f"(Git resolved it to {actual_root})"
+        )
+
+    actual = git(checkout, "rev-parse", "HEAD")
+    if actual != expected:
+        raise RuntimeError(
+            f"submodule {name} checkout does not match the parent gitlink: "
+            f"expected {expected}, found {actual}"
+        )
+    return actual
+
+
+def source_tuple(source: pathlib.Path) -> dict[str, str]:
+    return {
+        "source_commit": git(source, "rev-parse", "HEAD"),
+        "dsp56300_commit": submodule_commit(source, "source/dsp56300"),
+        "mc68k_commit": submodule_commit(source, "source/mc68k"),
+    }
+
+
 def sha256(path: pathlib.Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as source:
@@ -32,12 +70,20 @@ def bundle_module(bundle: pathlib.Path) -> pathlib.Path:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--source", type=pathlib.Path, required=True)
-    parser.add_argument("--output", type=pathlib.Path, required=True)
-    parser.add_argument("--artifact", type=pathlib.Path, action="append", required=True)
+    parser.add_argument("--output", type=pathlib.Path)
+    parser.add_argument("--artifact", type=pathlib.Path, action="append", default=[])
     parser.add_argument("--package-file", type=pathlib.Path, action="append", default=[])
+    parser.add_argument("--check-source-only", action="store_true")
     args = parser.parse_args()
 
     source = args.source.resolve()
+    commits = source_tuple(source)
+    if args.check_source_only:
+        print(json.dumps(commits, sort_keys=True))
+        return
+    if args.output is None or not args.artifact:
+        parser.error("--output and at least one --artifact are required when writing a receipt")
+
     artifacts = []
     for bundle in args.artifact:
         module = bundle_module(bundle.resolve())
@@ -68,9 +114,7 @@ def main() -> None:
         "architecture": "x86_64 arm64",
         "signing": "ad-hoc",
         "notarized": False,
-        "source_commit": git(source, "rev-parse", "HEAD"),
-        "dsp56300_commit": git(source / "source" / "dsp56300", "rev-parse", "HEAD"),
-        "mc68k_commit": git(source / "source" / "mc68k", "rev-parse", "HEAD"),
+        **commits,
         "firmware_included": False,
         "tests_run": True,
         "artifacts": artifacts,

--- a/scripts/windows/build_mdmm.ps1
+++ b/scripts/windows/build_mdmm.ps1
@@ -204,6 +204,14 @@ $receiptArtifacts = foreach ($artifact in $artifacts) {
     }
 }
 
+$zipPath = Join-Path $OutputDir 'Gearmulator-Elektron-Windows-x64.zip'
+if (Test-Path -LiteralPath $zipPath) { Remove-Item -LiteralPath $zipPath -Force }
+Compress-Archive -LiteralPath @(
+    $artifacts.FullName
+    (Join-Path $SourceDir 'LICENSE.md')
+) -DestinationPath $zipPath -CompressionLevel Optimal
+
+$zip = Get-Item -LiteralPath $zipPath
 $receipt = [ordered]@{
     schema = 'gearmulator-elektron-windows-build-v1'
     created_utc = [DateTime]::UtcNow.ToString('o')
@@ -214,17 +222,16 @@ $receipt = [ordered]@{
     mc68k_commit = $mc68kCommit
     firmware_included = $false
     tests_run = [bool]$WithTests
+    archive = [ordered]@{
+        name = $zip.Name
+        bytes = $zip.Length
+        sha256 = (Get-FileHash -LiteralPath $zip.FullName -Algorithm SHA256).Hash
+    }
     artifacts = $receiptArtifacts
 }
 
 $receiptPath = Join-Path $OutputDir 'Gearmulator-Elektron-Windows-x64-receipt.json'
 $receipt | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $receiptPath -Encoding UTF8
-$zipPath = Join-Path $OutputDir 'Gearmulator-Elektron-Windows-x64.zip'
-if (Test-Path -LiteralPath $zipPath) { Remove-Item -LiteralPath $zipPath -Force }
-Compress-Archive -LiteralPath @(
-    $artifacts.FullName
-    (Join-Path $SourceDir 'LICENSE.md')
-) -DestinationPath $zipPath -CompressionLevel Optimal
 
 Write-Host "WINDOWS_MDMM_ZIP=$zipPath"
 Write-Host "WINDOWS_MDMM_RECEIPT=$receiptPath"

--- a/scripts/windows/build_mdmm.ps1
+++ b/scripts/windows/build_mdmm.ps1
@@ -69,8 +69,9 @@ function Get-SubmoduleCommit {
 
     $expected = Invoke-GitText -GitPath $GitPath -Repository $Source -Arguments @(
         'rev-parse', "HEAD:$($relativePath -replace '\\', '/')")
-    $actualRoot = (Invoke-GitText -GitPath $GitPath -Repository $checkout -Arguments @(
-        'rev-parse', '--show-toplevel')).TrimEnd('/', '\')
+    $actualRoot = [IO.Path]::GetFullPath(
+        (Invoke-GitText -GitPath $GitPath -Repository $checkout -Arguments @(
+            'rev-parse', '--show-toplevel'))).TrimEnd('/', '\')
     if (-not $actualRoot.Equals($checkout, [StringComparison]::OrdinalIgnoreCase)) {
         throw "Submodule ${Name} is not initialized at ${relativePath} (Git resolved it to ${actualRoot})"
     }

--- a/scripts/windows/build_mdmm.ps1
+++ b/scripts/windows/build_mdmm.ps1
@@ -36,6 +36,52 @@ function Find-ExactlyOne {
     return $Candidates[0]
 }
 
+function Invoke-GitText {
+    param(
+        [Parameter(Mandatory = $true)] [string] $GitPath,
+        [Parameter(Mandatory = $true)] [string] $Repository,
+        [Parameter(Mandatory = $true)] [string[]] $Arguments
+    )
+    $output = & $GitPath -C $Repository @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Git failed in ${Repository}: git $($Arguments -join ' ')`n$($output -join "`n")"
+    }
+    return ($output -join "`n").Trim()
+}
+
+function Get-SubmoduleCommit {
+    param(
+        [Parameter(Mandatory = $true)] [string] $GitPath,
+        [Parameter(Mandatory = $true)] [string] $Source,
+        [Parameter(Mandatory = $true)] [string] $Name
+    )
+    $relativePath = Invoke-GitText -GitPath $GitPath -Repository $Source -Arguments @(
+        'config', '-f', '.gitmodules', '--get', "submodule.${Name}.path")
+    if ([IO.Path]::IsPathRooted($relativePath) -or $relativePath -split '[/\\]' -contains '..') {
+        throw "Unsafe path for submodule ${Name}: ${relativePath}"
+    }
+
+    $checkout = [IO.Path]::GetFullPath((Join-Path $Source $relativePath)).TrimEnd('/', '\')
+    $sourceRoot = [IO.Path]::GetFullPath($Source).TrimEnd('/', '\')
+    if (-not $checkout.StartsWith("${sourceRoot}\", [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Submodule ${Name} resolves outside the source tree: ${checkout}"
+    }
+
+    $expected = Invoke-GitText -GitPath $GitPath -Repository $Source -Arguments @(
+        'rev-parse', "HEAD:$($relativePath -replace '\\', '/')")
+    $actualRoot = (Invoke-GitText -GitPath $GitPath -Repository $checkout -Arguments @(
+        'rev-parse', '--show-toplevel')).TrimEnd('/', '\')
+    if (-not $actualRoot.Equals($checkout, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Submodule ${Name} is not initialized at ${relativePath} (Git resolved it to ${actualRoot})"
+    }
+
+    $actual = Invoke-GitText -GitPath $GitPath -Repository $checkout -Arguments @('rev-parse', 'HEAD')
+    if ($actual -ne $expected) {
+        throw "Submodule ${Name} checkout does not match the parent gitlink: expected ${expected}, found ${actual}"
+    }
+    return $actual
+}
+
 if ($env:OS -ne 'Windows_NT') {
     throw 'build_mdmm.ps1 requires Windows.'
 }
@@ -58,6 +104,10 @@ if ($TestOnly -and -not (Test-Path -LiteralPath (Join-Path $BuildDir 'CMakeCache
 $cmake = (Get-Command cmake -ErrorAction Stop).Source
 $ctest = (Get-Command ctest -ErrorAction Stop).Source
 $git = (Get-Command git -ErrorAction Stop).Source
+$sourceCommit = Invoke-GitText -GitPath $git -Repository $SourceDir -Arguments @('rev-parse', 'HEAD')
+$dspCommit = Get-SubmoduleCommit -GitPath $git -Source $SourceDir -Name 'source/dsp56300'
+$mc68kCommit = Get-SubmoduleCommit -GitPath $git -Source $SourceDir -Name 'source/mc68k'
+Write-Host "MDMM_SOURCE_TUPLE=${sourceCommit}:${dspCommit}:${mc68kCommit}"
 New-Item -ItemType Directory -Path $BuildDir -Force | Out-Null
 New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
 
@@ -153,9 +203,6 @@ $receiptArtifacts = foreach ($artifact in $artifacts) {
     }
 }
 
-$sourceCommit = (& $git -C $SourceDir rev-parse HEAD).Trim()
-$dspCommit = (& $git -C (Join-Path $SourceDir 'source\dsp56300') rev-parse HEAD).Trim()
-$mc68kCommit = (& $git -C (Join-Path $SourceDir 'source\mc68k') rev-parse HEAD).Trim()
 $receipt = [ordered]@{
     schema = 'gearmulator-elektron-windows-build-v1'
     created_utc = [DateTime]::UtcNow.ToString('o')


### PR DESCRIPTION
## Summary

- include one double-clickable macOS setup command that clears quarantine metadata from both MD/MM Standalone and VST3 bundles
- include concise installation instructions and hash both package-support files in the build receipt
- verify the final extracted ZIP by applying quarantine metadata, running the packaged helper, and rechecking all four code signatures
- resolve DSP56300 and MC68K locations from `.gitmodules` after the upstream source-tree move
- fail before compiling unless both dependency checkouts match the parent commit's exact gitlinks
- bind each uploaded receipt to the final ZIP's name, byte count, and SHA-256
- run the complete macOS and Windows artifact workflows when their release scripts change

## Validation

- `git diff --check`
- `bash -n` on the build, setup, and package-verification scripts
- `python3 -m py_compile scripts/macos/write_mdmm_receipt.py`
- source-tuple preflight against an initialized current release checkout
- negative source-tuple preflight against uninitialized submodules
- signed package fixture: archive/extract, quarantine bundle roots and nested executables, run setup helper, confirm metadata removal, verify signatures, and inspect receipt hashes

The macOS universal and Windows x64 artifact workflows are now the required hosted checks for this PR.