### PR TITLE
Preserve MD/MM front-panel LED timing

### DIFF
--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -5,6 +5,7 @@ project(mdJucePlugin VERSION ${CMAKE_PROJECT_VERSION})
 set(SOURCES
 	mdController.cpp mdController.h
 	mdEditor.cpp mdEditor.h
+	mdFrontPanelPresentation.h
 	mdPanelAffordances.h
 	mdPluginEditorState.cpp mdPluginEditorState.h
 	mdProductSkinPolicy.h

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -90,7 +90,8 @@ namespace mdJucePlugin
 		// Arbitrary endless-knob value range; only per-move deltas are used.
 		constexpr float g_encoderRange = 100.0f;
 		constexpr int g_encoderBurstCap = 8;	// max ±1 events emitted per Change
-		constexpr int g_presentationRateHz = 60;
+		constexpr int g_presentationTimerId = 1;
+		constexpr int g_panelTimerId = 2;
 		constexpr double g_sysexStatusIntervalMilliseconds = 100.0;
 		constexpr size_t g_ledTransitionBatchSize = 256;
 
@@ -151,7 +152,8 @@ namespace mdJucePlugin
 		juce::Desktop::getInstance().removeFocusChangeListener(this);
 		m_panelSteps.clear();
 		cancelPanelInputGestures();
-		stopTimer();
+		stopTimer(g_presentationTimerId);
+		stopTimer(g_panelTimerId);
 	}
 
 	md::Hardware* Editor::getHardware() const
@@ -169,8 +171,7 @@ namespace mdJucePlugin
 		const bool ledsChangedBeforeDrain = m_ledsChanged;
 
 		std::array<md::FrontPanelLedTransition, g_ledTransitionBatchSize> transitions;
-		const auto drainTransitions = [&](const bool _apply,
-			const uint64_t _afterSequence = 0)
+		const auto drainTransitions = [&](const uint64_t _afterSequence = 0)
 		{
 			// The queue is bounded, so a full pre-existing backlog takes at most
 			// eight batches. Newly arriving writes can wait for the next frame.
@@ -181,10 +182,9 @@ namespace mdJucePlugin
 			{
 				const auto count = device->drainFrontPanelLedTransitions(
 					transitions.data(), transitions.size());
-				if(_apply)
-					for(size_t i = 0; i < count; ++i)
-						if(transitions[i].sequence > _afterSequence)
-							m_ledPresentation.apply(transitions[i], _nowMilliseconds);
+				for(size_t i = 0; i < count; ++i)
+					if(transitions[i].sequence > _afterSequence)
+						m_ledPresentation.apply(transitions[i], _nowMilliseconds);
 				if(count < transitions.size())
 					break;
 			}
@@ -217,18 +217,19 @@ namespace mdJucePlugin
 			m_ledResyncPending = false;
 			// Discard transitions already represented by the coherent snapshot and
 			// retain only writes that raced publication.
-			drainTransitions(true, published.ledSequence);
+			drainTransitions(published.ledSequence);
 		}
 		else if(m_ledResyncPending)
 		{
-			// A dropped transition has not reached a complete snapshot yet. Keep
-			// displaying the last known-good LED state while allowing the producer
-			// to make progress.
-			drainTransitions(false);
+			// Do not consume transitions until a snapshot covers the recovery target.
+			// The bounded producer may drop more events, but it never blocks, and each
+			// new drop extends the target through the status check below. Keeping the
+			// queue intact prevents a successful racing write from being discarded
+			// behind a snapshot that does not include it yet.
 		}
 		else
 		{
-			drainTransitions(true);
+			drainTransitions();
 		}
 
 		auto finalStatus = device->getFrontPanelLedTransitionStatus();
@@ -296,9 +297,13 @@ namespace mdJucePlugin
 		});
 		m_lcdCanvas->repaint();
 
-		// Present decoded panel changes at the renderer's normal 60 Hz cadence. Panel
-		// input timing and slow status text use independent elapsed-time deadlines.
-		startTimerHz(g_presentationRateHz);
+		// Presentation and firmware-facing panel edges use independent timers. JUCE
+		// quantizes startTimerHz(60) to 16 ms, so deriving 33 ms panel deadlines from
+		// those callbacks would systematically delay every edge to 48 ms.
+		startTimer(g_presentationTimerId,
+			panelAffordances::g_presentationTimerIntervalMilliseconds);
+		startTimer(g_panelTimerId,
+			panelAffordances::g_panelTimerIntervalMilliseconds);
 	}
 
 	void Editor::createButtons()
@@ -682,19 +687,15 @@ namespace mdJucePlugin
 		}
 	}
 
-	// Keep firmware-facing edges at the established 30 Hz interval regardless of
-	// how often the UI is presented.
-	void Editor::servicePanelQueue(const double _nowMilliseconds)
+	// One step per dedicated 33 ms timer callback, so the firmware sees distinct
+	// press and release edges independent of the presentation timer.
+	void Editor::servicePanelQueue()
 	{
 		if(m_panelSteps.empty())
 		{
-			if(!m_panelPulseTiming.navigationReady(_nowMilliseconds))
-				return;
 			servicePanelNavigation();
 			return;
 		}
-		if(!m_panelPulseTiming.stepDue(_nowMilliseconds))
-			return;
 
 		const auto step = m_panelSteps.front();
 		m_panelSteps.pop_front();
@@ -702,17 +703,24 @@ namespace mdJucePlugin
 		const auto combined = step.press ? m_panelRows.press(step.packet) : m_panelRows.release(step.packet);
 		if(auto* hw = getHardware())
 			hw->sendPanelEvent(combined.row, combined.mask);
-		// Give the firmware a complete 30 Hz interval to update its LED readback
+
+		// Give the firmware a complete panel timer interval to update its LED readback
 		// before deciding whether the pending direct-selection target needs another
 		// pulse. This also makes a rapid replacement request use observed state.
-		m_panelPulseTiming.didSendStep(_nowMilliseconds,
-			m_panelSteps.empty() && !step.press);
+		if(m_panelSteps.empty() && !step.press)
+			m_panelSettleTicks = 1;
 	}
 
 	void Editor::servicePanelNavigation()
 	{
 		if(!m_panelSteps.empty())
 			return;
+
+		if(m_panelSettleTicks > 0)
+		{
+			--m_panelSettleTicks;
+			return;
+		}
 
 		if(!m_frontPanelSnapshotValid)
 			return;
@@ -1495,8 +1503,16 @@ namespace mdJucePlugin
 			0, 0, static_cast<int>(md::FrontPanel::g_lcdWidth), static_cast<int>(md::FrontPanel::g_lcdHeight));
 	}
 
-	void Editor::timerCallback()
+	void Editor::timerCallback(const int _timerId)
 	{
+		if(_timerId == g_panelTimerId)
+		{
+			servicePanelQueue();
+			return;
+		}
+		if(_timerId != g_presentationTimerId)
+			return;
+
 		const auto nowMilliseconds = juce::Time::getMillisecondCounterHiRes();
 		// Some plugin hosts can lose the modifier key-up when focus moves to
 		// another window. Poll the native state as a fail-safe so no panel row can
@@ -1506,7 +1522,6 @@ namespace mdJucePlugin
 			releaseShiftHeldPanelControls();
 
 		m_frontPanelSnapshotValid = refreshFrontPanelState(nowMilliseconds);
-		servicePanelQueue(nowMilliseconds);
 
 		if(m_lcdCanvas && m_lcdChanged)
 			m_lcdCanvas->repaint();

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -90,6 +90,9 @@ namespace mdJucePlugin
 		// Arbitrary endless-knob value range; only per-move deltas are used.
 		constexpr float g_encoderRange = 100.0f;
 		constexpr int g_encoderBurstCap = 8;	// max ±1 events emitted per Change
+		constexpr int g_presentationRateHz = 60;
+		constexpr double g_sysexStatusIntervalMilliseconds = 100.0;
+		constexpr size_t g_ledTransitionBatchSize = 256;
 
 		constexpr PanelButton g_panelButtons[] =
 		{
@@ -157,15 +160,92 @@ namespace mdJucePlugin
 		return device ? &device->getHardware() : nullptr;
 	}
 
-	bool Editor::refreshFrontPanelSnapshot()
+	bool Editor::refreshFrontPanelState(const double _nowMilliseconds)
 	{
 		auto* device = dynamic_cast<md::Device*>(getProcessor().getPlugin().getDevice());
 		if(!device)
 			return false;
+		const auto ledPresentationBeforeDrain = m_ledPresentation;
+		const bool ledsChangedBeforeDrain = m_ledsChanged;
 
-		auto snapshot = device->getFrontPanelSnapshot();
-		m_lcdChanged = !m_frontPanelSnapshotValid || lcdChanged(m_frontPanelSnapshot, snapshot);
-		m_frontPanelSnapshot = std::move(snapshot);
+		std::array<md::FrontPanelLedTransition, g_ledTransitionBatchSize> transitions;
+		const auto drainTransitions = [&](const bool _apply,
+			const uint64_t _afterSequence = 0)
+		{
+			// The queue is bounded, so a full pre-existing backlog takes at most
+			// eight batches. Newly arriving writes can wait for the next frame.
+			constexpr size_t maxBatches =
+				(md::FrontPanelPublisher::g_ledTransitionCapacity
+					+ g_ledTransitionBatchSize - 1) / g_ledTransitionBatchSize;
+			for(size_t batch = 0; batch < maxBatches; ++batch)
+			{
+				const auto count = device->drainFrontPanelLedTransitions(
+					transitions.data(), transitions.size());
+				if(_apply)
+					for(size_t i = 0; i < count; ++i)
+						if(transitions[i].sequence > _afterSequence)
+							m_ledPresentation.apply(transitions[i], _nowMilliseconds);
+				if(count < transitions.size())
+					break;
+			}
+		};
+
+		auto status = device->getFrontPanelLedTransitionStatus();
+		const auto streamChanged = [this](const auto& _status)
+		{
+			return !m_ledTransitionStatusValid
+				|| _status.epoch != m_ledTransitionStatus.epoch
+				|| _status.dropped != m_ledTransitionStatus.dropped;
+		};
+		if(streamChanged(status))
+		{
+			m_ledResyncPending = true;
+			m_ledResyncSequence = std::max(
+				m_ledResyncSequence, status.producedSequence);
+		}
+
+		auto published = device->getFrontPanelPublishedState();
+		m_lcdChanged = !m_frontPanelSnapshotValid
+			|| lcdChanged(m_frontPanelSnapshot, published.panel);
+		m_frontPanelSnapshot = std::move(published.panel);
+
+		if(m_ledResyncPending
+			&& published.ledSequence >= m_ledResyncSequence)
+		{
+			m_ledPresentation.reset(m_frontPanelSnapshot);
+			m_ledsChanged = true;
+			m_ledResyncPending = false;
+			// Discard transitions already represented by the coherent snapshot and
+			// retain only writes that raced publication.
+			drainTransitions(true, published.ledSequence);
+		}
+		else if(m_ledResyncPending)
+		{
+			// A dropped transition has not reached a complete snapshot yet. Keep
+			// displaying the last known-good LED state while allowing the producer
+			// to make progress.
+			drainTransitions(false);
+		}
+		else
+		{
+			drainTransitions(true);
+		}
+
+		auto finalStatus = device->getFrontPanelLedTransitionStatus();
+		if(finalStatus.epoch != status.epoch || finalStatus.dropped != status.dropped)
+		{
+			// Do not present a partial sequence when an overflow/reset races this
+			// callback. The next coherent snapshot will replace this saved state.
+			m_ledPresentation = ledPresentationBeforeDrain;
+			m_ledsChanged = ledsChangedBeforeDrain;
+			m_ledResyncPending = true;
+			m_ledResyncSequence = std::max(
+				m_ledResyncSequence, finalStatus.producedSequence);
+		}
+		m_ledTransitionStatus = finalStatus;
+		m_ledTransitionStatusValid = true;
+		m_ledsChanged = m_ledPresentation.advance(_nowMilliseconds)
+			|| m_ledsChanged;
 		return true;
 	}
 
@@ -216,8 +296,9 @@ namespace mdJucePlugin
 		});
 		m_lcdCanvas->repaint();
 
-		// ~30 Hz refresh of the live framebuffer (the firmware runs on the MCU thread).
-		startTimerHz(30);
+		// Present decoded panel changes at the renderer's normal 60 Hz cadence. Panel
+		// input timing and slow status text use independent elapsed-time deadlines.
+		startTimerHz(g_presentationRateHz);
 	}
 
 	void Editor::createButtons()
@@ -601,14 +682,19 @@ namespace mdJucePlugin
 		}
 	}
 
-	// One step per timer tick, so the firmware sees distinct press and release edges.
-	void Editor::servicePanelQueue()
+	// Keep firmware-facing edges at the established 30 Hz interval regardless of
+	// how often the UI is presented.
+	void Editor::servicePanelQueue(const double _nowMilliseconds)
 	{
 		if(m_panelSteps.empty())
 		{
+			if(!m_panelPulseTiming.navigationReady(_nowMilliseconds))
+				return;
 			servicePanelNavigation();
 			return;
 		}
+		if(!m_panelPulseTiming.stepDue(_nowMilliseconds))
+			return;
 
 		const auto step = m_panelSteps.front();
 		m_panelSteps.pop_front();
@@ -616,12 +702,11 @@ namespace mdJucePlugin
 		const auto combined = step.press ? m_panelRows.press(step.packet) : m_panelRows.release(step.packet);
 		if(auto* hw = getHardware())
 			hw->sendPanelEvent(combined.row, combined.mask);
-
-		// Give the firmware a complete timer interval to update its LED readback
+		// Give the firmware a complete 30 Hz interval to update its LED readback
 		// before deciding whether the pending direct-selection target needs another
 		// pulse. This also makes a rapid replacement request use observed state.
-		if(m_panelSteps.empty() && !step.press)
-			m_panelSettleTicks = 1;
+		m_panelPulseTiming.didSendStep(_nowMilliseconds,
+			m_panelSteps.empty() && !step.press);
 	}
 
 	void Editor::servicePanelNavigation()
@@ -629,13 +714,7 @@ namespace mdJucePlugin
 		if(!m_panelSteps.empty())
 			return;
 
-		if(m_panelSettleTicks > 0)
-		{
-			--m_panelSettleTicks;
-			return;
-		}
-
-		if(!m_frontPanelSnapshotValid && !refreshFrontPanelSnapshot())
+		if(!m_frontPanelSnapshotValid)
 			return;
 		m_frontPanelSnapshotValid = true;
 		const auto& frontPanel = m_frontPanelSnapshot;
@@ -1070,6 +1149,7 @@ namespace mdJucePlugin
 	{
 		auto* const button = findChild<juceRmlUi::ElemButton>("btSendSyx", false);
 		m_sysexStatus = findChild("syxStatus", false);
+		updateSysexTransfer();
 		if(!button)
 			return;
 
@@ -1310,17 +1390,28 @@ namespace mdJucePlugin
 
 	void Editor::updateLeds()
 	{
-		if(!m_frontPanelSnapshotValid)
+		if(!m_frontPanelSnapshotValid || !m_ledPresentation.valid()
+			|| !m_ledsChanged)
 			return;
 
-		const auto& fp = m_frontPanelSnapshot;
 		const auto isMonomachine = getModel() == md::MachineModel::Monomachine;
+		const auto lit = [this](const uint8_t _bank, const uint8_t _bit)
+		{
+			return m_ledPresentation.isLit(_bank, _bit);
+		};
 
 		for(uint32_t i=0; i<16; ++i)
 		{
 			if(m_stepLeds[i])
-				m_stepLeds[i]->SetClass("lit", isMonomachine
-					? fp.getMonomachineStepLed(i) : fp.getStepLed(i));
+			{
+				const auto bank = isMonomachine
+					? static_cast<uint8_t>(md::FrontPanel::g_firstLedBank + (i >> 2))
+					: static_cast<uint8_t>(md::FrontPanel::g_firstLedBank + (i >> 3));
+				const auto bit = isMonomachine
+					? static_cast<uint8_t>(((i & 3) << 1) + 1)
+					: static_cast<uint8_t>(i & 7);
+				m_stepLeds[i]->SetClass("lit", lit(bank, bit));
+			}
 		}
 
 		if(isMonomachine)
@@ -1330,10 +1421,6 @@ namespace mdJucePlugin
 				{ 0x25, 0, 0x25, 1 }, { 0x25, 2, 0x25, 3 },
 				{ 0x24, 0, 0x24, 1 }, { 0x24, 2, 0x24, 3 },
 				{ 0x24, 4, 0x24, 5 }, { 0x24, 6, 0x24, 7 },
-			};
-			const auto lit = [&fp](const uint8_t bank, const uint8_t bit)
-			{
-				return (fp.getLedBankRaw(bank) & static_cast<uint8_t>(1u << bit)) == 0;
 			};
 			for(size_t i = 0; i < std::size(tracks); ++i)
 			{
@@ -1350,26 +1437,30 @@ namespace mdJucePlugin
 				if(led.elem)
 					led.elem->SetClass("lit", lit(led.bank, led.bit));
 			}
+			m_ledsChanged = false;
 			return;
 		}
 
 		for(uint32_t i=0; i<16; ++i)
 		{
 			if(m_drumLeds[i])
-				m_drumLeds[i]->SetClass("lit", fp.getDrumLed(i));
+				m_drumLeds[i]->SetClass("lit", lit(
+					static_cast<uint8_t>(0x24 + (i >> 3)),
+					static_cast<uint8_t>(i & 7)));
 		}
 
 		for(const auto& s : m_statusLeds)
 		{
 			if(s.elem)
-				s.elem->SetClass("lit", fp.getStatusLed(static_cast<md::FrontPanel::StatusLed>(s.bit)));
+				s.elem->SetClass("lit", lit(0x22, s.bit));
 		}
 
 		for(const auto& m : m_mdModeLeds)
 		{
 			if(m.elem)
-				m.elem->SetClass("lit", fp.getModeLed(static_cast<md::FrontPanel::ModeLed>(m.bit)));
+				m.elem->SetClass("lit", lit(0x23, m.bit));
 		}
+		m_ledsChanged = false;
 	}
 
 	void Editor::paintLcd(const juce::Image& _target, juce::Graphics& _g) const
@@ -1406,6 +1497,7 @@ namespace mdJucePlugin
 
 	void Editor::timerCallback()
 	{
+		const auto nowMilliseconds = juce::Time::getMillisecondCounterHiRes();
 		// Some plugin hosts can lose the modifier key-up when focus moves to
 		// another window. Poll the native state as a fail-safe so no panel row can
 		// remain held indefinitely.
@@ -1413,14 +1505,19 @@ namespace mdJucePlugin
 			&& !juce::ModifierKeys::getCurrentModifiersRealtime().isShiftDown())
 			releaseShiftHeldPanelControls();
 
-		m_frontPanelSnapshotValid = refreshFrontPanelSnapshot();
-		servicePanelQueue();
+		m_frontPanelSnapshotValid = refreshFrontPanelState(nowMilliseconds);
+		servicePanelQueue(nowMilliseconds);
 
 		if(m_lcdCanvas && m_lcdChanged)
 			m_lcdCanvas->repaint();
 
 		updateLeds();
-		updateSysexTransfer();
+		if(nowMilliseconds >= m_nextSysexStatusUpdateMilliseconds)
+		{
+			updateSysexTransfer();
+			m_nextSysexStatusUpdateMilliseconds =
+				nowMilliseconds + g_sysexStatusIntervalMilliseconds;
+		}
 	}
 
 	std::pair<std::string, std::string> Editor::getDemoRestrictionText() const

--- a/source/elektron/md/mdJucePlugin/mdEditor.h
+++ b/source/elektron/md/mdJucePlugin/mdEditor.h
@@ -9,6 +9,7 @@
 
 #include "jucePluginEditorLib/pluginEditor.h"
 
+#include "mdFrontPanelPresentation.h"
 #include "mdPanelAffordances.h"
 #include "mdLib/mdfrontpanel.h"
 
@@ -80,7 +81,7 @@ namespace mdJucePlugin
 		void timerCallback() override;
 
 		md::Hardware* getHardware() const;
-		bool refreshFrontPanelSnapshot();
+		bool refreshFrontPanelState(double _nowMilliseconds);
 		md::MachineModel getModel() const;
 		void createLcd();
 		void createButtons();
@@ -100,7 +101,7 @@ namespace mdJucePlugin
 		void releaseAllPanelInputs();
 		void globalFocusChanged(juce::Component* _focusedComponent) override;
 		void queuePanelPulse(md::PanelControl _control, int _count = 1);
-		void servicePanelQueue();
+		void servicePanelQueue(double _nowMilliseconds);
 		void servicePanelNavigation();
 		void selectMachinedrumTrack(int _track);
 		void selectMachinedrumDataPage(int _page);
@@ -145,6 +146,12 @@ namespace mdJucePlugin
 		md::FrontPanel m_frontPanelSnapshot;
 		bool m_frontPanelSnapshotValid = false;
 		bool m_lcdChanged = true;
+		FrontPanelLedPresentation m_ledPresentation;
+		bool m_ledsChanged = true;
+		md::FrontPanelLedTransitionStatus m_ledTransitionStatus;
+		bool m_ledTransitionStatusValid = false;
+		bool m_ledResyncPending = false;
+		uint64_t m_ledResyncSequence = 0;
 
 		md::PanelRowState m_panelRows;
 		juceRmlUi::ElemButton* m_patternBankButton = nullptr;
@@ -166,7 +173,7 @@ namespace mdJucePlugin
 			bool press = false;
 		};
 		std::deque<PanelStep> m_panelSteps;
-		int m_panelSettleTicks = 0;
+		panelAffordances::PanelPulseTiming m_panelPulseTiming;
 		panelAffordances::PendingTarget<panelAffordances::g_machinedrumDataPages.size()>
 			m_machinedrumDataPageTarget;
 		panelAffordances::PendingTarget<panelAffordances::g_monomachineDataPages.size()>
@@ -189,6 +196,7 @@ namespace mdJucePlugin
 		std::array<Rml::Element*, 16> m_drumLeds{};
 		Rml::Element* m_sysexStatus = nullptr;
 		std::string m_sysexStatusOverride;
+		double m_nextSysexStatusUpdateMilliseconds = 0.0;
 
 		struct StatusLedElem
 		{

--- a/source/elektron/md/mdJucePlugin/mdEditor.h
+++ b/source/elektron/md/mdJucePlugin/mdEditor.h
@@ -43,7 +43,7 @@ namespace mdJucePlugin
 	class Controller;
 	struct EditorIdentityTestAccess;
 
-	class Editor final : public jucePluginEditorLib::Editor, juce::Timer,
+	class Editor final : public jucePluginEditorLib::Editor, juce::MultiTimer,
 		private juce::FocusChangeListener
 	{
 	public:
@@ -78,7 +78,7 @@ namespace mdJucePlugin
 	private:
 		friend struct EditorIdentityTestAccess;
 
-		void timerCallback() override;
+		void timerCallback(int _timerId) override;
 
 		md::Hardware* getHardware() const;
 		bool refreshFrontPanelState(double _nowMilliseconds);
@@ -101,7 +101,7 @@ namespace mdJucePlugin
 		void releaseAllPanelInputs();
 		void globalFocusChanged(juce::Component* _focusedComponent) override;
 		void queuePanelPulse(md::PanelControl _control, int _count = 1);
-		void servicePanelQueue(double _nowMilliseconds);
+		void servicePanelQueue();
 		void servicePanelNavigation();
 		void selectMachinedrumTrack(int _track);
 		void selectMachinedrumDataPage(int _page);
@@ -173,7 +173,7 @@ namespace mdJucePlugin
 			bool press = false;
 		};
 		std::deque<PanelStep> m_panelSteps;
-		panelAffordances::PanelPulseTiming m_panelPulseTiming;
+		int m_panelSettleTicks = 0;
 		panelAffordances::PendingTarget<panelAffordances::g_machinedrumDataPages.size()>
 			m_machinedrumDataPageTarget;
 		panelAffordances::PendingTarget<panelAffordances::g_monomachineDataPages.size()>

--- a/source/elektron/md/mdJucePlugin/mdFrontPanelPresentation.h
+++ b/source/elektron/md/mdJucePlugin/mdFrontPanelPresentation.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+#include "mdLib/mdfrontpanel.h"
+
+namespace mdJucePlugin
+{
+	// Converts the lossless firmware LED transition stream into a frame-oriented
+	// view. A pulse that begins and ends between two UI callbacks remains visible
+	// for one slow-renderer frame instead of disappearing into the final snapshot.
+	class FrontPanelLedPresentation
+	{
+	public:
+		static constexpr double g_minimumVisibleMilliseconds = 1000.0 / 30.0;
+
+		void reset(const md::FrontPanel& _panel)
+		{
+			for(uint8_t command = md::FrontPanel::g_firstLedBank;
+				command <= md::FrontPanel::g_lastLedBank; ++command)
+				m_sourceBanks[bankIndex(command)] = _panel.getLedBankRaw(command);
+			m_displayBanks = m_sourceBanks;
+			m_holdUntilMilliseconds.fill(0.0);
+			m_valid = true;
+		}
+
+		void apply(const md::FrontPanelLedTransition& _transition,
+			const double _nowMilliseconds)
+		{
+			if(!m_valid || !validCommand(_transition.command))
+				return;
+
+			const auto bank = bankIndex(_transition.command);
+			const uint8_t previous = m_sourceBanks[bank];
+			const uint8_t rising = static_cast<uint8_t>(previous & ~_transition.value);
+			for(uint8_t bit = 0; bit < 8; ++bit)
+			{
+				if((rising & static_cast<uint8_t>(1u << bit)) == 0)
+					continue;
+				auto& hold = m_holdUntilMilliseconds[bank * 8 + bit];
+				hold = std::max(hold,
+					_nowMilliseconds + g_minimumVisibleMilliseconds);
+			}
+			m_sourceBanks[bank] = _transition.value;
+		}
+
+		bool advance(const double _nowMilliseconds)
+		{
+			if(!m_valid)
+				return false;
+
+			auto next = m_sourceBanks;
+			for(size_t bank = 0; bank < next.size(); ++bank)
+			{
+				for(uint8_t bit = 0; bit < 8; ++bit)
+				{
+					if(_nowMilliseconds < m_holdUntilMilliseconds[bank * 8 + bit])
+						next[bank] &= static_cast<uint8_t>(~static_cast<uint8_t>(1u << bit));
+				}
+			}
+
+			if(next == m_displayBanks)
+				return false;
+			m_displayBanks = next;
+			return true;
+		}
+
+		bool valid() const { return m_valid; }
+
+		uint8_t getLedBankRaw(const uint8_t _command) const
+		{
+			return validCommand(_command)
+				? m_displayBanks[bankIndex(_command)] : 0xff;
+		}
+
+		bool isLit(const uint8_t _command, const uint8_t _bit) const
+		{
+			return _bit < 8
+				&& (getLedBankRaw(_command) & static_cast<uint8_t>(1u << _bit)) == 0;
+		}
+
+	private:
+		static constexpr bool validCommand(const uint8_t _command)
+		{
+			return _command >= md::FrontPanel::g_firstLedBank
+				&& _command <= md::FrontPanel::g_lastLedBank;
+		}
+
+		static constexpr size_t bankIndex(const uint8_t _command)
+		{
+			return _command - md::FrontPanel::g_firstLedBank;
+		}
+
+		std::array<uint8_t, md::FrontPanel::g_ledBankCount> m_sourceBanks{};
+		std::array<uint8_t, md::FrontPanel::g_ledBankCount> m_displayBanks{};
+		std::array<double, md::FrontPanel::g_ledBankCount * 8>
+			m_holdUntilMilliseconds{};
+		bool m_valid = false;
+	};
+}

--- a/source/elektron/md/mdJucePlugin/mdPanelAffordances.h
+++ b/source/elektron/md/mdJucePlugin/mdPanelAffordances.h
@@ -19,6 +19,11 @@ namespace mdJucePlugin::panelAffordances
 	constexpr const char* g_trackLabelPrefix = "trackLabel";
 	constexpr const char* g_trackMutePrefix = "trackMute";
 
+	// JUCE timers use integer millisecond intervals. Keep panel input on its own
+	// 33 ms clock instead of deriving it from the presentation timer's 16 ms ticks.
+	constexpr int g_presentationTimerIntervalMilliseconds = 1000 / 60;
+	constexpr int g_panelTimerIntervalMilliseconds = 1000 / 30;
+
 	// A label that issues FUNCTION + control when clicked.
 	struct Shortcut
 	{
@@ -31,38 +36,6 @@ namespace mdJucePlugin::panelAffordances
 	{
 		md::PanelControl control;
 		int count;
-	};
-
-	// Firmware-facing panel edges keep their established spacing even when the UI
-	// presentation rate changes. Time is supplied by the caller so this policy is
-	// deterministic and testable without JUCE.
-	class PanelPulseTiming
-	{
-	public:
-		static constexpr double g_edgeIntervalMilliseconds = 1000.0 / 30.0;
-
-		bool stepDue(const double _nowMilliseconds) const
-		{
-			return _nowMilliseconds >= m_nextStepMilliseconds;
-		}
-
-		void didSendStep(const double _nowMilliseconds,
-			const bool _finalRelease)
-		{
-			m_nextStepMilliseconds =
-				_nowMilliseconds + g_edgeIntervalMilliseconds;
-			if(_finalRelease)
-				m_navigationResumeMilliseconds = m_nextStepMilliseconds;
-		}
-
-		bool navigationReady(const double _nowMilliseconds) const
-		{
-			return _nowMilliseconds >= m_navigationResumeMilliseconds;
-		}
-
-	private:
-		double m_nextStepMilliseconds = 0.0;
-		double m_navigationResumeMilliseconds = 0.0;
 	};
 
 	// Classifies panel presses while Shift is down. The first control is held until

--- a/source/elektron/md/mdJucePlugin/mdPanelAffordances.h
+++ b/source/elektron/md/mdJucePlugin/mdPanelAffordances.h
@@ -33,6 +33,38 @@ namespace mdJucePlugin::panelAffordances
 		int count;
 	};
 
+	// Firmware-facing panel edges keep their established spacing even when the UI
+	// presentation rate changes. Time is supplied by the caller so this policy is
+	// deterministic and testable without JUCE.
+	class PanelPulseTiming
+	{
+	public:
+		static constexpr double g_edgeIntervalMilliseconds = 1000.0 / 30.0;
+
+		bool stepDue(const double _nowMilliseconds) const
+		{
+			return _nowMilliseconds >= m_nextStepMilliseconds;
+		}
+
+		void didSendStep(const double _nowMilliseconds,
+			const bool _finalRelease)
+		{
+			m_nextStepMilliseconds =
+				_nowMilliseconds + g_edgeIntervalMilliseconds;
+			if(_finalRelease)
+				m_navigationResumeMilliseconds = m_nextStepMilliseconds;
+		}
+
+		bool navigationReady(const double _nowMilliseconds) const
+		{
+			return _nowMilliseconds >= m_navigationResumeMilliseconds;
+		}
+
+	private:
+		double m_nextStepMilliseconds = 0.0;
+		double m_navigationResumeMilliseconds = 0.0;
+	};
+
 	// Classifies panel presses while Shift is down. The first control is held until
 	// Shift is released; subsequent controls remain ordinary momentary actions. The
 	// one exception preserves the established parameter-lock workflow: a gesture

--- a/source/elektron/md/mdJucePlugin/mdShiftTriggerLatchTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdShiftTriggerLatchTest.cpp
@@ -189,32 +189,17 @@ namespace
 			"steady LED was treated as a finite pulse");
 	}
 
-	void checkPanelPulseTimingAtRate(const double _rateHz)
+	void checkIndependentTimerCadence()
 	{
-		mdJucePlugin::panelAffordances::PanelPulseTiming timing;
-		constexpr size_t stepCount = 4;
-		std::array<double, stepCount> sent{};
-		size_t sentCount = 0;
-		const double frame = 1000.0 / _rateHz;
-		for(double now = 0.0; now < 1000.0 && sentCount < stepCount; now += frame)
-		{
-			if(!timing.stepDue(now))
-				continue;
-			sent[sentCount] = now;
-			++sentCount;
-			timing.didSendStep(now, sentCount == stepCount);
-		}
-		expect(sentCount == stepCount, "panel pulse sequence did not complete");
-		for(size_t i = 1; i < sent.size(); ++i)
-			expect(sent[i] - sent[i - 1] + 0.001
-				>= mdJucePlugin::panelAffordances::PanelPulseTiming::g_edgeIntervalMilliseconds,
-				"panel edge spacing changed with presentation rate");
-		expect(!timing.navigationReady(sent.back()),
-			"navigation resumed on the final release edge");
-		expect(timing.navigationReady(sent.back()
-			+ mdJucePlugin::panelAffordances::PanelPulseTiming::g_edgeIntervalMilliseconds),
-			"navigation did not resume after a complete firmware interval");
+		expect(mdJucePlugin::panelAffordances::g_presentationTimerIntervalMilliseconds == 16,
+			"presentation timer no longer models JUCE 60 Hz quantization");
+		expect(mdJucePlugin::panelAffordances::g_panelTimerIntervalMilliseconds == 33,
+			"panel timer no longer preserves its established cadence");
+		expect(mdJucePlugin::panelAffordances::g_panelTimerIntervalMilliseconds
+			> mdJucePlugin::panelAffordances::g_presentationTimerIntervalMilliseconds * 2,
+			"panel cadence was derived from two 16 ms presentation callbacks");
 	}
+
 }
 
 int main()
@@ -232,9 +217,7 @@ int main()
 	checkChordRows(md::MachineModel::Monomachine,
 		md::PanelControl::DataPageBackward, md::PanelControl::DataPageForward);
 	checkLedPulsePresentation();
-	checkPanelPulseTimingAtRate(30.0);
-	checkPanelPulseTimingAtRate(60.0);
-	checkPanelPulseTimingAtRate(120.0);
+	checkIndependentTimerCadence();
 
 	std::cout << "mdShiftTriggerLatchTest: PASS\n";
 	return 0;

--- a/source/elektron/md/mdJucePlugin/mdShiftTriggerLatchTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdShiftTriggerLatchTest.cpp
@@ -1,4 +1,5 @@
 #include "mdPanelAffordances.h"
+#include "mdFrontPanelPresentation.h"
 
 #include <array>
 #include <cstdlib>
@@ -155,6 +156,65 @@ namespace
 		for(uint8_t row = 0x20; row <= 0x25; ++row)
 			expect(rows.mask(row) == 0, "release left a panel row held");
 	}
+
+	void checkLedPulsePresentation()
+	{
+		md::FrontPanel panel;
+		mdJucePlugin::FrontPanelLedPresentation presentation;
+		presentation.reset(panel);
+		expect(!presentation.isLit(0x22, 1), "tempo LED baseline is not off");
+
+		constexpr double now = 1000.0;
+		presentation.apply({1, 100, 0x22, 0xfd}, now);
+		presentation.apply({2, 120, 0x22, 0xff}, now);
+		presentation.advance(now);
+		expect(presentation.isLit(0x22, 1),
+			"pulse collapsed inside one UI frame");
+		presentation.advance(now
+			+ mdJucePlugin::FrontPanelLedPresentation::g_minimumVisibleMilliseconds
+			- 0.01);
+		expect(presentation.isLit(0x22, 1),
+			"short pulse expired before one slow-renderer frame");
+		presentation.advance(now
+			+ mdJucePlugin::FrontPanelLedPresentation::g_minimumVisibleMilliseconds);
+		expect(!presentation.isLit(0x22, 1),
+			"short pulse did not return to firmware state");
+
+		presentation.apply({3, 200, 0x26, 0x7f}, now + 100.0);
+		presentation.advance(now + 100.0);
+		expect(presentation.isLit(0x26, 7),
+			"steady Monomachine tempo LED did not light");
+		presentation.advance(now + 1000.0);
+		expect(presentation.isLit(0x26, 7),
+			"steady LED was treated as a finite pulse");
+	}
+
+	void checkPanelPulseTimingAtRate(const double _rateHz)
+	{
+		mdJucePlugin::panelAffordances::PanelPulseTiming timing;
+		constexpr size_t stepCount = 4;
+		std::array<double, stepCount> sent{};
+		size_t sentCount = 0;
+		const double frame = 1000.0 / _rateHz;
+		for(double now = 0.0; now < 1000.0 && sentCount < stepCount; now += frame)
+		{
+			if(!timing.stepDue(now))
+				continue;
+			sent[sentCount] = now;
+			++sentCount;
+			timing.didSendStep(now, sentCount == stepCount);
+		}
+		expect(sentCount == stepCount, "panel pulse sequence did not complete");
+		for(size_t i = 1; i < sent.size(); ++i)
+			expect(sent[i] - sent[i - 1] + 0.001
+				>= mdJucePlugin::panelAffordances::PanelPulseTiming::g_edgeIntervalMilliseconds,
+				"panel edge spacing changed with presentation rate");
+		expect(!timing.navigationReady(sent.back()),
+			"navigation resumed on the final release edge");
+		expect(timing.navigationReady(sent.back()
+			+ mdJucePlugin::panelAffordances::PanelPulseTiming::g_edgeIntervalMilliseconds),
+			"navigation did not resume after a complete firmware interval");
+	}
 }
 
 int main()
@@ -171,6 +231,10 @@ int main()
 		md::PanelControl::Stop, md::PanelControl::Record);
 	checkChordRows(md::MachineModel::Monomachine,
 		md::PanelControl::DataPageBackward, md::PanelControl::DataPageForward);
+	checkLedPulsePresentation();
+	checkPanelPulseTimingAtRate(30.0);
+	checkPanelPulseTimingAtRate(60.0);
+	checkPanelPulseTimingAtRate(120.0);
 
 	std::cout << "mdShiftTriggerLatchTest: PASS\n";
 	return 0;

--- a/source/elektron/md/mdLib/mddevice.h
+++ b/source/elektron/md/mdLib/mddevice.h
@@ -101,6 +101,19 @@ namespace md
 		void setNativeProgramChangesEnabled(bool _enabled) { m_nativeProgramChangesEnabled = _enabled; }
 		bool nativeProgramChangesEnabled() const { return m_nativeProgramChangesEnabled; }
 		FrontPanel getFrontPanelSnapshot() const { return m_frontPanelPublisher->read(); }
+		FrontPanelPublishedState getFrontPanelPublishedState() const
+		{
+			return m_frontPanelPublisher->readPublishedState();
+		}
+		size_t drainFrontPanelLedTransitions(FrontPanelLedTransition* _output,
+			size_t _capacity)
+		{
+			return m_frontPanelPublisher->drainLedTransitions(_output, _capacity);
+		}
+		FrontPanelLedTransitionStatus getFrontPanelLedTransitionStatus() const
+		{
+			return m_frontPanelPublisher->getLedTransitionStatus();
+		}
 		MidiSysexTransferProgress getMidiSysexTransferProgress() const
 		{
 			return m_midiSysexProgressPublisher->read();

--- a/source/elektron/md/mdLib/mdfrontpanel.cpp
+++ b/source/elektron/md/mdLib/mdfrontpanel.cpp
@@ -1,5 +1,7 @@
 #include "mdfrontpanel.h"
 
+#include <algorithm>
+
 namespace md
 {
 	FrontPanel::FrontPanel()
@@ -28,21 +30,21 @@ namespace md
 		m_ledCommandCount = 0;
 	}
 
-	void FrontPanel::processByte(uint8_t _byte)
+	std::optional<FrontPanel::LedBankWrite> FrontPanel::processByte(uint8_t _byte)
 	{
 		++m_byteCount;
-		decode(_byte);
+		return decode(_byte);
 	}
 
 	void FrontPanel::processBytes(const uint8_t* _data, size_t _size)
 	{
 		for (size_t i = 0; i < _size; ++i)
-			processByte(_data[i]);
+			(void)processByte(_data[i]);
 	}
 
 	// Streaming decode of the host->panel command stream: skip LCD tile writes
 	// (0x1x + valid column base + 8 payload bytes), decode LED banks as [cmd][arg].
-	void FrontPanel::decode(uint8_t _byte)
+	std::optional<FrontPanel::LedBankWrite> FrontPanel::decode(uint8_t _byte)
 	{
 		switch (m_parseState)
 		{
@@ -70,7 +72,7 @@ namespace md
 			{
 				// not a tile after all: drop back to idle and reprocess this byte
 				m_parseState = 0;
-				decode(_byte);
+				return decode(_byte);
 			}
 			break;
 
@@ -96,13 +98,17 @@ namespace md
 		default: // case 3: LED command argument
 		{
 			const uint32_t idx = bankIndex(m_cmd);
+			const bool changed = m_ledBank[idx] != _byte;
 			m_ledBank[idx] = _byte;
 			m_ledBankWritten[idx] = true;
 			m_parseState = 0;
 			++m_ledCommandCount;
+			if(changed)
+				return LedBankWrite{m_cmd, _byte};
 			break;
 		}
 		}
+		return std::nullopt;
 	}
 
 	bool FrontPanel::getLcdPixel(uint32_t _x, uint32_t _y) const
@@ -211,6 +217,9 @@ namespace md
 		if(!lock.owns_lock())
 			return false;
 		m_snapshot = _panel;
+		m_publishedLedSequence.store(
+			m_ledTransitionSequence.load(std::memory_order_acquire),
+			std::memory_order_release);
 		return true;
 	}
 
@@ -229,9 +238,76 @@ namespace md
 		return m_snapshot;
 	}
 
+	FrontPanelPublishedState FrontPanelPublisher::readPublishedState() const
+	{
+		const std::lock_guard lock(m_mutex);
+		return
+		{
+			m_snapshot,
+			m_publishedLedSequence.load(std::memory_order_relaxed),
+		};
+	}
+
+	bool FrontPanelPublisher::tryPushLedTransition(const uint8_t _command,
+		const uint8_t _value, const uint64_t _emulationCycles)
+	{
+		const auto sequence = m_ledTransitionSequence.fetch_add(1,
+			std::memory_order_relaxed) + 1;
+		const auto write = m_ledTransitionWrite.load(std::memory_order_relaxed);
+		const auto read = m_ledTransitionRead.load(std::memory_order_acquire);
+		if(write - read >= g_ledTransitionCapacity)
+		{
+			m_ledTransitionDropped.fetch_add(1, std::memory_order_relaxed);
+			return false;
+		}
+
+		m_ledTransitions[write % g_ledTransitionCapacity] =
+			{sequence, _emulationCycles, _command, _value};
+		m_ledTransitionWrite.store(write + 1, std::memory_order_release);
+		return true;
+	}
+
+	size_t FrontPanelPublisher::drainLedTransitions(
+		FrontPanelLedTransition* const _output, const size_t _capacity)
+	{
+		if(!_output || _capacity == 0)
+			return 0;
+		// reset() also advances the consumer cursor. Serialize those two rare
+		// consumers without ever making the emulation-thread producer wait.
+		const std::lock_guard lock(m_mutex);
+
+		auto read = m_ledTransitionRead.load(std::memory_order_relaxed);
+		const auto write = m_ledTransitionWrite.load(std::memory_order_acquire);
+		const auto count = std::min(_capacity, write - read);
+		for(size_t i = 0; i < count; ++i)
+			_output[i] = m_ledTransitions[(read + i) % g_ledTransitionCapacity];
+		read += count;
+		m_ledTransitionRead.store(read, std::memory_order_release);
+		return count;
+	}
+
+	FrontPanelLedTransitionStatus FrontPanelPublisher::getLedTransitionStatus() const
+	{
+		return
+		{
+			m_ledTransitionEpoch.load(std::memory_order_acquire),
+			m_ledTransitionDropped.load(std::memory_order_acquire),
+			m_ledTransitionSequence.load(std::memory_order_acquire),
+			m_publishedLedSequence.load(std::memory_order_acquire),
+		};
+	}
+
 	void FrontPanelPublisher::reset()
 	{
 		const std::lock_guard lock(m_mutex);
 		m_snapshot.reset();
+		m_ledTransitionRead.store(
+			m_ledTransitionWrite.load(std::memory_order_acquire),
+			std::memory_order_release);
+		m_ledTransitionDropped.store(0, std::memory_order_release);
+		m_publishedLedSequence.store(
+			m_ledTransitionSequence.load(std::memory_order_acquire),
+			std::memory_order_release);
+		m_ledTransitionEpoch.fetch_add(1, std::memory_order_acq_rel);
 	}
 }

--- a/source/elektron/md/mdLib/mdfrontpanel.h
+++ b/source/elektron/md/mdLib/mdfrontpanel.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
+#include <optional>
 #include <vector>
 
 namespace md
@@ -32,6 +34,12 @@ namespace md
 	class FrontPanel
 	{
 	public:
+		struct LedBankWrite
+		{
+			uint8_t command = 0;
+			uint8_t value = 0xff;
+		};
+
 		static constexpr uint32_t g_lcdWidth  = 128;
 		static constexpr uint32_t g_lcdHeight = 64;
 		static constexpr uint8_t g_firstLedBank = 0x20;
@@ -81,7 +89,10 @@ namespace md
 		void reset();
 
 		// Consume the host->panel byte stream.
-		void processByte(uint8_t _byte);
+		// Returns a value only when a complete LED-bank command changes state. This
+		// lets the host preserve short pulses without coupling the decoder to a
+		// particular cross-thread transport.
+		std::optional<LedBankWrite> processByte(uint8_t _byte);
 		void processBytes(const uint8_t* _data, size_t _size);
 		void processBytes(const std::vector<uint8_t>& _data) { processBytes(_data.data(), _data.size()); }
 
@@ -116,7 +127,7 @@ namespace md
 		uint32_t getLedCommandCount() const { return m_ledCommandCount; }
 
 	private:
-		void decode(uint8_t _byte);
+		std::optional<LedBankWrite> decode(uint8_t _byte);
 		static uint32_t bankIndex(uint8_t _command) { return _command - g_firstLedBank; }
 		static uint32_t bankIndex(LedBank _bank)
 		{
@@ -144,21 +155,58 @@ namespace md
 		uint32_t m_ledCommandCount = 0;
 	};
 
+	struct FrontPanelLedTransition
+	{
+		uint64_t sequence = 0;
+		uint64_t emulationCycles = 0;
+		uint8_t command = 0;
+		uint8_t value = 0xff;
+	};
+
+	struct FrontPanelPublishedState
+	{
+		FrontPanel panel;
+		uint64_t ledSequence = 0;
+	};
+
+	struct FrontPanelLedTransitionStatus
+	{
+		uint64_t epoch = 0;
+		uint64_t dropped = 0;
+		uint64_t producedSequence = 0;
+		uint64_t publishedSequence = 0;
+	};
+
 	// Cross-thread publication boundary for the reconstructed display. The
 	// emulation thread owns and mutates its live FrontPanel, then offers a complete
 	// value copy without waiting. Readers may briefly wait while copying the last
-	// published value, but can never observe a torn copy. Display mutations become
-	// visible only after a complete LED command or LCD tile has been decoded.
+	// published value, but can never observe a torn copy. A separate bounded SPSC
+	// stream preserves completed LED transitions that would otherwise disappear
+	// between whole-panel snapshots.
 	class FrontPanelPublisher
 	{
 	public:
+		static constexpr size_t g_ledTransitionCapacity = 2048;
+
 		bool tryPublish(const FrontPanel& _panel);
 		bool tryRead(FrontPanel& _panel) const;
 		FrontPanel read() const;
+		FrontPanelPublishedState readPublishedState() const;
+		bool tryPushLedTransition(uint8_t _command, uint8_t _value,
+			uint64_t _emulationCycles);
+		size_t drainLedTransitions(FrontPanelLedTransition* _output, size_t _capacity);
+		FrontPanelLedTransitionStatus getLedTransitionStatus() const;
 		void reset();
 
 	private:
 		mutable std::mutex m_mutex;
 		FrontPanel m_snapshot;
+		std::array<FrontPanelLedTransition, g_ledTransitionCapacity> m_ledTransitions{};
+		std::atomic<size_t> m_ledTransitionWrite{0};
+		std::atomic<size_t> m_ledTransitionRead{0};
+		std::atomic<uint64_t> m_ledTransitionSequence{0};
+		std::atomic<uint64_t> m_ledTransitionDropped{0};
+		std::atomic<uint64_t> m_ledTransitionEpoch{0};
+		std::atomic<uint64_t> m_publishedLedSequence{0};
 	};
 }

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -163,6 +163,14 @@ namespace md
 
 		// Feed the OS's host->panel UART2 stream into the front-panel LCD/LED decoder.
 		m_uc.setFrontPanel(&m_frontPanel);
+		const auto panelPublisher = m_frontPanelPublisher;
+		m_uc.setPanelLedTransitionCallback(
+			[panelPublisher](const uint8_t _command, const uint8_t _value,
+				const uint64_t _emulationCycles)
+			{
+				(void)panelPublisher->tryPushLedTransition(
+					_command, _value, _emulationCycles);
+			});
 
 		// Inter-DSP ESSI0 ring. Each DSP's
 		// ESSI0 TX pushes its frame into the OTHER DSP's ESSI0 audio-INPUT ring (blocking

--- a/source/elektron/md/mdLib/mdmc.cpp
+++ b/source/elektron/md/mdLib/mdmc.cpp
@@ -296,7 +296,7 @@ namespace md
 
 			// Post-handshake UART2 traffic is host->panel (LCD tiles / LED banks).
 			if(m_panelDisplayReady && m_frontPanel)
-				m_frontPanel->processByte(_byte);
+				decodePanelByte(_byte);
 			return;
 		}
 		// ===== end MM panel handshake ====================================================
@@ -305,7 +305,7 @@ namespace md
 		// KS0108 LCD framebuffer writes + LED bank updates. Forward it to the front-panel
 		// decoder (if one is attached) so the reconstructed display can be observed.
 		if(m_panelDisplayReady && m_frontPanel)
-			m_frontPanel->processByte(_byte);
+			decodePanelByte(_byte);
 
 		// Match the Machinedrum panel probe implemented by the MAME Elektron driver.
 		static constexpr uint8_t probe[] =
@@ -333,6 +333,16 @@ namespace md
 		{
 			m_panelProbeIndex = (_byte == probe[0]) ? 1 : 0;
 		}
+	}
+
+	void Microcontroller::decodePanelByte(const uint8_t _byte)
+	{
+		if(!m_frontPanel)
+			return;
+		const auto transition = m_frontPanel->processByte(_byte);
+		if(transition && m_panelLedTransitionCallback)
+			m_panelLedTransitionCallback(transition->command, transition->value,
+				getCycles());
 	}
 
 	uint32_t Microcontroller::exec()

--- a/source/elektron/md/mdLib/mdmc.h
+++ b/source/elektron/md/mdLib/mdmc.h
@@ -82,6 +82,11 @@ namespace md
 		// Attach a front-panel decoder to receive the post-handshake UART2 host->panel
 		// stream (LCD framebuffer + LED banks). Owned by the caller (md::Hardware).
 		void setFrontPanel(FrontPanel* _fp) { m_frontPanel = _fp; }
+		void setPanelLedTransitionCallback(
+			std::function<void(uint8_t, uint8_t, uint64_t)> _callback)
+		{
+			m_panelLedTransitionCallback = std::move(_callback);
+		}
 
 		// Present a panel->host byte to the firmware over UART2 RX (the same channel as the
 		// startup handshake). Used to deliver button/encoder events. Call from the CPU thread.
@@ -171,6 +176,7 @@ namespace md
 		Region resolve(uint32_t _addr);
 		void logPeripheral(uint32_t _addr, uint32_t _value, uint8_t _size, bool _write);
 		void onPanelTransmit(uint8_t _byte);	// startup reply modeled from the public MAME driver
+		void decodePanelByte(uint8_t _byte);
 
 		// Match MAME's panel-ready notification after the startup handshake.
 		// Runs on the CPU thread.
@@ -243,5 +249,6 @@ namespace md
 
 
 		FrontPanel* m_frontPanel = nullptr;	// optional LCD/LED decoder (owned by md::Hardware)
+		std::function<void(uint8_t, uint8_t, uint64_t)> m_panelLedTransitionCallback;
 	};
 }

--- a/source/elektron/md/mdLibTest/turboMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/turboMidiTest.cpp
@@ -215,6 +215,83 @@ namespace
 				"out-of-range step LED was accepted");
 	}
 
+	bool testFrontPanelLedTransitions()
+	{
+		md::FrontPanel panel;
+		if(!check(!panel.processByte(0x22).has_value(),
+			"LED command byte completed a transition"))
+			return false;
+		const auto tempoOn = panel.processByte(0xfd);
+		if(!check(tempoOn.has_value() && tempoOn->command == 0x22
+				&& tempoOn->value == 0xfd,
+			"completed tempo LED transition was not reported"))
+			return false;
+		(void)panel.processByte(0x22);
+		if(!check(!panel.processByte(0xfd).has_value(),
+			"unchanged LED bank produced a transition"))
+			return false;
+
+		md::FrontPanelPublisher publisher;
+		if(!check(publisher.tryPushLedTransition(0x22, 0xfd, 100),
+			"first LED transition was rejected")
+			|| !check(publisher.tryPushLedTransition(0x22, 0xff, 120),
+				"second LED transition was rejected"))
+			return false;
+		const auto beforePublish = publisher.getLedTransitionStatus();
+		if(!check(beforePublish.producedSequence == 2
+				&& beforePublish.publishedSequence == 0,
+			"LED snapshot sequence advanced before publication")
+			|| !check(publisher.tryPublish(panel),
+				"front-panel snapshot publication failed"))
+			return false;
+		const auto published = publisher.readPublishedState();
+		if(!check(published.ledSequence == beforePublish.producedSequence
+				&& publisher.getLedTransitionStatus().publishedSequence
+					== published.ledSequence,
+			"front-panel snapshot did not capture its LED sequence"))
+			return false;
+
+		std::array<md::FrontPanelLedTransition, 4> output;
+		const auto count = publisher.drainLedTransitions(output.data(), output.size());
+		if(!check(count == 2, "LED transition queue returned the wrong count")
+			|| !check(output[0].sequence + 1 == output[1].sequence,
+				"LED transition sequence is discontinuous")
+			|| !check(output[0].emulationCycles == 100 && output[0].value == 0xfd,
+				"first LED transition payload is wrong")
+			|| !check(output[1].emulationCycles == 120 && output[1].value == 0xff,
+				"second LED transition payload is wrong"))
+			return false;
+
+		for(size_t i = 0; i < md::FrontPanelPublisher::g_ledTransitionCapacity; ++i)
+			if(!check(publisher.tryPushLedTransition(0x22,
+				static_cast<uint8_t>(i), i), "LED transition queue filled early"))
+				return false;
+		if(!check(!publisher.tryPushLedTransition(0x22, 0xff, 9999),
+			"full LED transition queue accepted an event")
+			|| !check(publisher.getLedTransitionStatus().dropped == 1,
+				"LED transition overflow was not reported"))
+			return false;
+		std::array<md::FrontPanelLedTransition,
+			md::FrontPanelPublisher::g_ledTransitionCapacity> backlog;
+		if(!check(publisher.drainLedTransitions(backlog.data(), backlog.size())
+				== backlog.size(), "full LED transition queue did not drain")
+			|| !check(publisher.tryPushLedTransition(0x26, 0x7f, 10000),
+				"wrapped LED transition queue rejected an event")
+			|| !check(publisher.drainLedTransitions(output.data(), output.size()) == 1
+				&& output[0].command == 0x26 && output[0].emulationCycles == 10000,
+				"wrapped LED transition queue corrupted its event"))
+			return false;
+
+		const auto epoch = publisher.getLedTransitionStatus().epoch;
+		publisher.reset();
+		return check(publisher.getLedTransitionStatus().epoch == epoch + 1,
+			"LED transition reset did not advance the epoch")
+			&& check(publisher.getLedTransitionStatus().dropped == 0,
+				"LED transition reset retained overflow state")
+			&& check(publisher.drainLedTransitions(output.data(), output.size()) == 0,
+				"LED transition reset retained queued events");
+	}
+
 	bool testFirmwareUpdateHandoff()
 	{
 		md::Sim mdHandoff;
@@ -244,6 +321,7 @@ int main()
 	if(!testTimeoutFallback() || !testDocumentedHandshake() || !testModelValidation()
 		|| !testDspMemoryFallback() || !testMk2PortAInvertedLoopback()
 		|| !testRealtimeMidiPendingState() || !testFrontPanelStepLeds()
+		|| !testFrontPanelLedTransitions()
 		|| !testFirmwareUpdateHandoff())
 		return 1;
 	std::cout << "mdLib tests passed\n";

--- a/source/elektron/md/mdLibTest/turboMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/turboMidiTest.cpp
@@ -271,6 +271,16 @@ namespace
 			|| !check(publisher.getLedTransitionStatus().dropped == 1,
 				"LED transition overflow was not reported"))
 			return false;
+		const auto overflowStatus = publisher.getLedTransitionStatus();
+		if(!check(publisher.readPublishedState().ledSequence
+				< overflowStatus.producedSequence,
+			"stale snapshot unexpectedly covered a dropped transition")
+			|| !check(publisher.tryPublish(panel),
+				"post-overflow front-panel snapshot publication failed")
+			|| !check(publisher.readPublishedState().ledSequence
+				== overflowStatus.producedSequence,
+			"post-overflow snapshot did not cover the recovery target"))
+			return false;
 		std::array<md::FrontPanelLedTransition,
 			md::FrontPanelPublisher::g_ledTransitionCapacity> backlog;
 		if(!check(publisher.drainLedTransitions(backlog.data(), backlog.size())


### PR DESCRIPTION
## Summary

- capture completed firmware LED-bank transitions in a bounded nonblocking SPSC stream
- present MD and MM LEDs at 60 Hz while holding short pulses long enough to survive renderer sampling
- keep firmware-facing panel edges on independent elapsed-time deadlines and throttle slower SysEx status work
- recover from transition overflow or device reset using sequence-tagged coherent snapshots
- avoid unnecessary LCD repaint and LED DOM updates when displayed state is unchanged

## Verification

- built mdJucePlugin
- built mmJucePlugin
- passed mdLibTests
- passed mdShiftTriggerLatchTest
- verified cleanly on release/md-mm-public-alpha-20260826 after PR #13

## Manual follow-up

A release-candidate visual pass should confirm tempo blinking at several tempos on both machines. The transition stream and minimum-visible-time policy are unit tested, but the final host and display behavior still benefits from an in-app check.