### PR TITLE
Add invertible MD and MM LCD colors

### DIFF
--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -144,6 +144,8 @@ namespace mdJucePlugin
 		, m_controller(dynamic_cast<Controller&>(_processor.getController()))
 		, m_model(dynamic_cast<const AudioPluginAudioProcessor&>(_processor).getModel())
 	{
+		m_lcdColorsInverted = _processor.getConfig().getBoolValue(
+			g_lcdColorsInvertedConfigKey, false);
 		juce::Desktop::getInstance().addFocusChangeListener(this);
 	}
 
@@ -920,6 +922,16 @@ namespace mdJucePlugin
 		apply(m_soundEncoder, 170.0f, wheelPercent);
 	}
 
+	void Editor::setLcdColorsInverted(const bool _inverted)
+	{
+		if(m_lcdColorsInverted == _inverted)
+			return;
+
+		m_lcdColorsInverted = _inverted;
+		if(m_lcdCanvas)
+			m_lcdCanvas->repaint();
+	}
+
 	void Editor::loadInstalledFactoryStorage()
 	{
 		if(m_model != md::MachineModel::Monomachine)
@@ -1474,8 +1486,10 @@ namespace mdJucePlugin
 	void Editor::paintLcd(const juce::Image& _target, juce::Graphics& _g) const
 	{
 		const auto isMonomachine = getModel() == md::MachineModel::Monomachine;
-		const auto lcdOff = isMonomachine ? g_mmLcdOff : g_mdLcdOff;
-		const auto lcdOn = isMonomachine ? g_mmLcdOn : g_mdLcdOn;
+		const auto normalOff = isMonomachine ? g_mmLcdOff : g_mdLcdOff;
+		const auto normalOn = isMonomachine ? g_mmLcdOn : g_mdLcdOn;
+		const auto lcdOff = m_lcdColorsInverted ? normalOn : normalOff;
+		const auto lcdOn = m_lcdColorsInverted ? normalOff : normalOn;
 
 		if(!m_frontPanelSnapshotValid)
 		{

--- a/source/elektron/md/mdJucePlugin/mdEditor.h
+++ b/source/elektron/md/mdJucePlugin/mdEditor.h
@@ -65,6 +65,7 @@ namespace mdJucePlugin
 		// Reapplies the configured wheel/encoder drag-speed percentages to the
 		// panel knobs. Called on create and from the settings page.
 		void applyPanelSpeeds();
+		void setLcdColorsInverted(bool _inverted);
 		void loadInstalledFactoryStorage();
 		void chooseStorageImage();
 		void restorePreviousStorage();
@@ -74,6 +75,7 @@ namespace mdJucePlugin
 		std::string sysexTransferStatusText() const;
 
 		static constexpr int g_panelSpeedPercents[] = {50, 75, 100, 150, 200, 300};
+		static constexpr const char* g_lcdColorsInvertedConfigKey = "lcdColorsInverted";
 
 	private:
 		friend struct EditorIdentityTestAccess;
@@ -146,6 +148,7 @@ namespace mdJucePlugin
 		md::FrontPanel m_frontPanelSnapshot;
 		bool m_frontPanelSnapshotValid = false;
 		bool m_lcdChanged = true;
+		bool m_lcdColorsInverted = false;
 		FrontPanelLedPresentation m_ledPresentation;
 		bool m_ledsChanged = true;
 		md::FrontPanelLedTransitionStatus m_ledTransitionStatus;

--- a/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.cpp
+++ b/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.cpp
@@ -3,6 +3,7 @@
 #include "mdEditor.h"
 
 #include "jucePluginEditorLib/pluginProcessor.h"
+#include "jucePluginEditorLib/settingsPlugin.h"
 
 #include "juceRmlUi/rmlElemButton.h"
 #include "juceRmlUi/rmlDragTarget.h"
@@ -43,6 +44,12 @@ namespace mdJucePlugin
 
 	SettingsPanelFeel::SettingsPanelFeel(Editor& _editor, Rml::Element* _root) : m_editor(_editor)
 	{
+		jucePluginEditorLib::SettingsPlugin::createToggleButton(_root,
+			"btInvertLcdColors", m_editor.getProcessor().getConfig(),
+			Editor::g_lcdColorsInvertedConfigKey, [this](const bool _inverted)
+			{
+				m_editor.setLcdColorsInverted(_inverted);
+			});
 		bindGroup(_root, "btWheelSpeed", "panelWheelSpeedPercent");
 		bindGroup(_root, "btEncoderSpeed", "panelEncoderSpeedPercent");
 		if(auto* const chooseSysex = juceRmlUi::helper::findChild(

--- a/source/elektron/md/mdJucePlugin/tus_settings_gui_Machinedrum.rml
+++ b/source/elektron/md/mdJucePlugin/tus_settings_gui_Machinedrum.rml
@@ -33,6 +33,13 @@
 </head>
 <body>
 	<settingsspacer1/>
+	<h1>Panel Appearance</h1>
+	<settingsspacer1/>
+	<div id="btInvertLcdColors" class="settings-checkboxwithlabel">
+		<button id="button" class="settings-checkbox"/>
+		<label>Invert LCD colors</label>
+	</div>
+	<settingsspacer1/>
 	<h1>SysEx File Transfer</h1>
 	<settingsspacer1/>
 	<label>Send kits, patterns, songs, globals, and other user-data .syx files through the emulated MIDI input.</label>

--- a/source/elektron/md/mdJucePlugin/tus_settings_gui_Monomachine.rml
+++ b/source/elektron/md/mdJucePlugin/tus_settings_gui_Monomachine.rml
@@ -47,6 +47,13 @@
 </head>
 <body>
 	<settingsspacer1/>
+	<h1>Panel Appearance</h1>
+	<settingsspacer1/>
+	<div id="btInvertLcdColors" class="settings-checkboxwithlabel">
+		<button id="button" class="settings-checkbox"/>
+		<label>Invert LCD colors</label>
+	</div>
+	<settingsspacer1/>
 	<h1>SysEx File Transfer</h1>
 	<settingsspacer1/>
 	<label>Send backups, user data, and DigiPRO waveform banks through the emulated MIDI input.</label>


### PR DESCRIPTION
## Summary
- add an Invert LCD colors checkbox to Panel Appearance in the Escape settings menu
- swap the LCD background and lit-pixel palettes without changing emulation state
- persist the preference and apply it immediately for both Machinedrum and Monomachine

## Validation
- built mdJucePlugin and mmJucePlugin
- parsed both device settings RML templates with xmllint
- passed mdShiftTriggerLatchTest and mdAutomationParameterTest

The build emitted only the existing DSP signed-shift warning.