### PR TITLE
Expose MD and MM audio inputs and individual outputs

### DIFF
--- a/.github/workflows/mdmm-core.yml
+++ b/.github/workflows/mdmm-core.yml
@@ -8,16 +8,22 @@ on:
     paths:
       - ".github/workflows/mdmm-core.yml"
       - "source/cmake/base.cmake"
+      - "source/3rdparty/libresample/**"
       - "source/elektron/md/**"
       - "source/framework/hardwareLib/**"
+      - "source/framework/juce/jucePluginLib/**"
+      - "source/framework/synthLib/**"
       - "source/cpu/mc68k"
       - "source/cpu/dsp56300"
   pull_request:
     paths:
       - ".github/workflows/mdmm-core.yml"
       - "source/cmake/base.cmake"
+      - "source/3rdparty/libresample/**"
       - "source/elektron/md/**"
       - "source/framework/hardwareLib/**"
+      - "source/framework/juce/jucePluginLib/**"
+      - "source/framework/synthLib/**"
       - "source/cpu/mc68k"
       - "source/cpu/dsp56300"
 
@@ -49,13 +55,17 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Configure asset-free core tests
+      - name: Install Linux plugin dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt update && sudo apt install -y libgl1-mesa-dev xorg-dev libasound2-dev
+
+      - name: Configure portable tests
         run: >-
           cmake -S . -B build
           -DCMAKE_BUILD_TYPE=Release
           -DBUILD_TESTING=ON
           -DGEARMULATOR_MD_BUILD_PROFILE_WORKLOAD=ON
-          -Dgearmulator_BUILD_JUCEPLUGIN=OFF
+          -Dgearmulator_BUILD_JUCEPLUGIN=ON
           -Dgearmulator_SYNTH_ELEKTRON=ON
           -Dgearmulator_SYNTH_OSIRUS=OFF
           -Dgearmulator_SYNTH_OSTIRUS=OFF
@@ -65,10 +75,10 @@ jobs:
           -Dgearmulator_SYNTH_JE8086=OFF
           ${{ matrix.platform_options }}
 
-      - name: Build asset-free core tests
+      - name: Build portable tests
         run: >-
           cmake --build build --config Release --parallel 3
-          --target dsp56kTestRunner mdLibTest mdFlashTest mdProfileWorkload
+          --target dsp56kTestRunner mdLibTest mdFlashTest mdProfileWorkload mdAudioIoLayoutTest
 
       - name: Build AMD flash regression test
         if: runner.os != 'Windows'
@@ -94,10 +104,10 @@ jobs:
           cmake --build build --config Release --parallel 3
           --target source/cpu/mc68k/mc68kColdFireDivideTest
 
-      - name: Run asset-free core tests
+      - name: Run portable tests
         run: >-
           ctest --test-dir build -C Release --output-on-failure
-          --tests-regex "^(dsp56300_unitTests|mc68kColdFireDivideTest|am29fTest|mdLibTests|mdFlashTest|mdProfileWorkload(Bounded)?Tests)$"
+          --tests-regex "^(dsp56300_unitTests|mc68kColdFireDivideTest|am29fTest|mdLibTests|mdFlashTest|mdAudioIoLayoutTest|mdProfileWorkload(Bounded)?Tests)$"
 
   apple-pgo:
     name: Apple PGO generate and use

--- a/source/3rdparty/libresample/include/libresample.h
+++ b/source/3rdparty/libresample/include/libresample.h
@@ -24,6 +24,10 @@ void *resample_open(int      highQuality,
 
 void *resample_dup(const void *handle);
 
+/* Copies a converter's timing state while replacing its audio history with
+   silence. This is useful when adding a synchronized channel to a live stream. */
+void *resample_dup_reset(const void *handle);
+
 int resample_get_filter_width(const void *handle);
 
 int resample_process(void   *handle,

--- a/source/3rdparty/libresample/src/resample.c
+++ b/source/3rdparty/libresample/src/resample.c
@@ -77,6 +77,17 @@ void *resample_dup(const void *	handle)
    return (void *)hp;
 }
 
+void *resample_dup_reset(const void *handle)
+{
+   rsdata *hp = (rsdata *)resample_dup(handle);
+   if (!hp)
+      return 0;
+
+   memset(hp->X, 0, (hp->XSize + hp->Xoff) * sizeof(float));
+   memset(hp->Y, 0, hp->YSize * sizeof(float));
+   return (void *)hp;
+}
+
 void *resample_open(int highQuality, double minFactor, double maxFactor)
 {
    double *Imp64;
@@ -344,4 +355,3 @@ void resample_close(void *handle)
    free(hp->ImpD);
    free(hp);
 }
-

--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -74,6 +74,16 @@ endif()
 target_compile_definitions(mmJucePlugin PRIVATE MD_JUCEPLUGIN_MONOMACHINE=1)
 
 if(BUILD_TESTING)
+	add_executable(mdAudioIoLayoutTest mdAudioIoLayoutTest.cpp)
+	target_link_libraries(mdAudioIoLayoutTest PRIVATE
+		mdJucePlugin jucePluginEditorLib mdLib juce_plugin_modules
+		juce::juce_opengl)
+	target_compile_definitions(mdAudioIoLayoutTest PRIVATE
+		JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1)
+	set_property(TARGET mdAudioIoLayoutTest PROPERTY FOLDER "Elektron/test")
+	add_test(NAME mdAudioIoLayoutTest COMMAND mdAudioIoLayoutTest)
+	set_tests_properties(mdAudioIoLayoutTest PROPERTIES LABELS "UnitTest")
+
 	add_executable(mdShiftTriggerLatchTest mdShiftTriggerLatchTest.cpp)
 	target_link_libraries(mdShiftTriggerLatchTest PRIVATE mdLib)
 	target_include_directories(mdShiftTriggerLatchTest PRIVATE

--- a/source/elektron/md/mdJucePlugin/mdAudioIoLayoutTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAudioIoLayoutTest.cpp
@@ -1,0 +1,590 @@
+#include "mdPluginProcessor.h"
+
+#include "juce_events/juce_events.h"
+#include "jucePluginLib/controller.h"
+#include "jucePluginLib/processor.h"
+#include "synthLib/device.h"
+#include "synthLib/plugin.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+	void require(const bool _condition, const std::string& _message)
+	{
+		if(!_condition)
+			throw std::runtime_error(_message);
+	}
+
+	class SyntheticAudioDevice final : public synthLib::Device
+	{
+	public:
+		SyntheticAudioDevice(const uint32_t _inputs, const uint32_t _outputs,
+			const uint32_t _inputLatency, const float _outputLevel = 0.125f)
+			: Device({}), m_inputs(_inputs), m_outputs(_outputs),
+			m_inputLatency(_inputLatency), m_outputLevel(_outputLevel)
+		{
+		}
+
+		float getSamplerate() const override { return 44100.0f; }
+		bool isValid() const override { return m_valid; }
+#if SYNTHLIB_DEMO_MODE == 0
+		bool getState(std::vector<uint8_t>&, synthLib::StateType) override
+		{
+			return false;
+		}
+		bool setState(const std::vector<uint8_t>&, synthLib::StateType) override
+		{
+			return false;
+		}
+#endif
+		uint32_t getChannelCountIn() override { return m_inputs; }
+		uint32_t getChannelCountOut() override { return m_outputs; }
+		uint32_t getInternalLatencyInputToOutput() const override
+		{
+			return m_inputLatency;
+		}
+		bool setDspClockPercent(uint32_t) override { return false; }
+		uint32_t getDspClockPercent() const override { return 100; }
+		uint64_t getDspClockHz() const override { return 100000000; }
+		bool receivedEveryOutput() const { return m_receivedEveryOutput; }
+		bool receivedEveryInput() const { return m_receivedEveryInput; }
+		float getInputPeak(const size_t _channel) const
+		{
+			return m_inputPeaks[_channel];
+		}
+		void invalidate() { m_valid = false; }
+
+	protected:
+		void readMidiOut(std::vector<synthLib::SMidiEvent>&) override {}
+		bool sendMidi(const synthLib::SMidiEvent&,
+			std::vector<synthLib::SMidiEvent>&) override
+		{
+			return true;
+		}
+		void processAudio(const synthLib::TAudioInputs& _inputs,
+			const synthLib::TAudioOutputs& _outputs, const size_t _samples) override
+		{
+			for(uint32_t channel = 0; channel < m_inputs; ++channel)
+			{
+				if(!_inputs[channel])
+				{
+					m_receivedEveryInput = false;
+					continue;
+				}
+				for(size_t sample = 0; sample < _samples; ++sample)
+					m_inputPeaks[channel] = std::max(m_inputPeaks[channel],
+						std::abs(_inputs[channel][sample]));
+			}
+			for(uint32_t channel = 0; channel < m_outputs; ++channel)
+			{
+				if(!_outputs[channel])
+				{
+					m_receivedEveryOutput = false;
+					continue;
+				}
+				std::fill_n(_outputs[channel], _samples,
+					m_outputLevel * static_cast<float>(channel + 1));
+			}
+		}
+
+	private:
+		uint32_t m_inputs;
+		uint32_t m_outputs;
+		uint32_t m_inputLatency;
+		float m_outputLevel;
+		bool m_receivedEveryOutput = true;
+		bool m_receivedEveryInput = true;
+		std::array<float, 4> m_inputPeaks{};
+		bool m_valid = true;
+	};
+
+	class SyntheticController final : public pluginLib::Controller
+	{
+	public:
+		explicit SyntheticController(pluginLib::Processor& _processor)
+			: Controller(_processor)
+		{
+		}
+
+		void sendParameterChange(const pluginLib::Parameter&, pluginLib::ParamValue,
+			pluginLib::Parameter::Origin) override
+		{
+		}
+		bool parseSysexMessage(const pluginLib::SysEx&,
+			synthLib::MidiEventSource) override
+		{
+			return false;
+		}
+		void onStateLoaded() override {}
+	};
+
+	class SyntheticProcessor final : public pluginLib::Processor
+	{
+	public:
+		SyntheticProcessor()
+			: Processor(BusesProperties()
+				.withInput("Input A/B", juce::AudioChannelSet::stereo(), true)
+				.withOutput("Main A/B", juce::AudioChannelSet::stereo(), true)
+				.withOutput("Out C/D", juce::AudioChannelSet::stereo(), false)
+				.withOutput("Out E/F", juce::AudioChannelSet::stereo(), false),
+				{"Synthetic audio I/O", "Test", true, true, false, false,
+					"Tsio", "urn:gearmulator:test:audio-io", {}})
+		{
+		}
+
+		synthLib::Device* createDevice() override
+		{
+			auto* const device = new SyntheticAudioDevice(2, 6, m_nextInputLatency);
+			m_syntheticDevice = device;
+			return device;
+		}
+
+		pluginLib::Controller* createController() override
+		{
+			return new SyntheticController(*this);
+		}
+		juce::AudioProcessorEditor* createEditor() override { return nullptr; }
+		bool hasEditor() const override { return false; }
+
+		SyntheticAudioDevice* getSyntheticDevice() const
+		{
+			return m_syntheticDevice;
+		}
+		void setNextInputLatency(const uint32_t _latency)
+		{
+			m_nextInputLatency = _latency;
+		}
+
+	private:
+		SyntheticAudioDevice* m_syntheticDevice = nullptr;
+		uint32_t m_nextInputLatency = 19;
+	};
+
+	class LatencyListener final : public juce::AudioProcessorListener
+	{
+	public:
+		void audioProcessorParameterChanged(juce::AudioProcessor*, int, float) override {}
+		void audioProcessorChanged(juce::AudioProcessor*,
+			const ChangeDetails& _details) override
+		{
+			if(_details.latencyChanged)
+				++latencyChanges;
+		}
+
+		std::atomic<uint32_t> latencyChanges{0};
+	};
+
+	void verifyModel(const md::MachineModel _model)
+	{
+		mdJucePlugin::AudioPluginAudioProcessor processor(_model,
+			mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig{}, false);
+
+		require(processor.getBusCount(true) == 1,
+			"expected one audio input bus");
+		require(processor.getBusCount(false) == 3,
+			"expected three audio output buses");
+		require(processor.getTotalNumInputChannels() == 2,
+			"expected two audio input channels");
+		require(processor.getTotalNumOutputChannels() == 2,
+			"expected only the main output to be enabled by default");
+
+		const std::array<const char*, 1> inputNames{"Input A/B"};
+		const std::array<const char*, 3> outputNames{
+			"Main A/B", "Out C/D", "Out E/F"};
+		for(int bus = 0; bus < static_cast<int>(inputNames.size()); ++bus)
+		{
+			const auto* const input = processor.getBus(true, bus);
+			require(input && input->isEnabled(), "input bus is disabled");
+			require(input->getName() == inputNames[bus], "unexpected input bus name");
+			require(input->getCurrentLayout() == juce::AudioChannelSet::stereo(),
+				"input bus is not stereo");
+		}
+		for(int bus = 0; bus < static_cast<int>(outputNames.size()); ++bus)
+		{
+			const auto* const output = processor.getBus(false, bus);
+			require(output, "output bus is missing");
+			require(output->getName() == outputNames[bus], "unexpected output bus name");
+			require(output->isEnabled() == (bus == 0),
+				"unexpected default output-bus state");
+			require(output->getCurrentLayout() == (bus == 0
+				? juce::AudioChannelSet::stereo()
+				: juce::AudioChannelSet::disabled()),
+				"unexpected default output-bus layout");
+		}
+
+		const auto defaultLayout = processor.getBusesLayout();
+		require(processor.checkBusesLayoutSupported(defaultLayout),
+			"default audio layout was rejected");
+
+		auto layout = defaultLayout;
+		layout.outputBuses.set(1, juce::AudioChannelSet::mono());
+		require(!processor.checkBusesLayoutSupported(layout),
+			"mono individual-output bus was accepted");
+
+		layout = defaultLayout;
+		layout.outputBuses.set(2, juce::AudioChannelSet::stereo());
+		require(!processor.checkBusesLayoutSupported(layout),
+			"enabled output after a disabled bus was accepted");
+
+		layout = defaultLayout;
+		layout.outputBuses.set(1, juce::AudioChannelSet::stereo());
+		require(processor.setBusesLayout(layout),
+			"host could not enable C/D");
+		require(processor.getTotalNumOutputChannels() == 4
+			&& processor.getBus(false, 1)->isEnabled()
+			&& !processor.getBus(false, 2)->isEnabled(),
+			"C/D-only auxiliary layout was not applied");
+
+		layout.outputBuses.set(2, juce::AudioChannelSet::stereo());
+		require(processor.setBusesLayout(layout),
+			"host could not enable E/F");
+		require(processor.getTotalNumOutputChannels() == 6
+			&& processor.getBus(false, 2)->isEnabled(),
+			"six-output layout was not applied");
+
+		require(processor.setBusesLayout(defaultLayout),
+			"host could not return to main-output-only layout");
+		require(processor.getTotalNumOutputChannels() == 2,
+			"main-output-only layout was not restored");
+	}
+
+	void verifyStandaloneLayout(const md::MachineModel _model)
+	{
+		const auto previousWrapper = juce::PluginHostType::getPluginLoadedAs();
+		juce::PluginHostType::jucePlugInClientCurrentWrapperType
+			= juce::AudioProcessor::wrapperType_Standalone;
+		juce::AudioProcessor::setTypeOfNextNewPlugin(
+			juce::AudioProcessor::wrapperType_Standalone);
+		auto processor = std::make_unique<mdJucePlugin::AudioPluginAudioProcessor>(
+			_model, mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig{}, false);
+		juce::AudioProcessor::setTypeOfNextNewPlugin(
+			juce::AudioProcessor::wrapperType_Undefined);
+		juce::PluginHostType::jucePlugInClientCurrentWrapperType = previousWrapper;
+
+		require(processor->wrapperType
+			== juce::AudioProcessor::wrapperType_Standalone,
+			"processor did not retain the Standalone wrapper type");
+		require(processor->getBusCount(false) == 1
+			&& processor->getTotalNumOutputChannels() == 6,
+			"Standalone did not expose one six-channel physical-output bus");
+		processor->disableNonMainBuses();
+		require(processor->getTotalNumOutputChannels() == 6,
+			"JUCE Standalone bus filtering hid auxiliary outputs");
+
+		for(const int channelCount : {2, 4, 6})
+		{
+			auto layout = processor->getBusesLayout();
+			layout.outputBuses.set(0,
+				juce::AudioChannelSet::canonicalChannelSet(channelCount));
+			require(processor->checkBusesLayoutSupported(layout),
+				"Standalone rejected a supported physical-output count");
+			require(processor->setBusesLayout(layout)
+				&& processor->getTotalNumOutputChannels() == channelCount,
+				"Standalone could not apply a supported physical-output count");
+		}
+	}
+
+	void verifyDeviceReplacementAudioTopology()
+	{
+		auto* const initial = new SyntheticAudioDevice(2, 2, 0);
+		auto replacement = std::make_unique<SyntheticAudioDevice>(2, 6, 23);
+		{
+			synthLib::Plugin plugin(initial,
+				[](synthLib::Device* const _device) { return _device; });
+			plugin.setHostSamplerate(48000.0f, 44100.0f);
+			plugin.setBlockSize(64);
+			const auto initialLatency = plugin.getLatencyInputToOutput();
+
+			plugin.setDevice(replacement.get());
+			require(plugin.getLatencyInputToOutput() > initialLatency,
+				"device replacement did not refresh input latency");
+
+			constexpr size_t blockSize = 256;
+			std::array<float, blockSize> leftInput{};
+			std::array<float, blockSize> rightInput{};
+			const synthLib::TAudioInputs inputs{
+				leftInput.data(), rightInput.data(), nullptr, nullptr};
+			std::array<std::array<float, blockSize>, 6> outputStorage{};
+			synthLib::TAudioOutputs outputs{};
+			for(size_t channel = 0; channel < outputStorage.size(); ++channel)
+				outputs[channel] = outputStorage[channel].data();
+			for(uint32_t block = 0; block < 4; ++block)
+				plugin.process(inputs, outputs, blockSize, 120.0f, 0.0f, true);
+
+			require(replacement->receivedEveryOutput(),
+				"six-channel replacement received a missing output buffer");
+			for(size_t channel = 0; channel < outputStorage.size(); ++channel)
+			{
+				const auto audible = std::any_of(outputStorage[channel].begin(),
+					outputStorage[channel].end(), [](const float _sample)
+					{
+						return std::abs(_sample) > 0.0001f;
+					});
+				require(audible,
+					"replacement output channel was not routed to the host");
+			}
+		}
+	}
+
+	void verifySameTopologyReplacementFlushesAudio()
+	{
+		auto* const initial = new SyntheticAudioDevice(2, 6, 0, 0.5f);
+		auto replacement = std::make_unique<SyntheticAudioDevice>(2, 6, 0, 0.0f);
+		{
+			synthLib::Plugin plugin(initial,
+				[](synthLib::Device* const _device) { return _device; });
+			plugin.setHostSamplerate(48000.0f, 44100.0f);
+			plugin.setBlockSize(64);
+
+			constexpr size_t blockSize = 256;
+			std::array<float, blockSize> leftInput{};
+			std::array<float, blockSize> rightInput{};
+			const synthLib::TAudioInputs inputs{
+				leftInput.data(), rightInput.data(), nullptr, nullptr};
+			std::array<std::array<float, blockSize>, 6> outputStorage{};
+			synthLib::TAudioOutputs outputs{};
+			for(size_t channel = 0; channel < outputStorage.size(); ++channel)
+				outputs[channel] = outputStorage[channel].data();
+
+			plugin.process(inputs, outputs, blockSize, 120.0f, 0.0f, true);
+			plugin.setDevice(replacement.get());
+			for(auto& output : outputStorage)
+				output.fill(0.0f);
+			plugin.process(inputs, outputs, blockSize, 120.0f, 0.0f, true);
+
+			for(const auto& output : outputStorage)
+			{
+				const auto staleAudio = std::any_of(output.begin(), output.end(),
+					[](const float _sample)
+					{
+						return std::abs(_sample) > 0.0001f;
+					});
+				require(!staleAudio,
+					"same-topology replacement emitted stale resampler audio");
+			}
+		}
+	}
+
+	void verifyOutputBusChangesPreserveMainResampler(
+		const synthLib::Resampler::Mode _mode)
+	{
+		auto* const referenceDevice = new SyntheticAudioDevice(2, 6, 0);
+		auto* const switchedDevice = new SyntheticAudioDevice(2, 6, 0);
+		synthLib::Plugin reference(referenceDevice,
+			[](synthLib::Device* const _device) { return _device; });
+		synthLib::Plugin switched(switchedDevice,
+			[](synthLib::Device* const _device) { return _device; });
+		for(auto* const plugin : {&reference, &switched})
+		{
+			plugin->setHostSamplerate(48000.0f, 44100.0f);
+			plugin->setResamplerMode(_mode);
+			plugin->setBlockSize(64);
+		}
+
+		constexpr size_t blockSize = 127;
+		std::array<float, blockSize> leftInput{};
+		std::array<float, blockSize> rightInput{};
+		const synthLib::TAudioInputs inputs{
+			leftInput.data(), rightInput.data(), nullptr, nullptr};
+		std::array<std::array<float, blockSize>, 6> referenceStorage{};
+		std::array<std::array<float, blockSize>, 6> switchedStorage{};
+		synthLib::TAudioOutputs referenceOutputs{};
+		synthLib::TAudioOutputs switchedOutputs{};
+		for(size_t channel = 0; channel < 6; ++channel)
+		{
+			referenceOutputs[channel] = referenceStorage[channel].data();
+			switchedOutputs[channel] = switchedStorage[channel].data();
+		}
+
+		const std::array<uint32_t, 7> switchedCounts{2, 2, 6, 6, 4, 2, 2};
+		for(const auto activeChannels : switchedCounts)
+		{
+			for(auto& output : referenceStorage)
+				output.fill(0.0f);
+			for(auto& output : switchedStorage)
+				output.fill(0.0f);
+			reference.process(inputs, referenceOutputs, blockSize,
+				120.0f, 0.0f, true, 2);
+			switched.process(inputs, switchedOutputs, blockSize,
+				120.0f, 0.0f, true, activeChannels);
+			for(size_t channel = 0; channel < 2; ++channel)
+				require(referenceStorage[channel] == switchedStorage[channel],
+					"output-bus change disturbed the main resampler");
+		}
+	}
+
+	void verifyReplacementLatencyNotificationIsAsync()
+	{
+		SyntheticProcessor processor;
+		juce::AudioProcessor& audioProcessor = processor;
+		audioProcessor.prepareToPlay(48000.0, 256);
+		LatencyListener listener;
+		processor.addListener(&listener);
+		processor.setNextInputLatency(97);
+		const auto previousHostLatency = processor.getLatencySamples();
+
+		std::thread worker([&]
+		{
+			processor.setDeviceType(pluginLib::DeviceType::Local, true);
+		});
+		worker.join();
+		require(listener.latencyChanges.load() == 0,
+			"device replacement notified the host synchronously");
+		require(processor.getLatencySamples() == previousHostLatency,
+			"device replacement changed host latency on the worker thread");
+		processor.removeListener(&listener);
+	}
+
+	void verifyInvalidDeviceReplacementRefreshesLatency()
+	{
+		auto initial = std::make_unique<SyntheticAudioDevice>(2, 6, 0);
+		auto replacement = std::make_unique<SyntheticAudioDevice>(2, 6, 31);
+		bool replaced = false;
+		{
+			synthLib::Plugin plugin(initial.get(),
+				[&](synthLib::Device* const _device)
+				{
+					require(_device == initial.get(),
+						"invalid-device callback received the wrong device");
+					initial.reset();
+					replaced = true;
+					return replacement.get();
+				});
+			plugin.setHostSamplerate(48000.0f, 44100.0f);
+			plugin.setBlockSize(64);
+			const auto initialLatency = plugin.getLatencyInputToOutput();
+
+			constexpr size_t blockSize = 256;
+			std::array<float, blockSize> leftInput{};
+			std::array<float, blockSize> rightInput{};
+			const synthLib::TAudioInputs inputs{
+				leftInput.data(), rightInput.data(), nullptr, nullptr};
+			std::array<std::array<float, blockSize>, 6> outputStorage{};
+			synthLib::TAudioOutputs outputs{};
+			for(size_t channel = 0; channel < outputStorage.size(); ++channel)
+				outputs[channel] = outputStorage[channel].data();
+
+			initial->invalidate();
+			plugin.process(inputs, outputs, blockSize, 120.0f, 0.0f, true);
+			require(replaced, "invalid device was not replaced");
+			require(plugin.getLatencyInputToOutput() > initialLatency,
+				"invalid-device replacement did not refresh Plugin latency");
+		}
+	}
+
+	void verifyProcessorAudioRouting()
+	{
+		SyntheticProcessor processor;
+		juce::AudioProcessor& audioProcessor = processor;
+		audioProcessor.prepareToPlay(48000.0, 256);
+		const auto expectedLatency = std::max(
+			processor.getPlugin().getLatencyMidiToOutput(),
+			processor.getPlugin().getLatencyInputToOutput());
+		require(processor.getLatencySamples() == static_cast<int>(expectedLatency),
+			"Processor did not report the prepared Plugin latency to the host");
+
+		constexpr int blockSize = 256;
+		juce::MidiBuffer midi;
+		juce::AudioBuffer<float> stereoBuffer(2, blockSize);
+		for(uint32_t block = 0; block < 4; ++block)
+		{
+			stereoBuffer.clear();
+			for(int sample = 0; sample < blockSize; ++sample)
+			{
+				stereoBuffer.setSample(0, sample, 0.25f);
+				stereoBuffer.setSample(1, sample, 0.5f);
+			}
+			audioProcessor.processBlock(stereoBuffer, midi);
+		}
+		require(processor.getSyntheticDevice()
+			&& processor.getSyntheticDevice()->receivedEveryOutput(),
+			"Processor did not provide every device output buffer");
+		for(int channel = 0; channel < stereoBuffer.getNumChannels(); ++channel)
+		{
+			const auto* const begin = stereoBuffer.getReadPointer(channel);
+			const auto audible = std::any_of(begin, begin + blockSize,
+				[](const float _sample)
+				{
+					return std::abs(_sample) > 0.0001f;
+				});
+			require(audible, "Processor dropped a main output channel");
+		}
+
+		auto layout = processor.getBusesLayout();
+		layout.outputBuses.set(1, juce::AudioChannelSet::stereo());
+		layout.outputBuses.set(2, juce::AudioChannelSet::stereo());
+		require(processor.setBusesLayout(layout),
+			"synthetic Processor rejected its six-output layout");
+		juce::AudioBuffer<float> buffer(6, blockSize);
+		for(uint32_t block = 0; block < 4; ++block)
+		{
+			buffer.clear();
+			for(int sample = 0; sample < blockSize; ++sample)
+			{
+				buffer.setSample(0, sample, 0.25f);
+				buffer.setSample(1, sample, 0.5f);
+			}
+			audioProcessor.processBlock(buffer, midi);
+		}
+		float previousPeak = 0.0f;
+		for(int channel = 0; channel < buffer.getNumChannels(); ++channel)
+		{
+			const auto* const begin = buffer.getReadPointer(channel);
+			const auto audible = std::any_of(begin, begin + blockSize,
+				[](const float _sample)
+				{
+					return std::abs(_sample) > 0.0001f;
+				});
+			require(audible, "Processor dropped an enabled output channel");
+			const auto peak = buffer.getMagnitude(channel, 0, blockSize);
+			require(peak > previousPeak,
+				"Processor reordered the enabled output channels");
+			previousPeak = peak;
+		}
+		require(processor.getSyntheticDevice()->receivedEveryInput()
+			&& processor.getSyntheticDevice()->getInputPeak(0) > 0.0f
+			&& processor.getSyntheticDevice()->getInputPeak(1)
+				> processor.getSyntheticDevice()->getInputPeak(0),
+			"Processor did not preserve both input channels");
+	}
+}
+
+int main()
+{
+	juce::ScopedJuceInitialiser_GUI juce;
+	try
+	{
+		verifyModel(md::MachineModel::Machinedrum);
+		verifyModel(md::MachineModel::Monomachine);
+		verifyStandaloneLayout(md::MachineModel::Machinedrum);
+		verifyStandaloneLayout(md::MachineModel::Monomachine);
+		verifyDeviceReplacementAudioTopology();
+		verifySameTopologyReplacementFlushesAudio();
+		verifyOutputBusChangesPreserveMainResampler(
+			synthLib::Resampler::Mode::Legacy);
+		verifyOutputBusChangesPreserveMainResampler(
+			synthLib::Resampler::Mode::MameHq);
+		verifyOutputBusChangesPreserveMainResampler(
+			synthLib::Resampler::Mode::MameLofi);
+		verifyInvalidDeviceReplacementRefreshesLatency();
+		verifyReplacementLatencyNotificationIsAsync();
+		verifyProcessorAudioRouting();
+		std::cout << "mdAudioIoLayoutTest: PASS\n";
+		return 0;
+	}
+	catch(const std::exception& _error)
+	{
+		std::cerr << "mdAudioIoLayoutTest: " << _error.what() << '\n';
+		return 1;
+	}
+}

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
@@ -69,17 +69,6 @@ namespace
 
 namespace mdJucePlugin
 {
-	auto AudioPluginAudioProcessor::makeBuses(const md::MachineModel _model)
-		-> BusesProperties
-	{
-		if(_model == md::MachineModel::Machinedrum)
-			return BusesProperties()
-				.withInput("Input", juce::AudioChannelSet::stereo(), true)
-				.withOutput("Out", juce::AudioChannelSet::stereo(), true);
-		return BusesProperties()
-			.withOutput("Out", juce::AudioChannelSet::stereo(), true);
-	}
-
 	void AudioPluginAudioProcessor::saveChunkData(baseLib::BinaryStream& _stream)
 	{
 		jucePluginEditorLib::Processor::saveChunkData(_stream);
@@ -298,7 +287,7 @@ namespace mdJucePlugin
 	AudioPluginAudioProcessor::AudioPluginAudioProcessor(const md::MachineModel _model,
 		std::vector<uint8_t> _initialPatchRam, const bool _allowMcpServer,
 		const bool _ephemeralConfig) :
-		Processor(makeBuses(_model),
+		Processor(createBusesProperties(),
 			getOptions(_model, _ephemeralConfig), makeProcessorProperties(_model),
 			_allowMcpServer, _ephemeralConfig
 				? jucePluginEditorLib::Processor::ConfigMode::Ephemeral
@@ -327,9 +316,60 @@ namespace mdJucePlugin
 		Processor::setLatencyBlocks(latencyBlocks);
 	}
 
+	juce::AudioProcessor::BusesProperties AudioPluginAudioProcessor::createBusesProperties()
+	{
+		auto buses = BusesProperties()
+			.withInput("Input A/B", juce::AudioChannelSet::stereo(), true);
+
+		// JUCE's Standalone wrapper disables every non-main bus after construction.
+		// Use one adaptive physical-output bus there so its audio-device dialog can
+		// expose all six outputs. Plug-in wrappers retain named stereo buses.
+		if(juce::PluginHostType::getPluginLoadedAs()
+			== juce::AudioProcessor::wrapperType_Standalone)
+			return buses.withOutput("Outputs A-F",
+				juce::AudioChannelSet::discreteChannels(6), true);
+
+		return buses
+			.withOutput("Main A/B", juce::AudioChannelSet::stereo(), true)
+			.withOutput("Out C/D", juce::AudioChannelSet::stereo(), false)
+			.withOutput("Out E/F", juce::AudioChannelSet::stereo(), false);
+	}
+
 	AudioPluginAudioProcessor::~AudioPluginAudioProcessor()
 	{
 		destroyEditorState();
+	}
+
+	bool AudioPluginAudioProcessor::isBusesLayoutSupported(
+		const BusesLayout& _layout) const
+	{
+		if(_layout.inputBuses.size() != 1
+			|| _layout.getMainInputChannelSet() != juce::AudioChannelSet::stereo())
+			return false;
+
+		if(_layout.outputBuses.size() == 1)
+		{
+			const auto channels = _layout.getMainOutputChannelSet().size();
+			return channels == 2 || channels == 4 || channels == 6;
+		}
+
+		if(_layout.outputBuses.size() != 3
+			|| _layout.getMainOutputChannelSet() != juce::AudioChannelSet::stereo())
+			return false;
+
+		bool precedingOutputEnabled = true;
+		for(int bus = 1; bus < _layout.outputBuses.size(); ++bus)
+		{
+			const auto channels = _layout.getChannelSet(false, bus);
+			if(channels == juce::AudioChannelSet::disabled())
+			{
+				precedingOutputEnabled = false;
+				continue;
+			}
+			if(!precedingOutputEnabled || channels != juce::AudioChannelSet::stereo())
+				return false;
+		}
+		return true;
 	}
 
 	jucePluginEditorLib::PluginEditorState* AudioPluginAudioProcessor::createEditorState()

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
@@ -39,7 +39,8 @@ namespace mdJucePlugin
 		void loadChunkData(baseLib::ChunkReader& _reader) override;
 
 	private:
-		static BusesProperties makeBuses(md::MachineModel _model);
+		static BusesProperties createBusesProperties();
+		bool isBusesLayoutSupported(const BusesLayout& _layout) const override;
 		AudioPluginAudioProcessor(md::MachineModel _model,
 			std::vector<uint8_t> _initialPatchRam, bool _allowMcpServer,
 			bool _ephemeralConfig);

--- a/source/elektron/md/mdLib/mddevice.cpp
+++ b/source/elektron/md/mdLib/mddevice.cpp
@@ -305,12 +305,12 @@ namespace md
 
 	uint32_t Device::getChannelCountIn()
 	{
-		return m_model == MachineModel::Machinedrum ? 2 : 0;
+		return 2;
 	}
 
 	uint32_t Device::getChannelCountOut()
 	{
-		return 2;
+		return 6;
 	}
 
 	bool Device::setDspClockPercent(const uint32_t _percent)
@@ -335,12 +335,8 @@ namespace md
 
 	void Device::processAudio(const synthLib::TAudioInputs& _inputs, const synthLib::TAudioOutputs& _outputs, const size_t _samples)
 	{
-		if(m_model == MachineModel::Machinedrum)
-			m_hardware->processAudio(_inputs, _outputs,
-				static_cast<uint32_t>(_samples), getExtraLatencySamples());
-		else
-			m_hardware->processAudio(_outputs, static_cast<uint32_t>(_samples),
-				getExtraLatencySamples());
+		m_hardware->processAudio(_inputs, _outputs,
+			static_cast<uint32_t>(_samples), getExtraLatencySamples());
 		m_numSamplesProcessed += static_cast<uint32_t>(_samples);
 	}
 

--- a/source/elektron/md/mdLib/mddevice.h
+++ b/source/elektron/md/mdLib/mddevice.h
@@ -99,6 +99,10 @@ namespace md
 		bool commitPreparedState(PreparedState& _prepared);
 		uint32_t getChannelCountIn() override;
 		uint32_t getChannelCountOut() override;
+		uint32_t getInternalLatencyInputToOutput() const override
+		{
+			return g_hostAudioInputSafetyFrames;
+		}
 		bool setDspClockPercent(uint32_t _percent) override;
 		uint32_t getDspClockPercent() const override;
 		uint64_t getDspClockHz() const override;

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -86,14 +86,6 @@ namespace md
 		return result;
 	}
 
-	dsp56k::TWord hostAudioInputSample(const synthLib::TAudioInputs& _inputs,
-		const uint32_t _frames, const uint32_t _cursor, const size_t _channel)
-	{
-		if(_channel >= 2 || _cursor >= _frames || !_inputs[_channel])
-			return 0;
-		return dsp56k::sample2dsp(_inputs[_channel][_cursor]);
-	}
-
 	Hardware::Hardware(const std::vector<uint8_t>& _romData, const std::string& _romName,
 		const MachineModel _model, const std::vector<uint8_t>& _initialPatchRam,
 		std::shared_ptr<FrontPanelPublisher> _frontPanelPublisher,
@@ -209,8 +201,8 @@ namespace md
 		// neither side of the FULL-DUPLEX link blocks at startup, and execTX runs before execRX
 		// each slot (esaiclock), so each DSP feeds its neighbour before it can block on its own
 		// RX - no deadlock, provided the two ESSI0 clock rates match (they do: same divider config
-		// on both DSPs). Codec ESSI1 RX is callback-fed and remains non-blocking: MD receives
-		// the current host input block, while MM and out-of-block reads receive silence.
+		// on both DSPs). Codec ESSI1 RX is callback-fed and remains non-blocking:
+		// out-of-block reads receive silence.
 		const auto txToRx = [](const dsp56k::Audio::TxFrame& _tx, dsp56k::Audio::RxFrame& _rx)
 		{
 			_rx.resize(_tx.size());
@@ -415,17 +407,11 @@ namespace md
 		const auto codecInput = [this](uint64_t& _frameIndex,
 			dsp56k::Audio::RxFrame& _frame)
 		{
-			const auto cursor = m_hostAudioInputCursor++;
-			const auto sample = [this, cursor](const size_t _channel)
-			{
-				return m_hostAudioInputActive
-					? hostAudioInputSample(m_hostAudioInputs,
-						m_hostAudioInputFrames, cursor, _channel)
-					: dsp56k::TWord{0};
-			};
+			RealtimeHostAudioInputQueue::Frame input{};
+			(void)m_hostAudioInput.pop(input);
 			_frame.resize(2);
-			_frame[0] = dsp56k::Audio::RxSlot{sample(0)};
-			_frame[1] = dsp56k::Audio::RxSlot{sample(1)};
+			_frame[0] = dsp56k::Audio::RxSlot{input[0]};
+			_frame[1] = dsp56k::Audio::RxSlot{input[1]};
 			++_frameIndex;
 		};
 
@@ -469,13 +455,9 @@ namespace md
 			m_dspMixer.getPeriph().getEssi0(), 0));
 		m_dspProducer.getPeriph().getEssi0().setReadRxCallback(blockingPop(
 			m_dspProducer.getPeriph().getEssi0(), 1));
-		// The Machinedrum mixer's ESSI1 is connected to the stereo codec ADC. The
-		// producer has no independent host input path, and MM behavior remains the
-		// established silent-input model until its input machines are qualified.
-		if(isMonomachine())
-			m_dspMixer.getPeriph().getEssi1().setReadRxCallback(silence);
-		else
-			m_dspMixer.getPeriph().getEssi1().setReadRxCallback(codecInput);
+		// Input A/B reaches the codec receiver on the mixer; the producer has no
+		// separate host input stream.
+		m_dspMixer.getPeriph().getEssi1().setReadRxCallback(codecInput);
 		m_dspProducer.getPeriph().getEssi1().setReadRxCallback(silence);
 
 		// Each mixer ESSI1 output frame advances the codec frame counter used by
@@ -980,9 +962,32 @@ namespace md
 		}
 	}
 
-	void Hardware::processAudio(const uint32_t _frames, const uint32_t /*_latency*/)
+	void Hardware::setHostAudioInputLatency(const uint32_t _latency)
+	{
+		const auto latency = std::min<uint32_t>(_latency + g_hostAudioInputSafetyFrames,
+			static_cast<uint32_t>(RealtimeHostAudioInputQueue::capacity()));
+		if(m_hostAudioInputLatencyInitialized && latency == m_hostAudioInputLatency)
+			return;
+
+		m_hostAudioInput.clear();
+		const RealtimeHostAudioInputQueue::Frame silence{};
+		for(uint32_t i = 0; i < latency; ++i)
+			m_hostAudioInput.push(silence);
+		m_hostAudioInputLatency = latency;
+		m_hostAudioInputLatencyInitialized = true;
+	}
+
+	void Hardware::queueHostAudioInput(const uint32_t _frames)
+	{
+		appendHostAudioInput(m_hostAudioInput, m_hostAudioInputSource,
+			m_hostAudioInputSourceFrames, m_hostAudioInputSourceCursor, _frames);
+		m_hostAudioInputSourceCursor += _frames;
+	}
+
+	void Hardware::processAudio(const uint32_t _frames, const uint32_t _latency)
 	{
 		ensureBufferSize(_frames);
+		setHostAudioInputLatency(_latency);
 
 		// During a real host callback retain the frames that the scheduler drains
 		// immediately, then copy them into the plug-in's six output channels.
@@ -991,7 +996,11 @@ namespace md
 
 		m_schedHostAudioActive = true;
 		const auto trimmed = renderHostAudio(m_schedHostAudio, m_audioOutputs, _frames,
-			[this](const uint32_t _chunk) { advance(_chunk); });
+			[this](const uint32_t _chunk)
+			{
+				queueHostAudioInput(_chunk);
+				advance(_chunk);
+			});
 		m_schedHostAudioActive = false;
 
 		// Preserve a small surplus to maintain codec continuity, but never allow
@@ -1004,7 +1013,7 @@ namespace md
 	{
 		processAudio(_frames, _latency);
 
-		for(uint32_t ch = 0; ch < 2; ++ch)
+		for(uint32_t ch = 0; ch < m_audioOutputs.size(); ++ch)
 		{
 			if(!_outputs[ch])
 				continue;
@@ -1017,14 +1026,13 @@ namespace md
 		const synthLib::TAudioOutputs& _outputs, const uint32_t _frames,
 		const uint32_t _latency)
 	{
-		m_hostAudioInputs = _inputs;
-		m_hostAudioInputFrames = _frames;
-		m_hostAudioInputCursor = 0;
-		m_hostAudioInputActive = true;
+		m_hostAudioInputSource = _inputs;
+		m_hostAudioInputSourceFrames = _frames;
+		m_hostAudioInputSourceCursor = 0;
 		processAudio(_outputs, _frames, _latency);
-		m_hostAudioInputActive = false;
-		m_hostAudioInputFrames = 0;
-		m_hostAudioInputs.fill(nullptr);
+		m_hostAudioInputSource.fill(nullptr);
+		m_hostAudioInputSourceFrames = 0;
+		m_hostAudioInputSourceCursor = 0;
 	}
 
 	// -------------------------------------------------------------------------------------------
@@ -1083,19 +1091,7 @@ namespace md
 				const bool dropped = m_schedHostAudio.emplace(
 					[&frame](RealtimeHostAudioQueue::Frame& _hostFrame)
 				{
-					_hostFrame.fill(0);
-					if(!frame.empty())
-					{
-						_hostFrame[0] = frame[0][0];	// AB left, ESSI1 TX0
-						_hostFrame[2] = frame[0][1];	// CD left, ESSI1 TX1
-						_hostFrame[4] = frame[0][2];	// EF left, ESSI1 TX2
-					}
-					if(frame.size() >= 2)
-					{
-						_hostFrame[1] = frame[1][0];	// AB right, ESSI1 TX0
-						_hostFrame[3] = frame[1][1];	// CD right, ESSI1 TX1
-						_hostFrame[5] = frame[1][2];	// EF right, ESSI1 TX2
-					}
+					mapCodecOutputFrame(_hostFrame, frame);
 				});
 				if(dropped)
 					m_schedHostAudioOverflow.fetch_add(1, std::memory_order_relaxed);

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -25,12 +25,12 @@
 
 namespace md
 {
-	struct ProfileWorkloadAccess;
-	// Convert one stereo codec-ADC sample with the bounds/null behavior used by
-	// ESSI1. Free-standing so the host-to-codec mapping can be tested without a ROM.
-	dsp56k::TWord hostAudioInputSample(const synthLib::TAudioInputs& _inputs,
-		uint32_t _frames, uint32_t _cursor, size_t _channel);
+	// One scheduler slice can finish its current JIT block after crossing a cycle
+	// target. Keep a small, reported input look-ahead so those codec reads never
+	// need samples from a future host callback.
+	inline constexpr uint32_t g_hostAudioInputSafetyFrames = 64;
 
+	struct ProfileWorkloadAccess;
 	inline const char* midiTurboSpeedLabel(const uint8_t _code)
 	{
 		switch(_code)
@@ -209,6 +209,8 @@ namespace md
 		void ensureBufferSize(uint32_t _frames);
 		void advanceFactoryFlashCapture();
 		void registerExternalInteraction();
+		void setHostAudioInputLatency(uint32_t _latency);
+		void queueHostAudioInput(uint32_t _frames);
 		void pumpDsp2HostRequest();		// DSP2 HI08 HREQ -> ColdFire external IRQ4 (see .cpp)
 		void onEssiCallbackMixer();		// master clock: advance the ESSI frame counter
 		template<typename InactiveObserved>
@@ -266,10 +268,12 @@ namespace md
 		RealtimeHostAudioQueue m_schedHostAudio;
 		std::atomic<uint64_t> m_schedHostAudioOverflow{0};
 		bool     m_schedHostAudioActive = false;	// retain drained frames for a host callback
-		synthLib::TAudioInputs m_hostAudioInputs{};
-		uint32_t m_hostAudioInputFrames = 0;
-		uint32_t m_hostAudioInputCursor = 0;
-		bool m_hostAudioInputActive = false;
+		RealtimeHostAudioInputQueue m_hostAudioInput;
+		synthLib::TAudioInputs m_hostAudioInputSource{};
+		uint32_t m_hostAudioInputSourceFrames = 0;
+		uint32_t m_hostAudioInputSourceCursor = 0;
+		uint32_t m_hostAudioInputLatency = 0;
+		bool m_hostAudioInputLatencyInitialized = false;
 		bool     m_schedInLinkDelivery = false;	// reentrancy guard for cross-DSP catch-up
 		bool     m_schedBoundedJit = false;		// experimental cycle-bounded background slices
 		double   m_schedFramesTotal   = 0.0;	// machine-time target, accumulated codec frames

--- a/source/elektron/md/mdLib/mdhostaudioqueue.h
+++ b/source/elektron/md/mdLib/mdhostaudioqueue.h
@@ -8,14 +8,15 @@
 
 #include "dsp56kBase/ringbuffer.h"
 #include "dsp56kEmu/audio.h"
+#include "synthLib/audioTypes.h"
 
 namespace md
 {
-	template<size_t Capacity>
+	template<size_t Channels, size_t Capacity>
 	class HostAudioQueue
 	{
 	public:
-		using Frame = std::array<dsp56k::TWord, 6>;
+		using Frame = std::array<dsp56k::TWord, Channels>;
 
 		template<typename Fill>
 		bool emplace(const Fill& _fill)
@@ -40,6 +41,19 @@ namespace md
 			return true;
 		}
 
+		size_t drop(const size_t _count)
+		{
+			const auto dropped = std::min(_count, m_frames.size());
+			for(size_t i = 0; i < dropped; ++i)
+				m_frames.pop_front();
+			return dropped;
+		}
+
+		void clear()
+		{
+			drop(m_frames.size());
+		}
+
 		size_t trimTo(const size_t _maximum)
 		{
 			const size_t dropped = m_frames.size() > _maximum
@@ -57,18 +71,50 @@ namespace md
 		dsp56k::RingBuffer<Frame, Capacity, false, false> m_frames;
 	};
 
-	using RealtimeHostAudioQueue = HostAudioQueue<dsp56k::Audio::RingBufferSize>;
+	using RealtimeHostAudioQueue = HostAudioQueue<6, dsp56k::Audio::RingBufferSize>;
+	using RealtimeHostAudioInputQueue = HostAudioQueue<2, dsp56k::Audio::RingBufferSize * 2>;
+
+	inline void mapCodecOutputFrame(RealtimeHostAudioQueue::Frame& _hostFrame,
+		const dsp56k::Audio::TxFrame& _codecFrame)
+	{
+		_hostFrame.fill(0);
+		const auto slots = std::min<size_t>(_codecFrame.size(), 2);
+		for(size_t slot = 0; slot < slots; ++slot)
+		{
+			for(size_t transmitter = 0; transmitter < 3; ++transmitter)
+				_hostFrame[transmitter * 2 + slot]
+					= _codecFrame[slot][transmitter];
+		}
+	}
+
+	template<size_t Capacity>
+	void appendHostAudioInput(HostAudioQueue<2, Capacity>& _queue,
+		const synthLib::TAudioInputs& _inputs, const uint32_t _sourceFrames,
+		const uint32_t _sourceOffset, const uint32_t _frames)
+	{
+		for(uint32_t i = 0; i < _frames; ++i)
+		{
+			typename HostAudioQueue<2, Capacity>::Frame frame{};
+			const auto sourceIndex = _sourceOffset + i;
+			for(size_t channel = 0; channel < frame.size(); ++channel)
+			{
+				if(_inputs[channel] && sourceIndex < _sourceFrames)
+					frame[channel] = dsp56k::sample2dsp(_inputs[channel][sourceIndex]);
+			}
+			_queue.push(frame);
+		}
+	}
 
 	// Drain a scheduler-owned codec queue into six host channels while advancing
 	// the machine by the full requested duration. Existing carry is always older
 	// than newly generated audio and is therefore copied first. Splitting oversized
 	// offline blocks keeps fixed storage bounded without changing machine time.
 	template<size_t Capacity, typename Advance>
-	size_t renderHostAudio(HostAudioQueue<Capacity>& _queue,
+	size_t renderHostAudio(HostAudioQueue<6, Capacity>& _queue,
 		std::array<std::vector<dsp56k::TWord>, 6>& _outputs,
 		const uint32_t _frames, Advance&& _advance)
 	{
-		typename HostAudioQueue<Capacity>::Frame frame{};
+		typename HostAudioQueue<6, Capacity>::Frame frame{};
 		uint32_t outputOffset = 0;
 		while(outputOffset < _frames)
 		{

--- a/source/elektron/md/mdLibTest/turboMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/turboMidiTest.cpp
@@ -1,4 +1,5 @@
 #include "mdLib/mdfrontpanel.h"
+#include "mdLib/mdhostaudioqueue.h"
 #include "mdLib/mdrealtimemidiqueue.h"
 #include "mdLib/mdhardware.h"
 #include "mdLib/mdsim.h"
@@ -213,6 +214,104 @@ namespace
 			&& check(queue.tryPop(output) && output == input[1],
 				"second realtime MIDI byte is wrong")
 			&& check(!queue.hasPending(), "drained realtime MIDI queue is not empty");
+	}
+
+	bool testHostAudioInputLookAhead()
+	{
+		md::HostAudioQueue<2, 16> queue;
+		const md::HostAudioQueue<2, 16>::Frame silence{};
+		for(uint32_t i = 0; i < 3; ++i)
+			queue.push(silence);
+
+		const std::array<float, 8> left{
+			0.01f, 0.02f, 0.03f, 0.04f, 0.05f, 0.06f, 0.07f, 0.08f};
+		const std::array<float, 8> right{
+			-0.01f, -0.02f, -0.03f, -0.04f, -0.05f, -0.06f, -0.07f, -0.08f};
+		const synthLib::TAudioInputs inputs{left.data(), right.data(), nullptr, nullptr};
+		md::appendHostAudioInput(queue, inputs, left.size(), 0, 4);
+
+		md::HostAudioQueue<2, 16>::Frame frame{};
+		for(uint32_t i = 0; i < 3; ++i)
+		{
+			if(!check(queue.pop(frame) && frame[0] == 0 && frame[1] == 0,
+				"host input look-ahead did not begin with silence"))
+				return false;
+		}
+		for(uint32_t sample = 0; sample < 2; ++sample)
+		{
+			if(!check(queue.pop(frame)
+				&& frame[0] == dsp56k::sample2dsp(left[sample])
+				&& frame[1] == dsp56k::sample2dsp(right[sample]),
+				"host input changed during simulated scheduler overshoot"))
+				return false;
+		}
+
+		md::appendHostAudioInput(queue, inputs, left.size(), 4, 4);
+		for(uint32_t sample = 2; sample < left.size(); ++sample)
+		{
+			if(!check(queue.pop(frame)
+				&& frame[0] == dsp56k::sample2dsp(left[sample])
+				&& frame[1] == dsp56k::sample2dsp(right[sample]),
+				"host input continuity was lost across callback blocks"))
+				return false;
+		}
+		return check(queue.empty(), "host input queue retained unexpected samples");
+	}
+
+	bool testHostAudioOutputRouting()
+	{
+		dsp56k::Audio::TxFrame codecFrame;
+		codecFrame.resize(2);
+		codecFrame[0] = {10, 20, 30};
+		codecFrame[1] = {11, 21, 31};
+		md::RealtimeHostAudioQueue::Frame mappedFrame{};
+		md::mapCodecOutputFrame(mappedFrame, codecFrame);
+		if(!check(mappedFrame == md::RealtimeHostAudioQueue::Frame{
+			10, 11, 20, 21, 30, 31},
+			"codec slots and transmitters were mapped to the wrong host channels"))
+			return false;
+
+		codecFrame.resize(1);
+		md::mapCodecOutputFrame(mappedFrame, codecFrame);
+		if(!check(mappedFrame == md::RealtimeHostAudioQueue::Frame{
+			10, 0, 20, 0, 30, 0},
+			"missing codec slot did not map to silent host channels"))
+			return false;
+
+		md::HostAudioQueue<6, 8> queue;
+		const auto pushFrame = [&queue](const dsp56k::TWord _sample)
+		{
+			queue.emplace([_sample](md::HostAudioQueue<6, 8>::Frame& _frame)
+			{
+				for(size_t channel = 0; channel < _frame.size(); ++channel)
+					_frame[channel] = _sample + static_cast<dsp56k::TWord>(channel * 100);
+			});
+		};
+		pushFrame(1);
+		pushFrame(2);
+
+		std::array<std::vector<dsp56k::TWord>, 6> outputs;
+		for(auto& output : outputs)
+			output.resize(5);
+		dsp56k::TWord generated = 3;
+		md::renderHostAudio(queue, outputs, 5, [&](const uint32_t _frames)
+		{
+			for(uint32_t i = 0; i < _frames; ++i)
+				pushFrame(generated++);
+		});
+
+		for(size_t channel = 0; channel < outputs.size(); ++channel)
+		{
+			for(dsp56k::TWord frameIndex = 0; frameIndex < 5; ++frameIndex)
+			{
+				if(!check(outputs[channel][frameIndex]
+					== frameIndex + 1 + static_cast<dsp56k::TWord>(channel * 100),
+					"host output channel mapping or carry order is wrong"))
+					return false;
+			}
+		}
+		return check(queue.size() == 2,
+			"host output queue did not preserve scheduler surplus");
 	}
 
 	bool testFrontPanelStepLeds()
@@ -488,23 +587,6 @@ namespace
 				"legacy MD state unexpectedly replaced flash");
 	}
 
-	bool testUwHostAudioInputMapping()
-	{
-		const float left[] = {0.25f, -0.5f};
-		const float right[] = {-0.75f, 0.125f};
-		synthLib::TAudioInputs inputs{};
-		inputs[0] = left;
-		inputs[1] = right;
-		return check(md::hostAudioInputSample(inputs, 2, 0, 0)
-				== dsp56k::sample2dsp(left[0]), "UW codec input changed the left channel")
-			&& check(md::hostAudioInputSample(inputs, 2, 1, 1)
-				== dsp56k::sample2dsp(right[1]), "UW codec input changed the right channel")
-			&& check(md::hostAudioInputSample(inputs, 2, 2, 0) == 0,
-				"UW codec input read beyond the host block")
-			&& check(md::hostAudioInputSample(inputs, 2, 0, 2) == 0,
-				"UW codec input accepted a non-codec channel");
-	}
-
 	bool testUwFactoryFlashCache()
 	{
 		std::vector<uint8_t> baseline(md::g_romSize, 0xff);
@@ -567,10 +649,10 @@ int main()
 {
 	if(!testTimeoutFallback() || !testDocumentedHandshake() || !testModelValidation()
 		|| !testDspMemoryFallback() || !testMk2PortAInvertedLoopback()
-		|| !testRealtimeMidiPendingState() || !testFrontPanelStepLeds()
+		|| !testRealtimeMidiPendingState() || !testHostAudioInputLookAhead()
+		|| !testHostAudioOutputRouting() || !testFrontPanelStepLeds()
 		|| !testFrontPanelLedTransitions()
 		|| !testFirmwareUpdateHandoff()
-		|| !testUwHostAudioInputMapping()
 		|| !testUwSparseProjectState()
 		|| !testUwFactoryFlashCache() || !testCachePromotionAndRecovery())
 		return 1;

--- a/source/framework/juce/jucePluginLib/processor.cpp
+++ b/source/framework/juce/jucePluginLib/processor.cpp
@@ -1,5 +1,6 @@
 #include "processor.h"
 
+#include <algorithm>
 #include <chrono>
 
 #include "dummydevice.h"
@@ -57,6 +58,7 @@ namespace pluginLib
 
 	Processor::~Processor()
 	{
+		cancelPendingUpdate();
 		m_midiPorts.close();
 		destroyController();
 		m_plugin.reset();
@@ -268,9 +270,24 @@ namespace pluginLib
 	void Processor::updateLatencySamples()
 	{
 		if(getProperties().isSynth)
-			setLatencySamples(getPlugin().getLatencyMidiToOutput());
+			setLatencySamples(std::max(getPlugin().getLatencyMidiToOutput(),
+				getPlugin().getLatencyInputToOutput()));
 		else
 			setLatencySamples(getPlugin().getLatencyInputToOutput());
+	}
+
+	void Processor::handleAsyncUpdate()
+	{
+		updateLatencySamples();
+	}
+
+	void Processor::requestLatencyUpdate()
+	{
+		auto* const messageManager = juce::MessageManager::getInstanceWithoutCreating();
+		if(messageManager && messageManager->isThisTheMessageThread())
+			updateLatencySamples();
+		else
+			triggerAsyncUpdate();
 	}
 
 	void Processor::saveCustomData(std::vector<uint8_t>& _targetBuffer)
@@ -593,6 +610,7 @@ namespace pluginLib
 				(void)m_device.release();
 				m_device.reset(dev);
 				m_deviceType = _type;
+				requestLatencyUpdate();
 			}
 		}
 		catch(synthLib::DeviceException& e)
@@ -799,7 +817,8 @@ namespace pluginLib
 			}
 		}
 
-		getPlugin().process(inputs, outputs, numSamples, bpm, ppqPos, isPlaying);
+		getPlugin().process(inputs, outputs, numSamples, bpm, ppqPos, isPlaying,
+			static_cast<uint32_t>(totalNumOutputChannels));
 
 		applyOutputGain(outputs, numSamples);
 
@@ -974,6 +993,7 @@ namespace pluginLib
 				if(newDevice && newDevice->isValid())
 				{
 					m_device.reset(newDevice);
+					triggerAsyncUpdate();
 					return newDevice;
 				}
 			}
@@ -1007,6 +1027,7 @@ namespace pluginLib
 			getPlugin().setDevice(device);
 			(void)m_device.release();
 			m_device.reset(device);
+			requestLatencyUpdate();
 
 			return true;
 		}

--- a/source/framework/juce/jucePluginLib/processor.h
+++ b/source/framework/juce/jucePluginLib/processor.h
@@ -40,7 +40,7 @@ namespace synthLib
 
 namespace pluginLib
 {
-	class Processor : public juce::AudioProcessor
+	class Processor : public juce::AudioProcessor, private juce::AsyncUpdater
 	{
 	public:
 		struct BinaryDataRef
@@ -226,6 +226,8 @@ namespace pluginLib
 		std::vector<synthLib::SMidiEvent> m_midiOut;
 
 	private:
+		void handleAsyncUpdate() override;
+		void requestLatencyUpdate();
 		void addHostMidiFeedback(const synthLib::SMidiEvent& _event);
 
 		const Properties m_properties;

--- a/source/framework/synthLib/plugin.cpp
+++ b/source/framework/synthLib/plugin.cpp
@@ -1,6 +1,7 @@
 #include "plugin.h"
 #include "device.h"
 
+#include <algorithm>
 #include <cmath>
 
 #include "baseLib/os.h"
@@ -81,7 +82,9 @@ namespace synthLib
 		m_device->reserveMidiEventCapacity(_capacity);
 	}
 
-	void Plugin::process(const TAudioInputs& _inputs, const TAudioOutputs& _outputs, size_t _count, const float _bpm, const float _ppqPos, const bool _isPlaying)
+	void Plugin::process(const TAudioInputs& _inputs, const TAudioOutputs& _outputs,
+		const size_t _count, const float _bpm, const float _ppqPos,
+		const bool _isPlaying, const uint32_t _activeOutputChannels)
 	{
 		baseLib::setFlushDenormalsToZero();
 
@@ -91,9 +94,6 @@ namespace synthLib
 		for(size_t i=0; i<inputs.size(); ++i)
 			inputs[i] = _inputs[i] ? _inputs[i] : getDummyBuffer(_count);
 
-		for(size_t i=0; i<outputs.size(); ++i)
-			outputs[i] = _outputs[i] ? _outputs[i] : getDummyBuffer(_count);
-
 		std::lock_guard lock(m_lock);
 
 		if(!m_device->isValid())
@@ -102,15 +102,28 @@ namespace synthLib
 
 			if(!m_device || !m_device->isValid())
 				return;
+
+			configureDeviceAudio();
 		}
+
+		const auto activeOutputChannels = _activeOutputChannels == 0
+			? m_device->getChannelCountOut()
+			: std::min(_activeOutputChannels, m_device->getChannelCountOut());
+		for(size_t i=0; i<activeOutputChannels; ++i)
+			outputs[i] = _outputs[i] ? _outputs[i] : getDummyBuffer(_count);
 
 		processMidiInEvents();
 		processMidiClock(_bpm, _ppqPos, _isPlaying, _count);
 
-		m_resampler.process(inputs, outputs, m_midiIn, m_midiOut, static_cast<uint32_t>(_count), 
+		m_resampler.process(inputs, outputs, m_midiIn, m_midiOut,
+			static_cast<uint32_t>(_count), activeOutputChannels,
 			[&](const TAudioInputs& _ins, const TAudioOutputs& _outs, size_t _c, const ResamplerInOut::TMidiVec& _midiIn, ResamplerInOut::TMidiVec& _midiOut)
 		{
-			m_device->process(_ins, _outs, _c, _midiIn, _midiOut);
+			TAudioOutputs deviceOutputs(_outs);
+			for(size_t i = activeOutputChannels;
+				i < m_device->getChannelCountOut(); ++i)
+				deviceOutputs[i] = getDummyBuffer(_c);
+			m_device->process(_ins, deviceOutputs, _c, _midiIn, _midiOut);
 		});
 
 		m_midiIn.clear();
@@ -141,14 +154,13 @@ namespace synthLib
 
 		m_device = _device;
 
-		m_device->setSamplerate(m_deviceSamplerate);
+		configureDeviceAudio();
 		if(!deviceState.empty())
 			setState(deviceState);
 
 		// MIDI clock has to send the start event again, some device find it confusing and do strange things if there isn't any
 		m_midiClock.restart();
 
-		updateDeviceLatency();
 	}
 
 #if !SYNTHLIB_DEMO_MODE
@@ -234,6 +246,14 @@ namespace synthLib
 			m_dummyBuffer.resize(_minimumSize);
 
 		return m_dummyBuffer.data();
+	}
+
+	void Plugin::configureDeviceAudio()
+	{
+		m_device->setSamplerate(m_deviceSamplerate);
+		m_resampler.reconfigure(m_device->getChannelCountIn(),
+			m_device->getChannelCountOut(), m_hostSamplerate, m_deviceSamplerate);
+		updateDeviceLatency();
 	}
 
 	void Plugin::updateDeviceLatency()

--- a/source/framework/synthLib/plugin.h
+++ b/source/framework/synthLib/plugin.h
@@ -41,7 +41,9 @@ namespace synthLib
 		uint32_t getLatencyMidiToOutput() const;
 		uint32_t getLatencyInputToOutput() const;
 
-		void process(const TAudioInputs& _inputs, const TAudioOutputs& _outputs, size_t _count, float _bpm, float _ppqPos, bool _isPlaying);
+		void process(const TAudioInputs& _inputs, const TAudioOutputs& _outputs,
+			size_t _count, float _bpm, float _ppqPos, bool _isPlaying,
+			uint32_t _activeOutputChannels = 0);
 		void getMidiOut(std::vector<SMidiEvent>& _midiOut);
 
 		bool isValid() const;
@@ -71,6 +73,7 @@ namespace synthLib
 	private:
 		void processMidiClock(float _bpm, float _ppqPos, bool _isPlaying, size_t _sampleCount);
 		float* getDummyBuffer(size_t _minimumSize);
+		void configureDeviceAudio();
 		void updateDeviceLatency();
 		void processMidiInEvents();
 		void processMidiInEvent(const SMidiEvent& _ev);

--- a/source/framework/synthLib/resampler.cpp
+++ b/source/framework/synthLib/resampler.cpp
@@ -202,32 +202,49 @@ void synthLib::Resampler::destroyResamplers()
 
 void synthLib::Resampler::setChannelCount(uint32_t _numChannels)
 {
-	if (m_tempOutput.size() == _numChannels)
+	const auto oldChannelCount = static_cast<uint32_t>(m_tempOutput.size());
+	if (oldChannelCount == _numChannels)
 		return;
 
-	destroyResamplers();
+	if (_numChannels < oldChannelCount)
+	{
+		for (uint32_t i = _numChannels; i < oldChannelCount; ++i)
+		{
+			if (m_resamplerOut[i])
+				resample_close(m_resamplerOut[i]);
+		}
+	}
 
 	m_resamplerOut.resize(_numChannels);
 	m_tempOutput.resize(_numChannels);
 	m_mameResamplerOut.resize(_numChannels);
 	m_mameTempOutput.resize(_numChannels);
-
-	for (auto& buf : m_tempOutput)
-		buf.clear();
-	for (auto& buf : m_mameTempOutput)
-		buf.clear();
+	if (_numChannels <= oldChannelCount)
+		return;
 
 	const auto factor = static_cast<double>(m_factorOutToIn);
 
 	if (useMameResampler())
 	{
 		const auto mode = (m_mode == Mode::MameLofi) ? MameResamplerMode::Lofi : MameResamplerMode::Hq;
-		for (auto& resampler : m_mameResamplerOut)
-			resampler = MameResampler::create(mode, static_cast<uint32_t>(m_samplerateIn), static_cast<uint32_t>(m_samplerateOut));
+		for (uint32_t i = oldChannelCount; i < _numChannels; ++i)
+		{
+			m_mameResamplerOut[i] = MameResampler::create(mode,
+				static_cast<uint32_t>(m_samplerateIn),
+				static_cast<uint32_t>(m_samplerateOut));
+			if (oldChannelCount > 0)
+				m_mameTempOutput[i].assign(m_mameTempOutput[0].size(), 0.0f);
+		}
 	}
 	else
 	{
-		for (auto& resampler : m_resamplerOut)
-			resampler = resample_open(1, factor, factor);
+		for (uint32_t i = oldChannelCount; i < _numChannels; ++i)
+		{
+			m_resamplerOut[i] = oldChannelCount > 0
+				? resample_dup_reset(m_resamplerOut[0])
+				: resample_open(1, factor, factor);
+			if (oldChannelCount > 0)
+				m_tempOutput[i].assign(m_tempOutput[0].size(), 0.0f);
+		}
 	}
 }

--- a/source/framework/synthLib/resamplerInOut.cpp
+++ b/source/framework/synthLib/resamplerInOut.cpp
@@ -1,5 +1,6 @@
 #include "resamplerInOut.h"
 
+#include <algorithm>
 #include <array>
 
 #include "dsp56kBase/fastmath.h"
@@ -57,6 +58,17 @@ namespace synthLib
 		recreate();
 	}
 
+	void ResamplerInOut::reconfigure(const uint32_t _channelCountIn,
+		const uint32_t _channelCountOut, const float _hostSamplerate,
+		const float _deviceSamplerate)
+	{
+		m_channelCountIn = _channelCountIn;
+		m_channelCountOut = _channelCountOut;
+		m_samplerateHost = _hostSamplerate;
+		m_samplerateDevice = _deviceSamplerate;
+		recreate();
+	}
+
 	void ResamplerInOut::reserveMidiEventCapacity(const size_t _capacity)
 	{
 		m_processedMidiIn.reserve(_capacity);
@@ -66,15 +78,22 @@ namespace synthLib
 
 	void ResamplerInOut::recreate()
 	{
+		m_out.reset();
+		m_in.reset();
+		m_scaledInput = AudioBuffer(m_channelCountIn);
+		m_input = AudioBuffer(m_channelCountIn);
+		m_processedMidiIn.clear();
+		m_midiIn.clear();
+		m_midiOut.clear();
+		m_scaledInputSize = 0;
+		m_inputLatency = 0;
+		m_outputLatency = 0;
+
 		if(m_samplerateDevice < 1 || m_samplerateHost < 1)
 			return;
 
 		m_out.reset(new Resampler(m_samplerateDevice, m_samplerateHost, m_mode));
 		m_in.reset(new Resampler(m_samplerateHost, m_samplerateDevice, m_mode));
-
-		m_scaledInputSize = 0;
-		m_inputLatency = 0;
-		m_outputLatency = 0;
 
 		// prewarm to calculate latency
 		std::array<std::vector<float>, 12> data;
@@ -92,7 +111,9 @@ namespace synthLib
 			outs[i] = i >= data.size() ? nullptr : &data[i][0];
 
 		TMidiVec midiIn, midiOut;
-		process(ins, outs, TMidiVec(), midiOut, static_cast<uint32_t>(data[0].size()), [&](const TAudioInputs&, const TAudioOutputs&, size_t, const TMidiVec&, TMidiVec&)
+		process(ins, outs, TMidiVec(), midiOut,
+			static_cast<uint32_t>(data[0].size()), m_channelCountOut,
+			[&](const TAudioInputs&, const TAudioOutputs&, size_t, const TMidiVec&, TMidiVec&)
 		{
 		});
 	}
@@ -135,10 +156,15 @@ namespace synthLib
 		}
 	}
 
-	void ResamplerInOut::process(const TAudioInputs& _inputs, TAudioOutputs& _outputs, const TMidiVec& _midiIn, TMidiVec& _midiOut, const uint32_t _numSamples, const TProcessFunc& _processFunc)
+	void ResamplerInOut::process(const TAudioInputs& _inputs, TAudioOutputs& _outputs,
+		const TMidiVec& _midiIn, TMidiVec& _midiOut, const uint32_t _numSamples,
+		const uint32_t _activeOutputChannels,
+		const TProcessFunc& _processFunc)
 	{
 		if(!m_in || !m_out)
 			return;
+		const auto activeOutputChannels = std::min(_activeOutputChannels,
+			m_channelCountOut);
 
 		if(m_samplerateDevice == m_samplerateHost)
 		{
@@ -222,7 +248,8 @@ namespace synthLib
 			}
 		};
 
-		const auto outputSize = m_out->process(_outputs, m_channelCountOut, _numSamples, false, feedOutput);
+		const auto outputSize = m_out->process(_outputs, activeOutputChannels,
+			_numSamples, false, feedOutput);
 
 		scaleMidiEvents(_midiOut, m_midiOut, hostDivDev);
 		m_midiOut.clear();

--- a/source/framework/synthLib/resamplerInOut.h
+++ b/source/framework/synthLib/resamplerInOut.h
@@ -20,9 +20,14 @@ namespace synthLib
 		void setDeviceSamplerate(float _samplerate);
 		void setHostSamplerate(float _samplerate);
 		void setSamplerates(float _hostSamplerate, float _deviceSamplerate);
+		void reconfigure(uint32_t _channelCountIn, uint32_t _channelCountOut,
+			float _hostSamplerate, float _deviceSamplerate);
 		void reserveMidiEventCapacity(size_t _capacity);
 
-		void process(const TAudioInputs& _inputs, TAudioOutputs& _outputs, const TMidiVec& _midiIn, TMidiVec& _midiOut, uint32_t _numSamples, const TProcessFunc& _processFunc);
+		void process(const TAudioInputs& _inputs, TAudioOutputs& _outputs,
+			const TMidiVec& _midiIn, TMidiVec& _midiOut, uint32_t _numSamples,
+			uint32_t _activeOutputChannels,
+			const TProcessFunc& _processFunc);
 
 		uint32_t getOutputLatency() const { return m_outputLatency; }
 		uint32_t getInputLatency() const { return m_inputLatency; }
@@ -33,8 +38,8 @@ namespace synthLib
 		static void clampMidiEvents(TMidiVec& _dst, const TMidiVec& _src, uint32_t _offsetMin, uint32_t _offsetMax);
 		static void extractMidiEvents(TMidiVec& _dst, const TMidiVec& _src, uint32_t _offsetMin, uint32_t _offsetMax);
 
-		const uint32_t m_channelCountIn;
-		const uint32_t m_channelCountOut;
+		uint32_t m_channelCountIn;
+		uint32_t m_channelCountOut;
 
 		std::unique_ptr<Resampler> m_out = nullptr;
 		std::unique_ptr<Resampler> m_in = nullptr;


### PR DESCRIPTION
Summary

- expose stereo Input A/B to plug-in hosts
- expose Main A/B, Out C/D, and Out E/F as three stereo plug-in output buses
- keep Main A/B enabled by default and let the host opt into C/D and E/F
- expose 2, 4, or 6 physical outputs through the shipped Standalone applications' adaptive main bus
- forward host input through the existing device audio path
- reject non-contiguous or non-stereo plug-in auxiliary layouts so channel mapping remains unambiguous
- resample only the host outputs that are enabled, while preserving the main pair's resampler state when the layout changes
- defer device-replacement latency notifications when replacement occurs off the message thread

Validation

- add firmware-free tests for MD and MM plug-in bus counts, names, defaults, and supported 2/4/6-output configurations
- exercise the same non-main-bus filtering used by JUCE Standalone and verify that 2, 4, and 6 physical outputs remain available
- directly verify the synthetic codec-slot/transmitter mapping to host channels A-F
- verify stereo input delivery and ordered output delivery through a synthetic six-output device
- compare an untouched stereo stream with a 2 -> 6 -> 4 -> 2 stream at 48 kHz host / 44.1 kHz device, using 127-sample blocks and all three resampler modes
- verify device replacement clears stale resampler audio, refreshes plug-in latency, and does not notify the host synchronously from a worker/audio-style thread
- keep MD/MM core coverage on Linux, macOS, Windows, and the Apple PGO build; changes to the vendored resampler now trigger that workflow too

All new audio tests use synthetic samples and devices; they require no firmware or firmware-derived test data.

No README changes are included.
