### PR TITLE
Fix AMD flash command sequencing

### DIFF
--- a/.github/workflows/mdmm-core.yml
+++ b/.github/workflows/mdmm-core.yml
@@ -9,6 +9,7 @@ on:
       - ".github/workflows/mdmm-core.yml"
       - "source/cmake/base.cmake"
       - "source/elektron/md/**"
+      - "source/framework/hardwareLib/**"
       - "source/cpu/mc68k"
       - "source/cpu/dsp56300"
   pull_request:
@@ -16,6 +17,7 @@ on:
       - ".github/workflows/mdmm-core.yml"
       - "source/cmake/base.cmake"
       - "source/elektron/md/**"
+      - "source/framework/hardwareLib/**"
       - "source/cpu/mc68k"
       - "source/cpu/dsp56300"
 
@@ -66,7 +68,7 @@ jobs:
       - name: Build asset-free core tests
         run: >-
           cmake --build build --config Release --parallel 3
-          --target dsp56kTestRunner mdLibTest mdProfileWorkload
+          --target dsp56kTestRunner am29fTest mdLibTest mdFlashTest mdProfileWorkload
 
       - name: Build ColdFire divide regression test
         if: runner.os != 'Windows'
@@ -83,7 +85,7 @@ jobs:
       - name: Run asset-free core tests
         run: >-
           ctest --test-dir build -C Release --output-on-failure
-          --tests-regex "^(dsp56300_unitTests|mc68kColdFireDivideTest|mdLibTests|mdProfileWorkload(Bounded)?Tests)$"
+          --tests-regex "^(dsp56300_unitTests|mc68kColdFireDivideTest|am29fTest|mdLibTests|mdFlashTest|mdProfileWorkload(Bounded)?Tests)$"
 
   apple-pgo:
     name: Apple PGO generate and use

--- a/.github/workflows/mdmm-core.yml
+++ b/.github/workflows/mdmm-core.yml
@@ -68,7 +68,19 @@ jobs:
       - name: Build asset-free core tests
         run: >-
           cmake --build build --config Release --parallel 3
-          --target dsp56kTestRunner am29fTest mdLibTest mdFlashTest mdProfileWorkload
+          --target dsp56kTestRunner mdLibTest mdFlashTest mdProfileWorkload
+
+      - name: Build AMD flash regression test
+        if: runner.os != 'Windows'
+        run: >-
+          cmake --build build --config Release --parallel 3
+          --target am29fTest
+
+      - name: Build AMD flash regression test (Windows)
+        if: runner.os == 'Windows'
+        run: >-
+          cmake --build build --config Release --parallel 3
+          --target source/framework/hardwareLib/am29fTest
 
       - name: Build ColdFire divide regression test
         if: runner.os != 'Windows'

--- a/source/elektron/md/mdLib/mdsysextransfer.h
+++ b/source/elektron/md/mdLib/mdsysextransfer.h
@@ -50,11 +50,16 @@ namespace md
 				return MidiSysexStreamValidation::InvalidFraming;
 			if(_bytes[offset + 4] != expectedProduct)
 				return MidiSysexStreamValidation::WrongModel;
+			if(_bytes[offset + 5] >= 0x80 || _bytes[offset + 6] >= 0x80)
+				return MidiSysexStreamValidation::InvalidFraming;
 
 			const auto end = std::find(
 				_bytes.begin() + static_cast<std::ptrdiff_t>(offset + 7),
 				_bytes.end(), uint8_t{0xf7});
 			if(end == _bytes.end())
+				return MidiSysexStreamValidation::InvalidFraming;
+			if(std::any_of(_bytes.begin() + static_cast<std::ptrdiff_t>(offset + 7), end,
+				[](const uint8_t _byte) { return _byte >= 0x80 && _byte < 0xf8; }))
 				return MidiSysexStreamValidation::InvalidFraming;
 			const uint8_t command = _bytes[offset + 6];
 			firmwareUpdate |= command == 0x7e || command == 0x7f;

--- a/source/elektron/md/mdLib/test/mdflash_test.cpp
+++ b/source/elektron/md/mdLib/test/mdflash_test.cpp
@@ -48,6 +48,23 @@ int main()
 		std::puts("FAIL: flash programming changed the source ROM image");
 		return 1;
 	}
+	constexpr uint32_t collisionTarget = sector + 0x0aaa;
+	program(mm, collisionTarget, 0x12aa);
+	if(mm.read16(collisionTarget) != 0x12aa)
+	{
+		std::puts("FAIL: Monomachine flash confused program data with an unlock cycle");
+		return 1;
+	}
+	mm.write16(g_commandAa, 0xaaaa);
+	if(mm.read16(g_commandAa) != 0xffff)
+	{
+		std::puts("FAIL: Monomachine flash programmed a stale word at the unlock address");
+		return 1;
+	}
+	// Finish the command begun above so the erase sequence starts from idle.
+	mm.write16(g_command55, 0x5555);
+	mm.write16(g_commandAa, 0xa0a0);
+	mm.write16(target, 0x5aa5);
 
 	eraseSector(mm, sector);
 	if(mm.read16(target) != 0xffff)

--- a/source/elektron/md/mdLibTest/turboMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/turboMidiTest.cpp
@@ -133,6 +133,32 @@ namespace
 				md::MachineModel::Monomachine) == MidiSysexStreamValidation::Valid,
 			"concatenated user-data messages were rejected"))
 			return false;
+
+		auto embeddedStatus = mmMessage;
+		embeddedStatus.insert(embeddedStatus.end() - 1, {0x90, 0x3c, 0x7f});
+		if(!check(md::validateMidiSysexStream(embeddedStatus,
+				md::MachineModel::Monomachine) == MidiSysexStreamValidation::InvalidFraming,
+			"embedded channel status was accepted as SysEx data"))
+			return false;
+		auto statusAsCommand = mmMessage;
+		statusAsCommand[6] = 0x90;
+		if(!check(md::validateMidiSysexStream(statusAsCommand,
+				md::MachineModel::Monomachine) == MidiSysexStreamValidation::InvalidFraming,
+			"MIDI status was accepted as the device command"))
+			return false;
+		auto nestedSysex = mmMessage;
+		nestedSysex.insert(nestedSysex.end() - 1,
+			mdMessage.begin(), mdMessage.end());
+		if(!check(md::validateMidiSysexStream(nestedSysex,
+				md::MachineModel::Monomachine) == MidiSysexStreamValidation::InvalidFraming,
+			"nested SysEx framing was accepted"))
+			return false;
+		auto realtime = mmMessage;
+		realtime.insert(realtime.end() - 1, 0xfe);
+		if(!check(md::validateMidiSysexStream(realtime,
+				md::MachineModel::Monomachine) == MidiSysexStreamValidation::Valid,
+			"legal MIDI realtime data was rejected inside SysEx"))
+			return false;
 		concatenated.push_back(0x00);
 		return check(md::validateMidiSysexStream(concatenated,
 			md::MachineModel::Monomachine) == MidiSysexStreamValidation::InvalidFraming,

--- a/source/framework/hardwareLib/CMakeLists.txt
+++ b/source/framework/hardwareLib/CMakeLists.txt
@@ -21,5 +21,13 @@ set_property(TARGET hardwareLib PROPERTY FOLDER "Gearmulator")
 
 target_include_directories(hardwareLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
+if(BUILD_TESTING)
+	add_executable(am29fTest test/am29f_test.cpp)
+	target_link_libraries(am29fTest PRIVATE hardwareLib)
+	add_test(NAME am29fTest COMMAND am29fTest)
+	set_tests_properties(am29fTest PROPERTIES LABELS "UnitTest")
+	set_property(TARGET am29fTest PROPERTY FOLDER "Gearmulator")
+endif()
+
 #target_compile_options(hardwareLib PRIVATE -fsanitize=thread)
 #target_link_options(hardwareLib PUBLIC -fsanitize=thread)

--- a/source/framework/hardwareLib/am29f.cpp
+++ b/source/framework/hardwareLib/am29f.cpp
@@ -1,92 +1,96 @@
 #include "am29f.h"
 
+#include <algorithm>
 #include <cassert>
+#include <limits>
 
 #include "mc68k/logging.h"
 #include "mc68k/mc68k.h"
 
 namespace hwLib
 {
-	Am29f::Am29f(uint8_t* _buffer, const size_t _size, const bool _useWriteEnable, const bool _bitreversedCmdAddr) : m_buffer(_buffer), m_size(_size), m_useWriteEnable(_useWriteEnable), m_bitreverseCmdAddr(_bitreversedCmdAddr)
+	Am29f::Am29f(uint8_t* _buffer, const size_t _size, const bool _useWriteEnable,
+		const bool _bitreversedCmdAddr)
+		: m_buffer(_buffer)
+		, m_size(_size)
+		, m_useWriteEnable(_useWriteEnable)
+		, m_commandAddressAa(_bitreversedCmdAddr
+			? static_cast<uint16_t>(bitreverse(0x555) >> 4) : 0x555)
+		, m_commandAddress55(_bitreversedCmdAddr
+			? static_cast<uint16_t>(bitreverse(0x2aa) >> 4) : 0x2aa)
 	{
-		auto br = [&](uint16_t x)
-		{
-			return m_bitreverseCmdAddr ? static_cast<uint16_t>(bitreverse(x) >> 4) : x;
-		};
+	}
 
-		// Chip Erase
-		m_commands.push_back({{{br(0x555),0xAA}, {br(0x2AA),0x55}, {br(0x555),0x80}, {br(0x555),0xAA}, {br(0x2AA),0x55}, {br(0x555),0x10}}});
+	bool Am29f::matches(const uint32_t _addr, const uint16_t _data,
+		const uint16_t _commandAddress, const uint8_t _commandData) const
+	{
+		return (_addr & 0xfff) == _commandAddress
+			&& static_cast<uint8_t>(_data) == _commandData;
+	}
 
-		// Sector Erase
-		m_commands.push_back({{{br(0x555),0xAA}, {br(0x2AA),0x55}, {br(0x555),0x80}, {br(0x555),0xAA}, {br(0x2AA),0x55}}});
-
-		// Program
-		m_commands.push_back({{{br(0x555),0xAA}, {br(0x2AA),0x55}, {br(0x555),0xA0}}});
+	void Am29f::resetCommand()
+	{
+		m_state = State::Idle;
 	}
 
 	void Am29f::write(const uint32_t _addr, const uint16_t _data)
 	{
-		const auto reset = [this]()
-		{
-			m_currentBusCycle = 0;
-			m_currentCommand = -1;
-		};
-
 		if(!writeEnabled())
 		{
-			reset();
+			resetCommand();
 			return;
 		}
 
-		bool anyMatch = false;
-
-		const auto d = _data & 0xff;
-		const auto a = _addr & 0xfff;
-		
-		for (size_t i=0; i<m_commands.size(); ++i)
+		switch(m_state)
 		{
-			auto& cycles = m_commands[i].cycles;
-
-			if(m_currentBusCycle < cycles.size())
-			{
-				const auto& c = cycles[m_currentBusCycle];
-
-				if(c.addr == a && c.data == d)
-				{
-					anyMatch = true;
-
-					if(m_currentBusCycle == cycles.size() - 1)
-						m_currentCommand = static_cast<int32_t>(i);
-				}
-			}
-		}
-
-		if(!anyMatch)
-		{
-			if(m_currentCommand >= 0)
-			{
-				const auto c = static_cast<CommandType>(m_currentCommand);
-
-				execCommand(c, _addr, _data);
-			}
-
-			reset();
-		}
-		else
-		{
-			++m_currentBusCycle;
+		case State::Idle:
+			if(matches(_addr, _data, m_commandAddressAa, 0xaa))
+				m_state = State::Unlock1;
+			break;
+		case State::Unlock1:
+			m_state = matches(_addr, _data, m_commandAddress55, 0x55)
+				? State::Command : State::Idle;
+			break;
+		case State::Command:
+			if(matches(_addr, _data, m_commandAddressAa, 0xa0))
+				m_state = State::Program;
+			else if(matches(_addr, _data, m_commandAddressAa, 0x80))
+				m_state = State::EraseUnlock1;
+			else
+				resetCommand();
+			break;
+		case State::Program:
+			execCommand(CommandType::Program, _addr, _data);
+			resetCommand();
+			break;
+		case State::EraseUnlock1:
+			m_state = matches(_addr, _data, m_commandAddressAa, 0xaa)
+				? State::EraseUnlock2 : State::Idle;
+			break;
+		case State::EraseUnlock2:
+			m_state = matches(_addr, _data, m_commandAddress55, 0x55)
+				? State::EraseCommand : State::Idle;
+			break;
+		case State::EraseCommand:
+			if(matches(_addr, _data, m_commandAddressAa, 0x10))
+				execCommand(CommandType::ChipErase, _addr, _data);
+			else if(static_cast<uint8_t>(_data) == 0x30)
+				execCommand(CommandType::SectorErase, _addr, _data);
+			resetCommand();
+			break;
 		}
 	}
 
 	bool Am29f::eraseSector(const uint32_t _addr, const size_t _sizeInKb) const
 	{
-		if (!_sizeInKb)
+		if(!_sizeInKb || _sizeInKb > std::numeric_limits<size_t>::max() / 1024)
+			return false;
+		const auto size = _sizeInKb * 1024;
+		if(_addr > m_size || size > m_size - _addr)
 			return false;
 
-		MCLOG("Erasing Sector at " << MCHEX(_addr) << ", size " << MCHEX(1024 * _sizeInKb));
-
-		for(size_t i = _addr; i< _addr + _sizeInKb * 1024; ++i)
-			m_buffer[i] = 0xff;
+		MCLOG("Erasing Sector at " << MCHEX(_addr) << ", size " << MCHEX(size));
+		std::fill_n(m_buffer + _addr, size, uint8_t{0xff});
 
 		return true;
 	}
@@ -146,7 +150,7 @@ namespace hwLib
 		switch (_command)
 		{
 		case CommandType::ChipErase:
-			assert(false);
+			std::fill_n(m_buffer, m_size, uint8_t{0xff});
 			break;
 		case CommandType::SectorErase:
 			{
@@ -159,7 +163,7 @@ namespace hwLib
 			break;
 		case CommandType::Program:
 			{
-				if(_addr >= m_size)
+				if(_addr >= m_size || m_size - _addr < sizeof(uint16_t))
 					return;
 #if defined(_DEBUG) && defined(_WIN32)
 				MCLOG("Programming word at " << MCHEX(_addr) << ", value " << MCHEXN(_data, 4));

--- a/source/framework/hardwareLib/am29f.h
+++ b/source/framework/hardwareLib/am29f.h
@@ -50,6 +50,17 @@ namespace hwLib
 		bool eraseSector4MbitTopBoot(uint32_t _addr) const;
 
 	private:
+		enum class State
+		{
+			Idle,
+			Unlock1,
+			Command,
+			Program,
+			EraseUnlock1,
+			EraseUnlock2,
+			EraseCommand
+		};
+
 		bool writeEnabled() const
 		{
 			return !m_useWriteEnable || m_writeEnable;
@@ -64,16 +75,17 @@ namespace hwLib
 			return ((_x & 0xff00) >> 8) | static_cast<uint16_t>((_x & 0x00ff) << 8);
 		}
 
+		bool matches(uint32_t _addr, uint16_t _data, uint16_t _commandAddress,
+			uint8_t _commandData) const;
+		void resetCommand();
 		void execCommand(CommandType _command, uint32_t _addr, uint16_t _data) const;
 
 		uint8_t* m_buffer;
 		const size_t m_size;
 		const bool m_useWriteEnable;
-		const bool m_bitreverseCmdAddr;
-
-		std::vector<Command> m_commands;
+		const uint16_t m_commandAddressAa;
+		const uint16_t m_commandAddress55;
 		bool m_writeEnable = false;
-		uint32_t m_currentBusCycle = 0;
-		int32_t m_currentCommand = -1;
+		State m_state = State::Idle;
 	};
 }

--- a/source/framework/hardwareLib/test/am29f_test.cpp
+++ b/source/framework/hardwareLib/test/am29f_test.cpp
@@ -1,0 +1,118 @@
+#include "hardwareLib/am29f.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace
+{
+	struct CommandAddresses
+	{
+		uint32_t aa;
+		uint32_t fiveFive;
+	};
+
+	constexpr CommandAddresses g_straight{0x555, 0x2aa};
+	constexpr CommandAddresses g_reversed{0xaaaa, 0x5554};
+
+	void program(hwLib::Am29f& _flash, const CommandAddresses& _commands,
+		const uint32_t _address, const uint16_t _value)
+	{
+		_flash.write(_commands.aa, 0xaaaa);
+		_flash.write(_commands.fiveFive, 0x5555);
+		_flash.write(_commands.aa, 0xa0a0);
+		_flash.write(_address, _value);
+	}
+
+	void eraseSector(hwLib::Am29f& _flash, const CommandAddresses& _commands,
+		const uint32_t _address)
+	{
+		_flash.write(_commands.aa, 0xaaaa);
+		_flash.write(_commands.fiveFive, 0x5555);
+		_flash.write(_commands.aa, 0x8080);
+		_flash.write(_commands.aa, 0xaaaa);
+		_flash.write(_commands.fiveFive, 0x5555);
+		_flash.write(_address, 0x3030);
+	}
+
+	void eraseChip(hwLib::Am29f& _flash, const CommandAddresses& _commands)
+	{
+		_flash.write(_commands.aa, 0xaaaa);
+		_flash.write(_commands.fiveFive, 0x5555);
+		_flash.write(_commands.aa, 0x8080);
+		_flash.write(_commands.aa, 0xaaaa);
+		_flash.write(_commands.fiveFive, 0x5555);
+		_flash.write(_commands.aa, 0x1010);
+	}
+
+	uint16_t readWord(const std::vector<uint8_t>& _bytes, const uint32_t _address)
+	{
+		return static_cast<uint16_t>((static_cast<uint16_t>(_bytes[_address]) << 8)
+			| _bytes[_address + 1]);
+	}
+
+	bool check(const bool _condition, const char* const _message)
+	{
+		if(_condition)
+			return true;
+		std::fprintf(stderr, "FAIL: %s\n", _message);
+		return false;
+	}
+}
+
+int main()
+{
+	constexpr size_t flashSize = 512 * 1024;
+	std::vector<uint8_t> bytes(flashSize, 0xff);
+	hwLib::Am29f straight(bytes.data(), bytes.size(), false, false);
+	program(straight, g_straight, 0x1234, 0x5aa5);
+	if(!check(readWord(bytes, 0x1234) == 0x5aa5,
+		"straight-address program command failed"))
+		return 1;
+
+	std::fill(bytes.begin(), bytes.end(), 0xff);
+	hwLib::Am29f reversed(bytes.data(), bytes.size(), false, true);
+	constexpr uint32_t collisionTarget = 0x20aaa;
+	program(reversed, g_reversed, collisionTarget, 0x12aa);
+	if(!check(readWord(bytes, collisionTarget) == 0x12aa,
+		"program data matching an erase unlock cycle was not written"))
+		return 1;
+	reversed.write(g_reversed.aa, 0xaaaa);
+	if(!check(readWord(bytes, g_reversed.aa) == 0xffff,
+		"the next unlock cycle was programmed as stale command data"))
+		return 1;
+	reversed.write(g_reversed.fiveFive, 0x5555);
+	reversed.write(g_reversed.aa, 0xa0a0);
+	reversed.write(0x1234, 0x34c7);
+	if(!check(readWord(bytes, 0x1234) == 0x34c7,
+		"the command following collision data did not execute normally"))
+		return 1;
+
+	std::fill(bytes.begin(), bytes.end(), 0x00);
+	eraseSector(reversed, g_reversed, 0x20000);
+	if(!check(std::all_of(bytes.begin() + 0x20000, bytes.begin() + 0x30000,
+		[](const uint8_t _byte) { return _byte == 0xff; }),
+		"sector erase did not erase its 64 KiB sector")
+		|| !check(bytes[0x1ffff] == 0x00 && bytes[0x30000] == 0x00,
+			"sector erase changed bytes outside its sector"))
+		return 1;
+
+	std::fill(bytes.begin(), bytes.end(), 0x00);
+	eraseChip(reversed, g_reversed);
+	if(!check(std::all_of(bytes.begin(), bytes.end(),
+		[](const uint8_t _byte) { return _byte == 0xff; }),
+		"chip erase did not execute on its final command cycle"))
+		return 1;
+
+	bytes.back() = 0x5a;
+	program(reversed, g_reversed, static_cast<uint32_t>(bytes.size() - 1), 0x0000);
+	if(!check(bytes.back() == 0x5a, "out-of-range word program changed the buffer tail")
+		|| !check(!reversed.eraseSector(static_cast<uint32_t>(bytes.size() - 1024), 2),
+			"out-of-range sector erase was accepted")
+		|| !check(bytes.back() == 0x5a, "out-of-range sector erase changed the buffer tail"))
+		return 1;
+
+	std::puts("PASS: AMD flash command sequencing and bounds");
+	return 0;
+}


### PR DESCRIPTION
## Summary

- replace ambiguous AM29 command matching with an explicit unlock/program/erase state machine
- fix Monomachine user-flash program collisions, chip-erase timing, and backing-store bounds
- reject malformed user SysEx status/framing while allowing legal MIDI real-time bytes
- add shared-decoder and MM integration regressions and run them in portable MD/MM CI

## Why

PR #5 exposed the shared AM29 decoder to arbitrary DigiPRO data. A program word written at an address ending in `0xAAA` with low byte `0xAA` was misread as an erase-unlock cycle. The target stayed erased, and the next unlock word was then programmed at the command address.

## Tests

- `am29fTest`
- `mdLibTests`
- `mdFirmwareUpdateTest`
- `mdFlashTest`
- `mdStateTest`
- `mdAutomationMidiTest`
- `am29fTest` under AddressSanitizer
