### PR TITLE
Harden MD/MM automation synchronization and realtime delivery

### DIFF
--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -111,6 +111,10 @@ if(BUILD_TESTING)
 	add_test(NAME mdAutomationRobustnessTest COMMAND mdAutomationRobustnessTest)
 	set_tests_properties(mdAutomationRobustnessTest PROPERTIES
 		LABELS "Integration" TIMEOUT 300)
+	add_test(NAME mdAutomationArchitectureTest COMMAND mdAutomationRobustnessTest
+		--architecture-only)
+	set_tests_properties(mdAutomationArchitectureTest PROPERTIES
+		LABELS "Unit" TIMEOUT 60)
 
 	add_md_automation_firmware_test(mdAutomationSoakTest
 		mdAutomationSoakTest.cpp)

--- a/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
@@ -32,7 +32,9 @@ namespace
 			"initial firmware synchronization timed out (global "
 			+ std::to_string(controller.hasAutomationGlobalSnapshot()) + ", kit "
 			+ std::to_string(controller.hasAutomationKitSnapshot()) + ", base "
-			+ std::to_string(controller.getAutomationBaseChannel()) + ")");
+			+ std::to_string(controller.getAutomationBaseChannel()) + ", requests="
+			+ std::to_string(controller.getSynchronizationRequestCount()) + ", "
+			+ harness.firmwareReadiness() + ")");
 		require(controller.getAutomationBaseChannel() < 16,
 			"firmware Global has MIDI base channel set to NONE");
 
@@ -115,9 +117,17 @@ namespace
 			"state restore did not resynchronize automation");
 		require(probe.getUnnormalizedValue() == 47,
 			"firmware-backed automation value was not restored from DAW state");
-		require(controller.getTransmittedAutomationChangeCount()
-			>= beforeRestoreFlush + audioProcessor.getParameters().size(),
-			"DAW-state automation snapshot was not flushed back to firmware");
+		// Synchronization can complete from inside the audio callback while its
+		// realtime drain guard is held. The message-thread completion path must not
+		// wait on that guard; the next bounded callback performs the replay instead.
+		harness.process(32);
+		const auto restoredWrites = controller.getTransmittedAutomationChangeCount()
+			- beforeRestoreFlush;
+		require(restoredWrites >= audioProcessor.getParameters().size(),
+			"DAW-state automation snapshot flushed "
+			+ std::to_string(restoredWrites) + " of "
+			+ std::to_string(audioProcessor.getParameters().size())
+			+ " values back to firmware");
 
 		std::cout << "mdAutomationFirmwareTest: "
 			<< modelName(_model)

--- a/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
@@ -45,10 +45,10 @@ namespace
 		probe.setValueFromSynth(0, pluginLib::Parameter::Origin::PresetChange);
 		const auto beforeZero = harness.telemetry();
 		hostWrite(probe, 0);
+		harness.process(32);
 		require(controller.getTransmittedAutomationChangeCount()
 			== beforeTransmitCount + 1,
 			"host write did not produce exactly one automation CC");
-		harness.process(32);
 		const auto afterZero = harness.telemetry();
 		require(afterZero.consumed >= beforeZero.consumed + 3
 			&& afterZero.overflows == beforeZero.overflows,
@@ -56,10 +56,10 @@ namespace
 
 		const auto beforeChanged = harness.telemetry();
 		hostWrite(probe, 127);
+		harness.process(32);
 		require(controller.getTransmittedAutomationChangeCount()
 			== beforeTransmitCount + 2,
 			"changed host write did not produce exactly one automation CC");
-		harness.process(32);
 		const auto afterChanged = harness.telemetry();
 		require(afterChanged.consumed >= beforeChanged.consumed + 3
 			&& afterChanged.overflows == beforeChanged.overflows,

--- a/source/elektron/md/mdJucePlugin/mdAutomationParameterTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationParameterTest.cpp
@@ -1,6 +1,9 @@
 #include "jucePluginLib/parameterdescriptions.h"
 #include "mdLib/mdautomation.h"
+#include "mdRealtimeQueue.h"
 
+#include <array>
+#include <atomic>
 #include <cstdlib>
 #include <cstdint>
 #include <fstream>
@@ -8,6 +11,8 @@
 #include <iterator>
 #include <set>
 #include <string>
+#include <thread>
+#include <vector>
 
 namespace
 {
@@ -131,10 +136,64 @@ namespace
 			require(false, "host parameter IDs/order/names/ranges/defaults changed");
 		}
 	}
+
+	void verifyRealtimeQueue()
+	{
+		mdJucePlugin::RealtimeQueue<uint32_t, 8> bounded;
+		for(uint32_t value = 0; value < 8; ++value)
+			require(bounded.tryPush(value), "bounded queue filled too early");
+		require(!bounded.tryPush(8), "bounded queue accepted an over-capacity item");
+		for(uint32_t value = 0; value < 8; ++value)
+		{
+			uint32_t observed = 99;
+			require(bounded.tryPop(observed) && observed == value,
+				"bounded queue changed FIFO order");
+		}
+		uint32_t empty = 0;
+		require(!bounded.tryPop(empty), "bounded queue popped from empty");
+
+		constexpr uint32_t ProducerCount = 4;
+		constexpr uint32_t ItemsPerProducer = 2000;
+		constexpr uint32_t ItemCount = ProducerCount * ItemsPerProducer;
+		mdJucePlugin::RealtimeQueue<uint32_t, 1024> concurrent;
+		std::array<std::atomic<uint8_t>, ItemCount> seen{};
+		std::array<std::thread, ProducerCount> producers;
+		for(uint32_t producer = 0; producer < ProducerCount; ++producer)
+		{
+			producers[producer] = std::thread([&, producer]
+			{
+				for(uint32_t ordinal = 0; ordinal < ItemsPerProducer; ++ordinal)
+				{
+					const auto value = producer * ItemsPerProducer + ordinal;
+					while(!concurrent.tryPush(value))
+						std::this_thread::yield();
+				}
+			});
+		}
+		for(uint32_t count = 0; count < ItemCount;)
+		{
+			uint32_t value = 0;
+			if(!concurrent.tryPop(value))
+			{
+				std::this_thread::yield();
+				continue;
+			}
+			require(value < ItemCount, "concurrent queue returned invalid data");
+			require(seen[value].fetch_add(1, std::memory_order_relaxed) == 0,
+				"concurrent queue returned an item twice");
+			++count;
+		}
+		for(auto& producer : producers)
+			producer.join();
+		for(const auto& count : seen)
+			require(count.load(std::memory_order_relaxed) == 1,
+				"concurrent queue lost an item");
+	}
 }
 
 int main()
 {
+	verifyRealtimeQueue();
 	verify("parameterDescriptions_md.json", md::MachineModel::Machinedrum,
 		26, md::automation::machinedrum::TrackCount, 416, 6612241820543455307ull);
 	verify("parameterDescriptions_mm.json", md::MachineModel::Monomachine,

--- a/source/elektron/md/mdJucePlugin/mdAutomationRobustnessTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationRobustnessTest.cpp
@@ -46,6 +46,29 @@ namespace
 		int programChanges = 0;
 	};
 
+	pluginLib::SysEx setStatus(const md::MachineModel _model,
+		const md::automation::sysex::StatusParameter _parameter,
+		const uint8_t _value)
+	{
+		return {0xf0, 0x00, 0x20, 0x3c,
+			static_cast<uint8_t>(_model == md::MachineModel::Monomachine ? 0x03 : 0x02),
+			0x00, 0x71, static_cast<uint8_t>(_parameter), _value, 0xf7};
+	}
+
+	int snapshotValue(const std::vector<uint8_t>& _snapshot,
+		const pluginLib::Parameter& _parameter)
+	{
+		const auto& description = _parameter.getDescription();
+		for(size_t position = 6; position + 3 < _snapshot.size(); position += 4)
+		{
+			if(_snapshot[position] == description.page
+				&& _snapshot[position + 1] == _parameter.getPart()
+				&& _snapshot[position + 2] == description.index)
+				return _snapshot[position + 3];
+		}
+		return -1;
+	}
+
 	void verifyQueuedPreBootWrites(Harness& _harness)
 	{
 		auto allParameters = parameters(_harness, false);
@@ -159,6 +182,119 @@ namespace
 		_harness.audioProcessor.removeListener(&processorListener);
 	}
 
+	void verifyCorrelatedDumpsAndStrictStatus(Harness& _harness)
+	{
+		auto& controller = _harness.controller;
+		const auto baseline = controller.createAutomationSnapshot();
+		require(!baseline.empty(), "missing correlated-dump test baseline");
+		const auto currentKit = baseline[3];
+		const auto wrongKit = static_cast<uint8_t>((currentKit + 1)
+			% (_harness.model == md::MachineModel::Monomachine ? 128 : 64));
+
+		// Valid but unsolicited dumps, including a duplicate for the active slot,
+		// must not replace the authoritative snapshot.
+		controller.parseSysexMessage(makeKitDump(_harness.model, wrongKit, 91),
+			synthLib::MidiEventSource::Physical);
+		controller.parseSysexMessage(makeKitDump(_harness.model, currentKit, 92),
+			synthLib::MidiEventSource::Physical);
+		require(controller.createAutomationSnapshot() == baseline,
+			"unsolicited Kit dump replaced the active snapshot");
+
+		// Strict framing matters at the controller boundary: malformed lookalikes
+		// must not invalidate an otherwise-ready snapshot.
+		const auto validSet = setStatus(_harness.model,
+			md::automation::sysex::StatusParameter::Kit, currentKit);
+		for(const auto position : {size_t{1}, size_t{2}, size_t{3}, size_t{4},
+			size_t{5}, size_t{6}, size_t{9}})
+		{
+			auto malformed = validSet;
+			malformed[position] ^= 1;
+			controller.parseSysexMessage(malformed,
+				synthLib::MidiEventSource::Physical);
+			require(controller.isAutomationSynchronized()
+				&& controller.createAutomationSnapshot() == baseline,
+				"malformed SET STATUS invalidated synchronization");
+		}
+
+		// Once a refresh is outstanding, a dump for a different slot is stale and
+		// cannot complete synchronization.
+		const synthLib::SMidiEvent programChange(synthLib::MidiEventSource::Physical,
+			static_cast<uint8_t>(0xc0 | controller.getAutomationBaseChannel()),
+			currentKit, 0);
+		controller.parseMidiMessage(programChange);
+		require(controller.createAutomationSnapshot().empty(),
+			"snapshot escaped while Kit refresh was incomplete");
+		controller.parseSysexMessage(makeKitDump(_harness.model, wrongKit, 93),
+			synthLib::MidiEventSource::Physical);
+		require(!controller.isAutomationSynchronized()
+			&& controller.createAutomationSnapshot().empty(),
+			"wrong-slot Kit dump completed synchronization");
+		require(_harness.synchronize(), "correlated Kit refresh timed out");
+
+		// Exercise the same correlation for Globals and prove that a duplicate late
+		// dump cannot alter the active base channel.
+		const auto originalBase = controller.getAutomationBaseChannel();
+		controller.parseSysexMessage(setStatus(_harness.model,
+			md::automation::sysex::StatusParameter::Global, 0),
+			synthLib::MidiEventSource::Physical);
+		controller.parseSysexMessage(makeGlobalDump(_harness.model, 1,
+			static_cast<uint8_t>((originalBase + 1) & 0x0f)),
+			synthLib::MidiEventSource::Physical);
+		require(!controller.isAutomationSynchronized(),
+			"wrong-slot Global dump completed synchronization");
+		controller.parseSysexMessage(makeGlobalDump(_harness.model, 0, originalBase),
+			synthLib::MidiEventSource::Physical);
+		require(controller.isAutomationSynchronized(),
+			"expected Global dump did not complete synchronization");
+		controller.parseSysexMessage(makeGlobalDump(_harness.model, 0,
+			static_cast<uint8_t>((originalBase + 1) & 0x0f)),
+			synthLib::MidiEventSource::Physical);
+		require(controller.getAutomationBaseChannel() == originalBase,
+			"duplicate late Global dump changed the base channel");
+	}
+
+	void verifyMidiNoneReplay(Harness& _harness)
+	{
+		auto& controller = _harness.controller;
+		auto& probe = *parameters(_harness, false).front();
+		const auto originalBase = controller.getAutomationBaseChannel();
+		require(originalBase < 16, "MIDI NONE replay test needs an enabled base");
+
+		controller.parseSysexMessage(setStatus(_harness.model,
+			md::automation::sysex::StatusParameter::Global, 0),
+			synthLib::MidiEventSource::Physical);
+		controller.parseSysexMessage(makeGlobalDump(_harness.model, 0, 0x7f),
+			synthLib::MidiEventSource::Physical);
+		require(controller.isAutomationSynchronized()
+			&& controller.getAutomationBaseChannel() == 0x7f,
+			"MIDI NONE was not accepted as a complete readable snapshot");
+
+		const auto before = controller.getTransmittedAutomationChangeCount();
+		const auto value = static_cast<int>((probe.getUnnormalizedValue() + 41) & 0x7f);
+		hostWrite(probe, value);
+		controller.processRealtimeParameterChanges(64);
+		const auto noneSnapshot = controller.createAutomationSnapshot();
+		require(snapshotValue(noneSnapshot, probe) == value,
+			"MIDI NONE snapshot lost the newest host value");
+		require(controller.getTransmittedAutomationChangeCount() == before,
+			"MIDI NONE transmitted an unroutable host write");
+
+		controller.parseSysexMessage(setStatus(_harness.model,
+			md::automation::sysex::StatusParameter::Global, 0),
+			synthLib::MidiEventSource::Physical);
+		controller.parseSysexMessage(makeGlobalDump(_harness.model, 0, originalBase),
+			synthLib::MidiEventSource::Physical);
+		require(controller.isAutomationSynchronized()
+			&& controller.getTransmittedAutomationChangeCount() == before + 1,
+			"host intent queued during MIDI NONE was not replayed exactly once");
+		require(snapshotValue(controller.createAutomationSnapshot(), probe) == value,
+			"re-enabled MIDI snapshot lost the replayed host value");
+
+		// Return to the actual firmware-selected Global after the synthetic probes.
+		controller.requestAutomationState();
+		require(_harness.synchronize(), "post-NONE firmware resynchronization timed out");
+	}
+
 	std::vector<uint8_t> withoutAutomationChunk(const std::vector<uint8_t>& _state)
 	{
 		std::vector<uint8_t> result;
@@ -188,6 +324,14 @@ namespace
 	void verifyStateContract(Harness& _harness)
 	{
 		auto& controller = _harness.controller;
+		auto& probe = *parameters(_harness, false).front();
+		const auto immediateValue = static_cast<int>(
+			(probe.getUnnormalizedValue() + 29) & 0x7f);
+		hostWrite(probe, immediateValue);
+		const auto immediate = controller.createAutomationSnapshot();
+		require(snapshotValue(immediate, probe) == immediateValue,
+			"snapshot did not publish an undrained host write atomically");
+		_harness.process(32);
 		const auto baseline = controller.createAutomationSnapshot();
 		require(!baseline.empty(), "automation snapshot was empty");
 		require(controller.createAutomationSnapshot() == baseline,
@@ -362,6 +506,8 @@ namespace
 		}
 		verifyQueuedPreBootWrites(harness);
 		verifyExternalNotifications(harness);
+		verifyCorrelatedDumpsAndStrictStatus(harness);
+		verifyMidiNoneReplay(harness);
 		verifyStateContract(harness);
 		verifyRandomizedLifecycle(harness);
 		std::cout << "mdAutomationRobustnessTest: " << modelName(_model)

--- a/source/elektron/md/mdJucePlugin/mdAutomationRobustnessTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationRobustnessTest.cpp
@@ -5,6 +5,8 @@
 
 #include "juce_events/juce_events.h"
 
+#include <array>
+#include <atomic>
 #include <cmath>
 #include <cstring>
 #include <exception>
@@ -12,6 +14,7 @@
 #include <map>
 #include <random>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace
@@ -82,18 +85,165 @@ namespace
 	{
 		auto& controller = _harness.controller;
 		controller.requestAutomationState();
+		controller.parseSysexMessage(makeGlobalDump(_harness.model, 0, 7),
+			synthLib::MidiEventSource::Device);
+		controller.parseSysexMessage(makeKitDump(_harness.model, 0, 99),
+			synthLib::MidiEventSource::Device);
+		require(!controller.isAutomationSynchronized()
+			&& !controller.hasAutomationGlobalSnapshot()
+			&& !controller.hasAutomationKitSnapshot(),
+			"unsolicited startup dumps completed synchronization before status");
 		controller.parseSysexMessage(statusResponse(_harness.model,
 			md::automation::sysex::StatusParameter::Global, 0),
 			synthLib::MidiEventSource::Device);
 		controller.parseSysexMessage(statusResponse(_harness.model,
 			md::automation::sysex::StatusParameter::Kit, 0),
 			synthLib::MidiEventSource::Device);
+		controller.parseSysexMessage(makeGlobalDump(_harness.model, 1, 7),
+			synthLib::MidiEventSource::Device);
+		controller.parseSysexMessage(makeKitDump(_harness.model, 1, 99),
+			synthLib::MidiEventSource::Device);
+		require(!controller.isAutomationSynchronized()
+			&& !controller.hasAutomationGlobalSnapshot()
+			&& !controller.hasAutomationKitSnapshot(),
+			"wrong-slot startup dumps satisfied correlated requests");
 		controller.parseSysexMessage(makeGlobalDump(_harness.model, 0, 0),
 			synthLib::MidiEventSource::Device);
+		require(!controller.isAutomationSynchronized()
+			&& controller.hasAutomationGlobalSnapshot()
+			&& !controller.hasAutomationKitSnapshot(),
+			"one correlated startup reply completed a partial snapshot");
 		controller.parseSysexMessage(makeKitDump(_harness.model, 0, 23),
 			synthLib::MidiEventSource::Device);
 		require(controller.isAutomationSynchronized(),
 			"synthetic architecture snapshot did not synchronize");
+	}
+
+	void verifyAdversarialRestoreSynchronization(Harness& _harness)
+	{
+		auto& controller = _harness.controller;
+		auto& probe = *parameters(_harness, false).front();
+		auto restored = controller.createAutomationSnapshot();
+		require(!restored.empty(), "missing restore synchronization baseline");
+		const auto desired = static_cast<uint8_t>(
+			(static_cast<int>(probe.getUnnormalizedValue()) + 61) & 0x7f);
+		const auto& description = probe.getDescription();
+		bool changed = false;
+		for(size_t position = 6; position < restored.size(); position += 4)
+		{
+			if(restored[position] == description.page
+				&& restored[position + 1] == probe.getPart()
+				&& restored[position + 2] == description.index)
+			{
+				restored[position + 3] = desired;
+				changed = true;
+				break;
+			}
+		}
+		require(changed && controller.restoreAutomationSnapshot(restored),
+			"adversarial restore snapshot was rejected");
+		controller.onStateLoaded();
+
+		// Replies left over from the retired firmware generation have no request
+		// identity in this epoch and must not complete the restored snapshot.
+		controller.parseSysexMessage(makeGlobalDump(_harness.model, 0, 3),
+			synthLib::MidiEventSource::Device);
+		controller.parseSysexMessage(makeKitDump(_harness.model, 0, 4),
+			synthLib::MidiEventSource::Device);
+		require(!controller.isAutomationSynchronized()
+			&& controller.createAutomationSnapshot().empty(),
+			"pre-status replies completed state restore synchronization");
+
+		controller.parseSysexMessage(statusResponse(_harness.model,
+			md::automation::sysex::StatusParameter::Global, 0),
+			synthLib::MidiEventSource::Device);
+		controller.parseSysexMessage(statusResponse(_harness.model,
+			md::automation::sysex::StatusParameter::Kit, 0),
+			synthLib::MidiEventSource::Device);
+		controller.parseSysexMessage(makeGlobalDump(_harness.model, 1, 3),
+			synthLib::MidiEventSource::Device);
+		controller.parseSysexMessage(makeKitDump(_harness.model, 1, 4),
+			synthLib::MidiEventSource::Device);
+		require(!controller.isAutomationSynchronized(),
+			"wrong-slot replies completed state restore synchronization");
+
+		// Complete in the opposite order from startup and interleave another stale
+		// reply. The restored dirty publication must win over the Kit payload.
+		controller.parseSysexMessage(makeKitDump(_harness.model, 0, 12),
+			synthLib::MidiEventSource::Device);
+		controller.parseSysexMessage(makeKitDump(_harness.model, 1, 13),
+			synthLib::MidiEventSource::Device);
+		require(!controller.isAutomationSynchronized()
+			&& probe.getUnnormalizedValue() == desired,
+			"Kit-first restore completion lost restored intent");
+		controller.parseSysexMessage(makeGlobalDump(_harness.model, 0, 0),
+			synthLib::MidiEventSource::Device);
+		require(controller.isAutomationSynchronized()
+			&& snapshotValue(controller.createAutomationSnapshot(), probe) == desired,
+			"correlated restore replies did not publish the restored snapshot");
+
+		const auto completed = controller.createAutomationSnapshot();
+		controller.parseSysexMessage(makeGlobalDump(_harness.model, 0, 9),
+			synthLib::MidiEventSource::Device);
+		controller.parseSysexMessage(makeKitDump(_harness.model, 0, 10),
+			synthLib::MidiEventSource::Device);
+		require(controller.createAutomationSnapshot() == completed,
+			"late duplicate replies mutated the completed restore snapshot");
+	}
+
+	void verifyConcurrentPublicationArchitecture(Harness& _harness)
+	{
+		auto allParameters = parameters(_harness, false);
+		require(allParameters.size() >= 4,
+			"concurrent publication architecture needs four parameters");
+		constexpr int ProducerCount = 4;
+		constexpr int WritesPerProducer = 2048;
+		std::array<int, ProducerCount> expected{};
+		std::atomic<bool> start{false};
+		std::atomic<int> active{ProducerCount};
+		std::array<std::thread, ProducerCount> producers;
+		std::thread drainer([&]
+		{
+			while(!start.load(std::memory_order_acquire))
+				std::this_thread::yield();
+			while(active.load(std::memory_order_acquire) > 0)
+				_harness.controller.processRealtimeParameterChanges(32);
+			for(size_t pass = 0; pass < allParameters.size(); ++pass)
+				_harness.controller.processRealtimeParameterChanges(32);
+		});
+		for(int producer = 0; producer < ProducerCount; ++producer)
+		{
+			producers[producer] = std::thread([&, producer]
+			{
+				while(!start.load(std::memory_order_acquire))
+					std::this_thread::yield();
+				for(int write = 0; write < WritesPerProducer; ++write)
+				{
+					const auto value = (producer * 31 + write * 17) & 0x7f;
+					expected[producer] = value;
+					if(producer == ProducerCount - 1)
+						allParameters[producer]->setUnnormalizedValue(value,
+							pluginLib::Parameter::Origin::Ui);
+					else
+						hostWrite(*allParameters[producer], value);
+				}
+				active.fetch_sub(1, std::memory_order_release);
+			});
+		}
+		start.store(true, std::memory_order_release);
+		for(auto& producer : producers)
+			producer.join();
+		drainer.join();
+
+		const auto snapshot = _harness.controller.createAutomationSnapshot();
+		require(!snapshot.empty(),
+			"concurrent publication invalidated the synchronized snapshot");
+		for(int producer = 0; producer < ProducerCount; ++producer)
+		{
+			require(snapshotValue(snapshot, *allParameters[producer])
+				== expected[producer],
+				"concurrent producer lost its latest authoritative publication");
+		}
 	}
 
 	void verifyQueuedPreBootWrites(Harness& _harness)
@@ -372,8 +522,24 @@ namespace
 			&& snapshotValue(controller.createAutomationSnapshot(), probe) == externalValue,
 			"Kit dump overwrote a newer post-request MIDI publication");
 
-		// Host and UI writes now share one publication order. The older queued host
-		// value must never arrive after the newer synchronous UI value.
+		// Ordinary DAW writes retain their exact FIFO sequence even when two values
+		// for one address are published before the audio callback drains them.
+		const auto firstHostValue = (hostValue + 3) & 0x7f;
+		const auto secondHostValue = (hostValue + 5) & 0x7f;
+		const auto beforeHostSequence = controller.getTransmittedAutomationChangeCount();
+		hostWrite(probe, firstHostValue);
+		hostWrite(probe, secondHostValue);
+		controller.processRealtimeParameterChanges(64);
+		require(controller.getTransmittedAutomationChangeCount()
+			== beforeHostSequence + 2,
+			"ordered DAW publications did not preserve both explicit writes");
+		require(snapshotValue(controller.createAutomationSnapshot(), probe)
+			== secondHostValue,
+			"ordered DAW publications did not retain the latest snapshot value");
+
+		// Host and UI writes share one publication order, but a synchronous UI edit
+		// intentionally supersedes an older queued host value. It must never arrive
+		// after the newer UI value.
 		const auto olderHostValue = (hostValue + 11) & 0x7f;
 		const auto newerUiValue = (hostValue + 29) & 0x7f;
 		const auto beforeUi = controller.getTransmittedAutomationChangeCount();
@@ -401,13 +567,39 @@ namespace
 			"overflow probe did not exceed the bounded hint queue");
 		require(snapshotValue(controller.createAutomationSnapshot(), probe) == overflowValue,
 			"overflow lost the authoritative latest publication");
-		for(int pass = 0; pass < 8; ++pass)
+		int recoveryPasses = 0;
+		while(controller.getTransmittedAutomationChangeCount()
+			== beforeOverflowTransmit && recoveryPasses < 2)
+		{
 			controller.processRealtimeParameterChanges(1024);
+			++recoveryPasses;
+		}
 		require(controller.getTransmittedAutomationChangeCount()
 			== beforeOverflowTransmit + 1,
 			"overflow did not coalesce to exactly one latest delivery");
+		require(recoveryPasses <= 2,
+			"overflow recovery exceeded the reserved slot-scan bound");
 		require(snapshotValue(controller.createAutomationSnapshot(), probe) == overflowValue,
 			"overflow delivery changed the authoritative snapshot");
+
+		// Even the smallest caller budget alternates progress through the rotating
+		// slot scan and the stale hint backlog. Two slot-table traversals are therefore
+		// an absolute recovery bound, independent of queue depth, without starving the
+		// ordinary FIFO.
+		const auto oneAtATimeValue = (overflowValue + 41) & 0x7f;
+		hostWrite(probe, oneAtATimeValue);
+		const auto beforeOneAtATime = controller.getTransmittedAutomationChangeCount();
+		const auto maximumPasses = controller.getExposedParameters().size() * 2;
+		size_t oneAtATimePasses = 0;
+		while(controller.getTransmittedAutomationChangeCount() == beforeOneAtATime
+			&& oneAtATimePasses < maximumPasses)
+		{
+			controller.processRealtimeParameterChanges(1);
+			++oneAtATimePasses;
+		}
+		require(controller.getTransmittedAutomationChangeCount()
+			== beforeOneAtATime + 1,
+			"minimum-budget overflow recovery exceeded two slot-table traversals");
 	}
 
 	std::vector<uint8_t> withoutAutomationChunk(const std::vector<uint8_t>& _state)
@@ -635,6 +827,8 @@ namespace
 		Harness harness(_model);
 		primeSyntheticSnapshot(harness);
 		verifyOrderedIntentArchitecture(harness);
+		verifyAdversarialRestoreSynchronization(harness);
+		verifyConcurrentPublicationArchitecture(harness);
 		std::cout << "mdAutomationRobustnessTest: " << modelName(_model)
 			<< " ARCHITECTURE PASS\n";
 	}

--- a/source/elektron/md/mdJucePlugin/mdAutomationRobustnessTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationRobustnessTest.cpp
@@ -55,6 +55,15 @@ namespace
 			0x00, 0x71, static_cast<uint8_t>(_parameter), _value, 0xf7};
 	}
 
+	pluginLib::SysEx statusResponse(const md::MachineModel _model,
+		const md::automation::sysex::StatusParameter _parameter,
+		const uint8_t _value)
+	{
+		auto result = setStatus(_model, _parameter, _value);
+		result[6] = 0x72;
+		return result;
+	}
+
 	int snapshotValue(const std::vector<uint8_t>& _snapshot,
 		const pluginLib::Parameter& _parameter)
 	{
@@ -67,6 +76,24 @@ namespace
 				return _snapshot[position + 3];
 		}
 		return -1;
+	}
+
+	void primeSyntheticSnapshot(Harness& _harness)
+	{
+		auto& controller = _harness.controller;
+		controller.requestAutomationState();
+		controller.parseSysexMessage(statusResponse(_harness.model,
+			md::automation::sysex::StatusParameter::Global, 0),
+			synthLib::MidiEventSource::Device);
+		controller.parseSysexMessage(statusResponse(_harness.model,
+			md::automation::sysex::StatusParameter::Kit, 0),
+			synthLib::MidiEventSource::Device);
+		controller.parseSysexMessage(makeGlobalDump(_harness.model, 0, 0),
+			synthLib::MidiEventSource::Device);
+		controller.parseSysexMessage(makeKitDump(_harness.model, 0, 23),
+			synthLib::MidiEventSource::Device);
+		require(controller.isAutomationSynchronized(),
+			"synthetic architecture snapshot did not synchronize");
 	}
 
 	void verifyQueuedPreBootWrites(Harness& _harness)
@@ -295,6 +322,94 @@ namespace
 		require(_harness.synchronize(), "post-NONE firmware resynchronization timed out");
 	}
 
+	void verifyOrderedIntentArchitecture(Harness& _harness)
+	{
+		auto& controller = _harness.controller;
+		auto& probe = *parameters(_harness, false).front();
+		const auto baseline = controller.createAutomationSnapshot();
+		require(!baseline.empty(), "missing ordered-intent test baseline");
+		const auto currentKit = baseline[3];
+
+		// Reproduce the timer ordering that previously lost a host write: the Kit
+		// dump is parsed before the controller's host-automation queue is drained.
+		const synthLib::SMidiEvent programChange(synthLib::MidiEventSource::Physical,
+			static_cast<uint8_t>(0xc0 | controller.getAutomationBaseChannel()),
+			currentKit, 0);
+		controller.parseMidiMessage(programChange);
+		controller.parseSysexMessage(statusResponse(_harness.model,
+			md::automation::sysex::StatusParameter::Kit, currentKit),
+			synthLib::MidiEventSource::Device);
+		const auto hostValue = static_cast<int>((probe.getUnnormalizedValue() + 37) & 0x7f);
+		hostWrite(probe, hostValue);
+		controller.parseSysexMessage(makeKitDump(_harness.model, currentKit,
+			static_cast<uint8_t>((hostValue + 19) & 0x7f)),
+			synthLib::MidiEventSource::Device);
+		require(controller.isAutomationSynchronized(),
+			"Kit dump did not complete ordered-intent synchronization");
+		require(probe.getUnnormalizedValue() == hostValue
+			&& snapshotValue(controller.createAutomationSnapshot(), probe) == hostValue,
+			"Kit dump overwrote an undrained host publication");
+
+		// A direct MIDI edit observed after the dump request is newer authoritative
+		// state even though it does not need delivery. The request watermark keeps a
+		// subsequently arriving stale dump from rolling it back.
+		controller.parseMidiMessage(programChange);
+		controller.parseSysexMessage(statusResponse(_harness.model,
+			md::automation::sysex::StatusParameter::Kit, currentKit),
+			synthLib::MidiEventSource::Device);
+		const auto externalValue = (hostValue + 7) & 0x7f;
+		const auto& description = probe.getDescription();
+		const auto external = md::automation::encodeParameterChange(_harness.model,
+			{description.page, probe.getPart(), description.index,
+				static_cast<uint8_t>(externalValue)}, controller.getAutomationBaseChannel());
+		require(external.has_value(), "post-request MIDI value did not encode");
+		controller.parseControllerMessage({synthLib::MidiEventSource::Physical,
+			(*external)[0], (*external)[1], (*external)[2]});
+		controller.parseSysexMessage(makeKitDump(_harness.model, currentKit,
+			static_cast<uint8_t>((externalValue + 13) & 0x7f)),
+			synthLib::MidiEventSource::Device);
+		require(probe.getUnnormalizedValue() == externalValue
+			&& snapshotValue(controller.createAutomationSnapshot(), probe) == externalValue,
+			"Kit dump overwrote a newer post-request MIDI publication");
+
+		// Host and UI writes now share one publication order. The older queued host
+		// value must never arrive after the newer synchronous UI value.
+		const auto olderHostValue = (hostValue + 11) & 0x7f;
+		const auto newerUiValue = (hostValue + 29) & 0x7f;
+		const auto beforeUi = controller.getTransmittedAutomationChangeCount();
+		hostWrite(probe, olderHostValue);
+		probe.setUnnormalizedValue(newerUiValue, pluginLib::Parameter::Origin::Ui);
+		require(controller.getTransmittedAutomationChangeCount() == beforeUi + 1,
+			"ordered UI publication did not coalesce the older host value");
+		require(probe.getUnnormalizedValue() == newerUiValue
+			&& snapshotValue(controller.createAutomationSnapshot(), probe) == newerUiValue,
+			"older host publication won after a newer UI change");
+
+		// Overflow drops queue hints only. The latest atomic publication must remain
+		// immediately snapshot-visible and must be delivered once by the slot scan.
+		controller.processRealtimeParameterChanges(1024);
+		const auto beforeOverflow = controller.getRealtimeAutomationOverflowCount();
+		const auto beforeOverflowTransmit =
+			controller.getTransmittedAutomationChangeCount();
+		int overflowValue = newerUiValue;
+		for(size_t write = 0; write < 4352; ++write)
+		{
+			overflowValue = static_cast<int>((write * 23 + 17) & 0x7f);
+			hostWrite(probe, overflowValue);
+		}
+		require(controller.getRealtimeAutomationOverflowCount() > beforeOverflow,
+			"overflow probe did not exceed the bounded hint queue");
+		require(snapshotValue(controller.createAutomationSnapshot(), probe) == overflowValue,
+			"overflow lost the authoritative latest publication");
+		for(int pass = 0; pass < 8; ++pass)
+			controller.processRealtimeParameterChanges(1024);
+		require(controller.getTransmittedAutomationChangeCount()
+			== beforeOverflowTransmit + 1,
+			"overflow did not coalesce to exactly one latest delivery");
+		require(snapshotValue(controller.createAutomationSnapshot(), probe) == overflowValue,
+			"overflow delivery changed the authoritative snapshot");
+	}
+
 	std::vector<uint8_t> withoutAutomationChunk(const std::vector<uint8_t>& _state)
 	{
 		std::vector<uint8_t> result;
@@ -508,10 +623,20 @@ namespace
 		verifyExternalNotifications(harness);
 		verifyCorrelatedDumpsAndStrictStatus(harness);
 		verifyMidiNoneReplay(harness);
+		verifyOrderedIntentArchitecture(harness);
 		verifyStateContract(harness);
 		verifyRandomizedLifecycle(harness);
 		std::cout << "mdAutomationRobustnessTest: " << modelName(_model)
 			<< " PASS\n";
+	}
+
+	void verifyArchitecture(const md::MachineModel _model)
+	{
+		Harness harness(_model);
+		primeSyntheticSnapshot(harness);
+		verifyOrderedIntentArchitecture(harness);
+		std::cout << "mdAutomationRobustnessTest: " << modelName(_model)
+			<< " ARCHITECTURE PASS\n";
 	}
 
 }
@@ -523,6 +648,7 @@ int main(const int _argc, const char* const* _argv)
 	{
 		bool mdOnly = false;
 		bool mmOnly = false;
+		bool architectureOnly = false;
 		for(int argument = 1; argument < _argc; ++argument)
 		{
 			const std::string value(_argv[argument]);
@@ -530,6 +656,16 @@ int main(const int _argc, const char* const* _argv)
 				mdOnly = true;
 			else if(value == "--mm")
 				mmOnly = true;
+			else if(value == "--architecture-only")
+				architectureOnly = true;
+		}
+		if(architectureOnly)
+		{
+			if(!mmOnly)
+				verifyArchitecture(md::MachineModel::Machinedrum);
+			if(!mdOnly)
+				verifyArchitecture(md::MachineModel::Monomachine);
+			return 0;
 		}
 		if(!mmOnly)
 			verifyModel(md::MachineModel::Machinedrum);

--- a/source/elektron/md/mdJucePlugin/mdAutomationTestSupport.h
+++ b/source/elektron/md/mdJucePlugin/mdAutomationTestSupport.h
@@ -10,6 +10,7 @@
 #include "juce_events/juce_events.h"
 
 #include <cstdint>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -111,6 +112,41 @@ namespace mdAutomationTest
 					return true;
 			}
 			return false;
+		}
+
+		std::string firmwareReadiness()
+		{
+			std::ostringstream result;
+			processor.getPlugin().withDeviceLocked(
+				[this, &result](synthLib::Device* const _device)
+				{
+					auto* const device = dynamic_cast<md::Device*>(_device);
+					if(device == nullptr)
+					{
+						result << "device=nonlocal";
+						return;
+					}
+					auto& hardware = device->getHardware();
+					const auto panel = hardware.getFrontPanelSnapshot();
+					result << "audio=" << hardware.isAudioReady()
+						<< ", mixer=" << hardware.getDspMixer().booted()
+						<< ", producer=" << hardware.getDspProducer().booted()
+						<< ", pixels=" << panel.countLitPixels()
+						<< ", tiles=" << panel.getTileWriteCount()
+						<< ", restore=" << hardware.isProjectStateRestorePending()
+						<< ", factory=" << hardware.isFactoryFlashCacheReady()
+						<< ", midiQueued=" << hardware.queuedMidiRxBytes()
+						<< ", midiConsumed=" << hardware.midiRxConsumedCount()
+						<< ", midiOverflows=" << hardware.midiRxOverflowCount()
+						<< ", ingressContention="
+						<< controller.getRealtimeMidiIngressContentionDropCount()
+						<< ", ingressCapacity="
+						<< controller.getRealtimeMidiIngressCapacityDropCount();
+					result
+						<< ", ucCycles=" << hardware.getUC().getCycles()
+						<< ", ucPC=" << hardware.getUC().getPC();
+				});
+			return result.str();
 		}
 
 		MidiTelemetry telemetry()
@@ -227,7 +263,7 @@ namespace mdAutomationTest
 		md::automation::sysex::Message result{
 			0xf0, 0x00, 0x20, 0x3c,
 			static_cast<uint8_t>(_model == md::MachineModel::Monomachine ? 0x03 : 0x02),
-			0x00, _command, _slot, 0x01, 0x00};
+			0x00, _command, 0x01, 0x01, _slot};
 		if(_model == md::MachineModel::Monomachine)
 		{
 			const auto packed = packMmPayload(_decoded);

--- a/source/elektron/md/mdJucePlugin/mdAutomationTestSupport.h
+++ b/source/elektron/md/mdJucePlugin/mdAutomationTestSupport.h
@@ -5,6 +5,7 @@
 
 #include "mdLib/mdautomation.h"
 #include "mdLib/mddevice.h"
+#include "mdLib/mdsysexautomation.h"
 
 #include "juce_events/juce_events.h"
 
@@ -167,5 +168,117 @@ namespace mdAutomationTest
 	{
 		_parameter.setValue(_parameter.getNormalisableRange().convertTo0to1(
 			static_cast<float>(_value)));
+	}
+
+	inline void finishDump(md::automation::sysex::Message& _message)
+	{
+		uint32_t checksum = 0;
+		for(size_t index = 9; index < _message.size(); ++index)
+			checksum += _message[index];
+		checksum &= 0x3fff;
+		const auto length = static_cast<uint16_t>(_message.size() - 5);
+		_message.push_back(static_cast<uint8_t>(checksum >> 7));
+		_message.push_back(static_cast<uint8_t>(checksum & 0x7f));
+		_message.push_back(static_cast<uint8_t>(length >> 7));
+		_message.push_back(static_cast<uint8_t>(length & 0x7f));
+		_message.push_back(0xf7);
+	}
+
+	inline std::vector<uint8_t> packMmPayload(const std::vector<uint8_t>& _decoded)
+	{
+		std::vector<uint8_t> rle;
+		for(size_t position = 0; position < _decoded.size();)
+		{
+			const auto value = _decoded[position];
+			size_t count = 1;
+			while(position + count < _decoded.size()
+				&& _decoded[position + count] == value && count < 127)
+				++count;
+			if(value >= 0x80 || count > 1)
+			{
+				rle.push_back(static_cast<uint8_t>(0x80 | count));
+				rle.push_back(value);
+			}
+			else
+				rle.push_back(value);
+			position += count;
+		}
+
+		std::vector<uint8_t> packed;
+		for(size_t position = 0; position < rle.size();)
+		{
+			const auto header = packed.size();
+			packed.push_back(0);
+			for(uint8_t bit = 0; bit < 7 && position < rle.size(); ++bit)
+			{
+				const auto value = rle[position++];
+				if(value & 0x80)
+					packed[header] |= static_cast<uint8_t>(1u << (6u - bit));
+				packed.push_back(static_cast<uint8_t>(value & 0x7f));
+			}
+		}
+		return packed;
+	}
+
+	inline md::automation::sysex::Message makeDump(const md::MachineModel _model,
+		const uint8_t _command, const uint8_t _slot,
+		const std::vector<uint8_t>& _decoded)
+	{
+		md::automation::sysex::Message result{
+			0xf0, 0x00, 0x20, 0x3c,
+			static_cast<uint8_t>(_model == md::MachineModel::Monomachine ? 0x03 : 0x02),
+			0x00, _command, _slot, 0x01, 0x00};
+		if(_model == md::MachineModel::Monomachine)
+		{
+			const auto packed = packMmPayload(_decoded);
+			result.insert(result.end(), packed.begin(), packed.end());
+		}
+		else
+			result.insert(result.end(), _decoded.begin(), _decoded.end());
+		finishDump(result);
+		return result;
+	}
+
+	inline md::automation::sysex::Message makeGlobalDump(
+		const md::MachineModel _model, const uint8_t _slot, const uint8_t _base)
+	{
+		if(_model == md::MachineModel::Monomachine)
+		{
+			std::vector<uint8_t> decoded(260, 0);
+			decoded[0] = 0x91;
+			decoded[1] = _base;
+			return makeDump(_model, 0x50, _slot, decoded);
+		}
+		// makeDump contributes the ten-byte header before this raw payload, so the
+		// firmware's absolute base-channel offset 0xad maps to payload offset 0xa3.
+		std::vector<uint8_t> decoded(0xa6, 0);
+		decoded[0xa3] = _base;
+		return makeDump(_model, 0x50, _slot, decoded);
+	}
+
+	inline md::automation::sysex::Message makeKitDump(
+		const md::MachineModel _model, const uint8_t _slot, const uint8_t _value)
+	{
+		if(_model == md::MachineModel::Monomachine)
+		{
+			std::vector<uint8_t> decoded(698, 0);
+			for(uint8_t track = 0; track < md::automation::monomachine::TrackCount;
+				++track)
+			{
+				decoded[0x0b + track] = _value;
+				for(uint8_t parameter = 0; parameter < 56; ++parameter)
+					decoded[0x11 + track * 72 + parameter] = _value;
+			}
+			return makeDump(_model, 0x52, _slot, decoded);
+		}
+		std::vector<uint8_t> decoded(1218, 0);
+		for(uint8_t track = 0; track < md::automation::machinedrum::TrackCount;
+			++track)
+		{
+			for(uint8_t parameter = 0; parameter < 24; ++parameter)
+				decoded[0x10 + track * 24 + parameter] = _value;
+			decoded[0x190 + track] = _value;
+		}
+		return makeDump(_model, 0x52, _slot, decoded);
 	}
 }

--- a/source/elektron/md/mdJucePlugin/mdController.cpp
+++ b/source/elektron/md/mdJucePlugin/mdController.cpp
@@ -41,15 +41,27 @@ namespace mdJucePlugin
 			return _nonPartSensitive ? juce::String("Global")
 				: juce::String("Track ") + juce::String(_part + 1);
 		});
+		for(const auto& [address, parameters] : getExposedParameters())
+		{
+			(void)parameters;
+			assert(m_automationSlotCount < m_automationSlots.size());
+			const Address automationAddress{address.page, address.partNum,
+				address.paramNum};
+			auto& slot = m_automationSlots[m_automationSlotCount];
+			slot.address = automationAddress;
+			m_automationSlotIndices.emplace(automationAddress,
+				m_automationSlotCount++);
+		}
 
 		// Give mute (which is not part of a Kit dump) a defined initial cache value.
 		// The other values are replaced by the firmware snapshot below.
 		for(const auto& [address, parameters] : getExposedParameters())
 		{
-			(void)address;
 			for(auto* const parameter : parameters)
 				parameter->setValueFromSynth(parameter->getDefault(),
 					pluginLib::Parameter::Origin::PresetChange);
+			publishAutomationValue({address.page, address.partNum, address.paramNum},
+				static_cast<uint8_t>(std::clamp(parameters.front()->getDefault(), 0, 127)));
 		}
 
 		requestAutomationState();
@@ -80,7 +92,10 @@ namespace mdJucePlugin
 
 	std::vector<uint8_t> Controller::createAutomationSnapshot() const
 	{
-		if(!m_haveGlobal.load(std::memory_order_acquire)
+		const auto epoch = m_synchronizationEpoch.load(std::memory_order_acquire);
+		if(!m_automationReady.load(std::memory_order_acquire)
+			|| !m_haveGlobal.load(std::memory_order_acquire)
+			|| !m_haveKit.load(std::memory_order_acquire)
 			|| m_currentKit.load(std::memory_order_acquire) == 0xff)
 			return {};
 		std::vector<uint8_t> result;
@@ -96,12 +111,18 @@ namespace mdJucePlugin
 		{
 			if(parameters.empty())
 				continue;
+			const auto* const slot = findAutomationSlot(
+				{address.page, address.partNum, address.paramNum});
+			if(slot == nullptr)
+				return {};
 			result.push_back(address.page);
 			result.push_back(address.partNum);
 			result.push_back(address.paramNum);
-			result.push_back(static_cast<uint8_t>(std::clamp(
-				parameters.front()->getUnnormalizedValue(), 0, 127)));
+			result.push_back(slot->snapshotValue.load(std::memory_order_acquire));
 		}
+		if(!m_automationReady.load(std::memory_order_acquire)
+			|| epoch != m_synchronizationEpoch.load(std::memory_order_acquire))
+			return {};
 		return result;
 	}
 
@@ -129,6 +150,7 @@ namespace mdJucePlugin
 		}
 
 		m_automationReady.store(false, std::memory_order_release);
+		m_synchronizationEpoch.fetch_add(1, std::memory_order_acq_rel);
 		m_baseChannel.store(_snapshot[2], std::memory_order_release);
 		m_currentKit.store(_snapshot[3], std::memory_order_release);
 		std::map<Address, pluginLib::ParamValue> restored;
@@ -143,13 +165,12 @@ namespace mdJucePlugin
 			for(auto* const parameter : parameters)
 				parameter->setValueFromSynth(_snapshot[position + 3],
 					pluginLib::Parameter::Origin::PresetChange);
+			publishAutomationValue(address, _snapshot[position + 3]);
 			restored[address] = _snapshot[position + 3];
 		}
-		{
-			const std::lock_guard lock(m_pendingMutex);
-			for(const auto& [address, value] : restored)
-				m_pendingChanges[address] = value;
-		}
+		for(const auto& [address, value] : restored)
+			storePendingChange({address.page, address.track, address.index,
+				static_cast<uint8_t>(std::clamp<pluginLib::ParamValue>(value, 0, 127))});
 		m_haveGlobal.store(false, std::memory_order_release);
 		m_haveKit.store(false, std::memory_order_release);
 		getProcessor().updateHostDisplay(
@@ -160,6 +181,7 @@ namespace mdJucePlugin
 	void Controller::requestAutomationState()
 	{
 		m_automationReady.store(false, std::memory_order_release);
+		m_synchronizationEpoch.fetch_add(1, std::memory_order_acq_rel);
 		m_haveGlobal.store(false, std::memory_order_release);
 		m_haveKit.store(false, std::memory_order_release);
 		m_currentGlobal.store(0xff, std::memory_order_release);
@@ -172,6 +194,7 @@ namespace mdJucePlugin
 	void Controller::requestKitState()
 	{
 		m_automationReady.store(false, std::memory_order_release);
+		m_synchronizationEpoch.fetch_add(1, std::memory_order_acq_rel);
 		m_haveKit.store(false, std::memory_order_release);
 		m_kitDumpRequestMs.store(0, std::memory_order_release);
 		sendMissingSynchronizationRequests();
@@ -210,6 +233,7 @@ namespace mdJucePlugin
 
 	void Controller::onControllerTimer()
 	{
+		drainRealtimeParameterChanges(RealtimeAutomationCapacity, false);
 		completeSynchronizationIfReady();
 		const auto now = milliseconds();
 		if(m_automationReady.load(std::memory_order_acquire))
@@ -224,6 +248,18 @@ namespace mdJucePlugin
 				md::automation::sysex::StatusParameter::Global)));
 			sendSynchronizationRequest(toPluginSysex(md::automation::sysex::statusRequest(m_model,
 				md::automation::sysex::StatusParameter::Kit)));
+			// A status response identifies the active Global slot, but does not expose
+			// edits to that Global's MIDI base channel. Refresh the selected Global too
+			// so queued writes survive MIDI NONE and resume when a channel is enabled.
+			const auto currentGlobal = m_currentGlobal.load(std::memory_order_acquire);
+			const auto requested = m_globalDumpRequestMs.load(std::memory_order_acquire);
+			if(currentGlobal != 0xff && (requested == 0
+				|| now - requested >= g_dumpRequestRetryMs))
+			{
+				m_globalDumpRequestMs.store(now, std::memory_order_release);
+				sendSynchronizationRequest(toPluginSysex(md::automation::sysex::globalRequest(
+					m_model, currentGlobal)));
+			}
 			return;
 		}
 		if(now - m_lastSynchronizationRequestMs.load(std::memory_order_acquire) < 500)
@@ -232,7 +268,7 @@ namespace mdJucePlugin
 	}
 
 	void Controller::sendParameterChange(const pluginLib::Parameter& _parameter,
-		const pluginLib::ParamValue _value, pluginLib::Parameter::Origin)
+		const pluginLib::ParamValue _value, const pluginLib::Parameter::Origin _origin)
 	{
 		const auto& description = _parameter.getDescription();
 		const md::automation::ParameterChange change{
@@ -241,18 +277,56 @@ namespace mdJucePlugin
 			description.index,
 			static_cast<uint8_t>(std::clamp<pluginLib::ParamValue>(_value, 0, 127))
 		};
+		publishAutomationValue({change.page, change.track, change.index}, change.value);
+		if(_origin == pluginLib::Parameter::Origin::HostAutomation)
+		{
+			if(!m_realtimeAutomationChanges.tryPush(change))
+			{
+				// A hostile producer can outrun any bounded queue. Preserve the latest
+				// value for this address and expose the exceptional coalescing event.
+				storePendingChange(change);
+				m_realtimeAutomationOverflows.fetch_add(1, std::memory_order_relaxed);
+			}
+			return;
+		}
 		if(!m_automationReady.load(std::memory_order_acquire)
 			|| getAutomationBaseChannel() == 0x7f)
 		{
-			const std::lock_guard lock(m_pendingMutex);
-			if(!m_automationReady.load(std::memory_order_relaxed)
-				|| getAutomationBaseChannel() == 0x7f)
-			{
-				m_pendingChanges[{change.page, change.track, change.index}] = _value;
-				return;
-			}
+			storePendingChange(change);
+			return;
 		}
 		transmitParameterChange(change);
+	}
+
+	Controller::AutomationSlot* Controller::findAutomationSlot(
+		const Address& _address)
+	{
+		const auto found = m_automationSlotIndices.find(_address);
+		return found == m_automationSlotIndices.end()
+			? nullptr : &m_automationSlots[found->second];
+	}
+
+	const Controller::AutomationSlot* Controller::findAutomationSlot(
+		const Address& _address) const
+	{
+		const auto found = m_automationSlotIndices.find(_address);
+		return found == m_automationSlotIndices.end()
+			? nullptr : &m_automationSlots[found->second];
+	}
+
+	void Controller::publishAutomationValue(const Address& _address,
+		const uint8_t _value)
+	{
+		if(auto* const slot = findAutomationSlot(_address))
+			slot->snapshotValue.store(_value, std::memory_order_release);
+	}
+
+	void Controller::storePendingChange(
+		const md::automation::ParameterChange& _change)
+	{
+		if(auto* const slot = findAutomationSlot(
+			{_change.page, _change.track, _change.index}))
+			slot->pendingValue.store(_change.value, std::memory_order_release);
 	}
 
 	void Controller::transmitParameterChange(
@@ -279,16 +353,97 @@ namespace mdJucePlugin
 		}
 	}
 
+	bool Controller::transmitRealtimeParameterChange(
+		const md::automation::ParameterChange& _change)
+	{
+		const auto message = md::automation::encodeParameterChange(
+			m_model, _change, getAutomationBaseChannel());
+		if(!message)
+			return true;
+		const synthLib::SMidiEvent event(synthLib::MidiEventSource::Editor,
+			(*message)[0], (*message)[1], (*message)[2]);
+		if(!getProcessor().tryAddRealtimeMidiEvent(event))
+			return false;
+
+		auto observed = m_transmittedAutomationDigest.load(std::memory_order_relaxed);
+		for(;;)
+		{
+			auto desired = observed;
+			for(const auto byte : *message)
+			{
+				desired ^= byte;
+				desired *= 1099511628211ull;
+			}
+			if(m_transmittedAutomationDigest.compare_exchange_weak(observed, desired,
+				std::memory_order_release, std::memory_order_relaxed))
+				break;
+		}
+		m_transmittedAutomationChanges.fetch_add(1, std::memory_order_release);
+		return true;
+	}
+
+	void Controller::drainRealtimeParameterChanges(const size_t _maximumChanges,
+		const bool _realtime)
+	{
+		if(m_realtimeAutomationDrain.test_and_set(std::memory_order_acquire))
+			return;
+		struct ClearFlag
+		{
+			std::atomic_flag& flag;
+			~ClearFlag() { flag.clear(std::memory_order_release); }
+		} clear{m_realtimeAutomationDrain};
+
+		size_t processed = 0;
+		while(processed < _maximumChanges)
+		{
+			md::automation::ParameterChange change;
+			if(m_deferredRealtimeChange)
+				change = *m_deferredRealtimeChange;
+			else if(!m_realtimeAutomationChanges.tryPop(change))
+				break;
+
+			if(!m_automationReady.load(std::memory_order_acquire)
+				|| getAutomationBaseChannel() == 0x7f)
+			{
+				storePendingChange(change);
+				m_deferredRealtimeChange.reset();
+				++processed;
+				continue;
+			}
+
+			if(_realtime && !transmitRealtimeParameterChange(change))
+			{
+				m_deferredRealtimeChange = change;
+				break;
+			}
+			if(!_realtime)
+				transmitParameterChange(change);
+			m_deferredRealtimeChange.reset();
+			++processed;
+		}
+	}
+
+	void Controller::processRealtimeParameterChanges(const size_t _maximumChanges)
+	{
+		drainRealtimeParameterChanges(_maximumChanges, true);
+	}
+
 	void Controller::applyKitParameters(
 		const std::vector<md::automation::ParameterChange>& _changes)
 	{
 		for(const auto& change : _changes)
 		{
+			const auto* const slot = findAutomationSlot(
+				{change.page, change.track, change.index});
+			const auto pending = slot == nullptr ? -1
+				: slot->pendingValue.load(std::memory_order_acquire);
+			const auto value = static_cast<uint8_t>(pending >= 0 ? pending : change.value);
 			const auto& parameters = findSynthParam(change.track, change.page,
 				change.index);
 			for(auto* const parameter : parameters)
-				parameter->setValueFromSynth(change.value,
+				parameter->setValueFromSynth(value,
 					pluginLib::Parameter::Origin::PresetChange);
+			publishAutomationValue({change.page, change.track, change.index}, value);
 		}
 		getProcessor().updateHostDisplay(
 			juce::AudioProcessorListener::ChangeDetails().withProgramChanged(true));
@@ -300,35 +455,46 @@ namespace mdJucePlugin
 			|| !m_haveKit.load(std::memory_order_acquire)
 			|| !firmwareReadyForAutomation())
 			return;
+		if(getAutomationBaseChannel() == 0x7f)
+		{
+			// MIDI NONE is a valid firmware setting. The cache may become ready for
+			// reads, but pending DAW intent must remain intact until a routable Global
+			// dump is observed.
+			m_lastStatePollMs.store(milliseconds(), std::memory_order_release);
+			m_automationReady.store(true, std::memory_order_release);
+			return;
+		}
 
 		// Writes can arrive on the host audio thread while a dump is being applied.
 		// Keep draining until no such write remains, then publish the lock-free ready
 		// state. This preserves the newest host value over the older firmware snapshot.
 		for(;;)
 		{
-			std::map<Address, pluginLib::ParamValue> pending;
+			bool foundPending = false;
+			for(size_t index = 0; index < m_automationSlotCount; ++index)
 			{
-				const std::lock_guard lock(m_pendingMutex);
-				if(m_pendingChanges.empty())
-				{
-					m_lastStatePollMs.store(milliseconds(), std::memory_order_release);
-					m_automationReady.store(true, std::memory_order_release);
-					return;
-				}
-				pending.swap(m_pendingChanges);
-			}
-
-			for(const auto& [address, value] : pending)
-			{
-				const auto clamped = static_cast<uint8_t>(
-					std::clamp<pluginLib::ParamValue>(value, 0, 127));
+				auto& slot = m_automationSlots[index];
+				const auto pending = slot.pendingValue.exchange(-1,
+					std::memory_order_acq_rel);
+				if(pending < 0)
+					continue;
+				foundPending = true;
+				const auto clamped = static_cast<uint8_t>(pending);
+				const auto& address = slot.address;
 				const auto& parameters = findSynthParam(address.track, address.page,
 					address.index);
 				for(auto* const parameter : parameters)
 					parameter->setValueFromSynth(clamped,
 						pluginLib::Parameter::Origin::HostAutomation);
+				publishAutomationValue(address, clamped);
 				transmitParameterChange({address.page, address.track, address.index,
 					clamped});
+			}
+			if(!foundPending)
+			{
+				m_lastStatePollMs.store(milliseconds(), std::memory_order_release);
+				m_automationReady.store(true, std::memory_order_release);
+				return;
 			}
 		}
 	}
@@ -365,6 +531,7 @@ namespace mdJucePlugin
 				if(!m_haveGlobal.load(std::memory_order_acquire) || changed)
 				{
 					m_automationReady.store(false, std::memory_order_release);
+					m_synchronizationEpoch.fetch_add(1, std::memory_order_acq_rel);
 					m_haveGlobal.store(false, std::memory_order_release);
 					const auto now = milliseconds();
 					const auto requested =
@@ -387,6 +554,7 @@ namespace mdJucePlugin
 				if(!m_haveKit.load(std::memory_order_acquire) || changed)
 				{
 					m_automationReady.store(false, std::memory_order_release);
+					m_synchronizationEpoch.fetch_add(1, std::memory_order_acq_rel);
 					m_haveKit.store(false, std::memory_order_release);
 					const auto now = milliseconds();
 					const auto requested =
@@ -406,20 +574,31 @@ namespace mdJucePlugin
 			}
 		}
 
-		if(const auto channel = md::automation::sysex::parseBaseChannel(
+		if(const auto global = md::automation::sysex::parseGlobalDump(
 			m_model, _message))
 		{
-			m_baseChannel.store(*channel, std::memory_order_release);
+			if(global->slot != m_currentGlobal.load(std::memory_order_acquire)
+				|| m_globalDumpRequestMs.load(std::memory_order_acquire) == 0)
+				return true;
+			// A periodic refresh may update the base channel while an otherwise-ready
+			// snapshot is being serialized. Invalidate first so the snapshot either
+			// observes the old generation in full or is rejected and retried.
+			m_automationReady.store(false, std::memory_order_release);
+			m_synchronizationEpoch.fetch_add(1, std::memory_order_acq_rel);
+			m_baseChannel.store(global->baseChannel, std::memory_order_release);
 			m_haveGlobal.store(true, std::memory_order_release);
 			m_globalDumpRequestMs.store(0, std::memory_order_release);
 			completeSynchronizationIfReady();
 			return true;
 		}
 
-		if(const auto parameters = md::automation::sysex::parseKitParameters(
+		if(const auto kit = md::automation::sysex::parseKitDump(
 			m_model, _message))
 		{
-			applyKitParameters(*parameters);
+			if(kit->slot != m_currentKit.load(std::memory_order_acquire)
+				|| m_kitDumpRequestMs.load(std::memory_order_acquire) == 0)
+				return true;
+			applyKitParameters(kit->parameters);
 			m_haveKit.store(true, std::memory_order_release);
 			m_kitDumpRequestMs.store(0, std::memory_order_release);
 			completeSynchronizationIfReady();
@@ -429,24 +608,20 @@ namespace mdJucePlugin
 		// External SET STATUS messages can change the active Global, selected Kit,
 		// or Pattern without going through the controller. Refresh after the firmware
 		// consumes the same queued MIDI event.
-		if(_message.size() == 10 && _message[0] == 0xf0
-			&& _message[4] == (m_model == md::MachineModel::Monomachine ? 0x03 : 0x02)
-			&& _message[6] == 0x71)
+		if(const auto status = md::automation::sysex::parseSetStatus(m_model, _message))
 		{
-			if(_message[7] == static_cast<uint8_t>(
-				md::automation::sysex::StatusParameter::Global))
+			if(status->parameter == md::automation::sysex::StatusParameter::Global)
 			{
-				m_currentGlobal.store(_message[8], std::memory_order_release);
+				m_currentGlobal.store(status->value, std::memory_order_release);
 				m_automationReady.store(false, std::memory_order_release);
+				m_synchronizationEpoch.fetch_add(1, std::memory_order_acq_rel);
 				m_haveGlobal.store(false, std::memory_order_release);
 				m_globalDumpRequestMs.store(milliseconds(), std::memory_order_release);
 				sendSynchronizationRequest(toPluginSysex(md::automation::sysex::globalRequest(
-					m_model, _message[8])));
+					m_model, status->value)));
 			}
-			else if(_message[7] == static_cast<uint8_t>(
-				md::automation::sysex::StatusParameter::Kit)
-				|| _message[7] == static_cast<uint8_t>(
-					md::automation::sysex::StatusParameter::Pattern))
+			else if(status->parameter == md::automation::sysex::StatusParameter::Kit
+				|| status->parameter == md::automation::sysex::StatusParameter::Pattern)
 			{
 				requestKitState();
 			}
@@ -468,6 +643,8 @@ namespace mdJucePlugin
 		const auto origin = midiEventSourceToParameterOrigin(_event.source);
 		for(auto* const parameter : parameters)
 			parameter->setValueFromSynth(change->value, origin);
+		publishAutomationValue({change->page, change->track, change->index},
+			change->value);
 		return true;
 	}
 

--- a/source/elektron/md/mdJucePlugin/mdController.cpp
+++ b/source/elektron/md/mdJucePlugin/mdController.cpp
@@ -8,7 +8,6 @@
 #include <algorithm>
 #include <chrono>
 #include <set>
-#include <thread>
 
 namespace mdJucePlugin
 {
@@ -172,7 +171,7 @@ namespace mdJucePlugin
 				parameter->setValueFromSynth(_snapshot[position + 3],
 					pluginLib::Parameter::Origin::PresetChange);
 			publishAutomationIntent({address.page, address.track, address.index,
-				_snapshot[position + 3]});
+				_snapshot[position + 3]}, true);
 		}
 		m_haveGlobal.store(false, std::memory_order_release);
 		m_haveKit.store(false, std::memory_order_release);
@@ -213,12 +212,15 @@ namespace mdJucePlugin
 
 	void Controller::sendMissingSynchronizationRequests()
 	{
-		m_lastSynchronizationRequestMs.store(milliseconds(), std::memory_order_release);
 		// Do not accumulate status requests in the plug-in MIDI queue while the
 		// firmware DSPs are still booting. Once consumed, those duplicates can yield
 		// late Kit dumps that overwrite host writes after synchronization completed.
 		if(!firmwareReadyForAutomation())
 			return;
+		// A boot-time no-op is not a request and must not start the retry interval.
+		// Leaving the timestamp at zero makes the first timer tick after the DSPs
+		// become ready send immediately, including in faster-than-realtime renders.
+		m_lastSynchronizationRequestMs.store(milliseconds(), std::memory_order_release);
 		if(!m_haveGlobal.load(std::memory_order_acquire))
 			sendSynchronizationRequest(toPluginSysex(md::automation::sysex::statusRequest(m_model,
 				md::automation::sysex::StatusParameter::Global)));
@@ -233,6 +235,7 @@ namespace mdJucePlugin
 		// these exact read-only requests and keeps them factory-baseline-neutral.
 		synthLib::SMidiEvent event(synthLib::MidiEventSource::Editor);
 		event.sysex = _message;
+		m_synchronizationRequests.fetch_add(1, std::memory_order_relaxed);
 		sendMidiEvent(event);
 	}
 
@@ -282,7 +285,9 @@ namespace mdJucePlugin
 			description.index,
 			static_cast<uint8_t>(std::clamp<pluginLib::ParamValue>(_value, 0, 127))
 		};
-		publishAutomationIntent(change);
+		publishAutomationIntent(change,
+			_origin != pluginLib::Parameter::Origin::HostAutomation
+				|| !m_automationReady.load(std::memory_order_acquire));
 		// UI changes use exactly the same ordered publication path as host
 		// automation. A non-realtime caller may drain immediately, while a host
 		// callback only performs the bounded publication and returns.
@@ -315,7 +320,8 @@ namespace mdJucePlugin
 	}
 
 	void Controller::publishAutomationIntent(
-		const md::automation::ParameterChange& _change)
+		const md::automation::ParameterChange& _change,
+		const bool _supersedeEarlier)
 	{
 		const auto found = m_automationSlotIndices.find(
 			{_change.page, _change.track, _change.index});
@@ -323,13 +329,33 @@ namespace mdJucePlugin
 			return;
 
 		const auto publication = createPublication(_change.value, true);
-		m_automationSlots[found->second].publication.exchange(
-			publication, std::memory_order_acq_rel);
+		auto& slot = m_automationSlots[found->second];
+		slot.publication.exchange(publication, std::memory_order_acq_rel);
+		const auto advanceDeliveryFloor = [&slot](const uint64_t _revision)
+		{
+			// Keep the realtime producer strictly bounded: a fixed number of strong
+			// attempts can only all fail under sustained same-address contention.
+			// Failure to advance merely permits an extra stale value before the latest;
+			// it cannot lose or overwrite the authoritative publication.
+			auto floor = slot.deliveryFloorRevision.load(std::memory_order_acquire);
+			for(size_t attempt = 0; attempt < 8 && floor < _revision; ++attempt)
+			{
+				if(slot.deliveryFloorRevision.compare_exchange_strong(floor, _revision,
+					std::memory_order_release, std::memory_order_acquire))
+					return;
+			}
+		};
+		if(_supersedeEarlier)
+			advanceDeliveryFloor(publicationRevision(publication));
 		if(!m_realtimeAutomationChanges.tryPush(
 			{_change, found->second, publication}))
 		{
 			// The atomic slot remains authoritative. A bounded slot scan will deliver
-			// it even when queue capacity or producer contention drops this hint.
+			// it even when queue capacity or producer contention drops this hint. Once
+			// a hint is missing, older queued values can no longer form a complete FIFO
+			// stream, so explicitly coalesce them behind the recovered latest value.
+			advanceDeliveryFloor(publicationRevision(publication));
+			slot.scanPublication.store(publication, std::memory_order_release);
 			m_realtimeAutomationOverflows.fetch_add(1, std::memory_order_relaxed);
 		}
 	}
@@ -363,6 +389,11 @@ namespace mdJucePlugin
 		{
 			// An undelivered DAW/UI intent always survives a dump. For Kit dumps,
 			// direct changes observed after the request watermark survive as well.
+			// The watermark is valid because both the read request and later editor/host
+			// MIDI enter synthLib::Plugin's FIFO in publication order; processBlock
+			// appends its bounded realtime insertions after general ingress already
+			// queued for that block. Firmware therefore cannot observe the later change
+			// before the earlier request.
 			if(publicationIsDirty(observed)
 				|| (_kitRequestRevision != 0
 					&& publicationRevision(observed) > _kitRequestRevision))
@@ -421,7 +452,20 @@ namespace mdJucePlugin
 			return true;
 		auto& slot = m_automationSlots[_queued.slotIndex];
 		auto observed = slot.publication.load(std::memory_order_acquire);
-		if(observed != _queued.publication || !publicationIsDirty(observed))
+		const auto queuedRevision = publicationRevision(_queued.publication);
+		if(queuedRevision < slot.deliveryFloorRevision.load(std::memory_order_acquire))
+			return true;
+		if(observed != _queued.publication)
+		{
+			// A later ordinary DAW publication does not invalidate this FIFO entry.
+			// Transmit the older value now and leave the latest dirty publication for
+			// its own hint. If the latest was already delivered, its clean state proves
+			// this reordered/stale hint must instead be ignored.
+			if(!publicationIsDirty(observed)
+				|| publicationRevision(observed) <= queuedRevision)
+				return true;
+		}
+		else if(!publicationIsDirty(observed))
 			return true;
 		if(!m_automationReady.load(std::memory_order_acquire)
 			|| getAutomationBaseChannel() == 0x7f)
@@ -437,69 +481,102 @@ namespace mdJucePlugin
 			transmitParameterChange(_queued.change);
 		}
 
-		// Clear the delivery bit only if no newer publication replaced this one
-		// while MIDI was being queued. A failed CAS leaves that newer value dirty.
-		const auto delivered = observed & ~PublicationDirty;
-		slot.publication.compare_exchange_strong(observed, delivered,
-			std::memory_order_release, std::memory_order_acquire);
+		if(observed == _queued.publication)
+		{
+			// Clear the delivery bit only if no newer publication replaced this one
+			// while MIDI was being queued. A failed CAS leaves that newer value dirty.
+			const auto delivered = observed & ~PublicationDirty;
+			slot.publication.compare_exchange_strong(observed, delivered,
+				std::memory_order_release, std::memory_order_acquire);
+		}
 		return true;
 	}
 
 	void Controller::drainRealtimeParameterChanges(const size_t _maximumChanges,
 		const bool _realtime)
 	{
-		if(_realtime)
-		{
-			if(m_realtimeAutomationDrain.test_and_set(std::memory_order_acquire))
-				return;
-		}
-		else
-		{
-			while(m_realtimeAutomationDrain.test_and_set(std::memory_order_acquire))
-				std::this_thread::yield();
-		}
+		if(_maximumChanges == 0
+			|| m_realtimeAutomationDrain.test_and_set(std::memory_order_acquire))
+			return;
 		struct ClearFlag
 		{
 			std::atomic_flag& flag;
 			~ClearFlag() { flag.clear(std::memory_order_release); }
 		} clear{m_realtimeAutomationDrain};
 
+		const auto routable = m_automationReady.load(std::memory_order_acquire)
+			&& getAutomationBaseChannel() != 0x7f && !m_automationSlots.empty();
+		// A successful hint is the only way to preserve an exact DAW sequence. Do not
+		// consume it while firmware routing is unavailable; synchronization completion
+		// (or a later MIDI-channel enable) will drain the intact FIFO. Failed hints have
+		// their separate recovery marker and remain safe if this queue fills meanwhile.
+		if(!routable)
+			return;
+		// Always reserve part of a routable callback for recovery-marked slots.
+		// A full queue can contain thousands of stale hints for one address; without
+		// this reservation, an unhinted latest value could wait for all of them.
+		size_t reservedScan = routable ? std::min(m_automationSlots.size(),
+			std::max<size_t>(1, _maximumChanges / 4)) : size_t{0};
+		if(routable && _maximumChanges == 1)
+		{
+			// A one-event caller cannot serve the FIFO and recovery scan in one pass.
+			// Alternate them so neither source can starve; larger budgets serve both.
+			reservedScan = m_minimumBudgetRecoveryTurn ? 1 : 0;
+			m_minimumBudgetRecoveryTurn = !m_minimumBudgetRecoveryTurn;
+		}
+		const auto queueLimit = _maximumChanges - reservedScan;
 		size_t processed = 0;
-		while(processed < _maximumChanges)
+		bool queueEmpty = false;
+		while(processed < queueLimit)
 		{
 			QueuedAutomationChange queued;
 			if(!m_realtimeAutomationChanges.tryPop(queued))
+			{
+				queueEmpty = true;
 				break;
+			}
 			if(!deliverAutomationPublication(queued, _realtime))
 				return;
 			++processed;
 		}
 
-		if(processed >= _maximumChanges
-			|| !m_automationReady.load(std::memory_order_acquire)
-			|| getAutomationBaseChannel() == 0x7f || m_automationSlots.empty())
-			return;
-
 		// Queue overflow and producer contention only drop hints. Scan a bounded
-		// number of authoritative slots so every latest dirty publication remains
-		// deliverable without making the producer retry or wait.
+		// rotating slice for explicit recovery markers, even while hints remain. Do
+		// not deliver ordinary dirty slots from the scan: jumping their healthy FIFO
+		// hints would incorrectly coalesce explicit host writes. If the queue
+		// empties early, spend the unused budget on the scan. Thus a dirty slot is
+		// reconsidered within ceil(slot-count / reserved-scan) callbacks regardless
+		// of stale queue depth, while total callback work never exceeds the caller's
+		// explicit maximum.
+		const auto scanLimit = std::min(m_automationSlots.size(),
+			queueEmpty ? _maximumChanges - processed : reservedScan);
 		size_t inspected = 0;
-		while(processed < _maximumChanges && inspected < m_automationSlots.size())
+		while(inspected < scanLimit)
 		{
 			if(m_dirtyScanPosition >= m_automationSlots.size())
 				m_dirtyScanPosition = 0;
 			const auto slotIndex = m_dirtyScanPosition++;
 			auto& slot = m_automationSlots[slotIndex];
-			const auto publication = slot.publication.load(std::memory_order_acquire);
-			if(publicationIsDirty(publication))
+			auto recovery = slot.scanPublication.load(std::memory_order_acquire);
+			if(recovery != 0)
 			{
-				const auto& address = slot.address;
-				if(!deliverAutomationPublication({
-					{address.page, address.track, address.index,
-						publicationValue(publication)}, slotIndex, publication}, _realtime))
-					return;
+				const auto publication = slot.publication.load(std::memory_order_acquire);
+				if(publicationIsDirty(publication))
+				{
+					const auto& address = slot.address;
+					if(!deliverAutomationPublication({
+						{address.page, address.track, address.index,
+							publicationValue(publication)}, slotIndex, publication}, _realtime))
+						return;
+				}
+				// Retain the marker until the FIFO has actually been observed empty, so a
+				// later same-slot host write cannot disappear behind the known stale backlog.
+				// CAS still prevents an older scan from clearing a replacement marker.
+				if(queueEmpty && !publicationIsDirty(
+					slot.publication.load(std::memory_order_acquire)))
+					slot.scanPublication.compare_exchange_strong(recovery, 0,
+						std::memory_order_release, std::memory_order_acquire);
 			}
-			++processed;
 			++inspected;
 		}
 	}
@@ -565,7 +642,15 @@ namespace mdJucePlugin
 				if(const auto* const device = dynamic_cast<md::Device*>(_device))
 				{
 					const auto& hardware = device->getHardware();
+					const auto panel = hardware.getFrontPanelSnapshot();
 					ready = hardware.isAudioReady()
+						// The DSPs become runnable before the main firmware has finished
+						// initializing its peripherals. Use the same observable
+						// front-panel boot boundary as the ROM integration tools rather
+						// than assuming DSP audio readiness also means MIDI readiness.
+						&& (panel.countLitPixels() > 2000
+							|| (panel.getTileWriteCount() >= 64
+								&& panel.countLitPixels() >= 100))
 						&& !hardware.isProjectStateRestorePending();
 				}
 			});

--- a/source/elektron/md/mdJucePlugin/mdController.cpp
+++ b/source/elektron/md/mdJucePlugin/mdController.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <chrono>
 #include <set>
+#include <thread>
 
 namespace mdJucePlugin
 {
@@ -44,13 +45,13 @@ namespace mdJucePlugin
 		for(const auto& [address, parameters] : getExposedParameters())
 		{
 			(void)parameters;
-			assert(m_automationSlotCount < m_automationSlots.size());
 			const Address automationAddress{address.page, address.partNum,
 				address.paramNum};
-			auto& slot = m_automationSlots[m_automationSlotCount];
+			const auto slotIndex = m_automationSlots.size();
+			m_automationSlots.emplace_back();
+			auto& slot = m_automationSlots.back();
 			slot.address = automationAddress;
-			m_automationSlotIndices.emplace(automationAddress,
-				m_automationSlotCount++);
+			m_automationSlotIndices.emplace(automationAddress, slotIndex);
 		}
 
 		// Give mute (which is not part of a Kit dump) a defined initial cache value.
@@ -60,8 +61,13 @@ namespace mdJucePlugin
 			for(auto* const parameter : parameters)
 				parameter->setValueFromSynth(parameter->getDefault(),
 					pluginLib::Parameter::Origin::PresetChange);
-			publishAutomationValue({address.page, address.partNum, address.paramNum},
-				static_cast<uint8_t>(std::clamp(parameters.front()->getDefault(), 0, 127)));
+			if(auto* const slot = findAutomationSlot(
+				{address.page, address.partNum, address.paramNum}))
+			{
+				slot->publication.store(createPublication(static_cast<uint8_t>(
+					std::clamp(parameters.front()->getDefault(), 0, 127)), false),
+					std::memory_order_release);
+			}
 		}
 
 		requestAutomationState();
@@ -118,7 +124,8 @@ namespace mdJucePlugin
 			result.push_back(address.page);
 			result.push_back(address.partNum);
 			result.push_back(address.paramNum);
-			result.push_back(slot->snapshotValue.load(std::memory_order_acquire));
+			result.push_back(publicationValue(
+				slot->publication.load(std::memory_order_acquire)));
 		}
 		if(!m_automationReady.load(std::memory_order_acquire)
 			|| epoch != m_synchronizationEpoch.load(std::memory_order_acquire))
@@ -153,7 +160,6 @@ namespace mdJucePlugin
 		m_synchronizationEpoch.fetch_add(1, std::memory_order_acq_rel);
 		m_baseChannel.store(_snapshot[2], std::memory_order_release);
 		m_currentKit.store(_snapshot[3], std::memory_order_release);
-		std::map<Address, pluginLib::ParamValue> restored;
 		for(size_t position = 6; position < _snapshot.size(); position += 4)
 		{
 			const Address address{_snapshot[position], _snapshot[position + 1],
@@ -165,12 +171,9 @@ namespace mdJucePlugin
 			for(auto* const parameter : parameters)
 				parameter->setValueFromSynth(_snapshot[position + 3],
 					pluginLib::Parameter::Origin::PresetChange);
-			publishAutomationValue(address, _snapshot[position + 3]);
-			restored[address] = _snapshot[position + 3];
+			publishAutomationIntent({address.page, address.track, address.index,
+				_snapshot[position + 3]});
 		}
-		for(const auto& [address, value] : restored)
-			storePendingChange({address.page, address.track, address.index,
-				static_cast<uint8_t>(std::clamp<pluginLib::ParamValue>(value, 0, 127))});
 		m_haveGlobal.store(false, std::memory_order_release);
 		m_haveKit.store(false, std::memory_order_release);
 		getProcessor().updateHostDisplay(
@@ -188,6 +191,7 @@ namespace mdJucePlugin
 		m_currentKit.store(0xff, std::memory_order_release);
 		m_globalDumpRequestMs.store(0, std::memory_order_release);
 		m_kitDumpRequestMs.store(0, std::memory_order_release);
+		m_kitDumpRequestRevision.store(0, std::memory_order_release);
 		sendMissingSynchronizationRequests();
 	}
 
@@ -197,6 +201,7 @@ namespace mdJucePlugin
 		m_synchronizationEpoch.fetch_add(1, std::memory_order_acq_rel);
 		m_haveKit.store(false, std::memory_order_release);
 		m_kitDumpRequestMs.store(0, std::memory_order_release);
+		m_kitDumpRequestRevision.store(0, std::memory_order_release);
 		sendMissingSynchronizationRequests();
 	}
 
@@ -277,25 +282,56 @@ namespace mdJucePlugin
 			description.index,
 			static_cast<uint8_t>(std::clamp<pluginLib::ParamValue>(_value, 0, 127))
 		};
-		publishAutomationValue({change.page, change.track, change.index}, change.value);
-		if(_origin == pluginLib::Parameter::Origin::HostAutomation)
-		{
-			if(!m_realtimeAutomationChanges.tryPush(change))
-			{
-				// A hostile producer can outrun any bounded queue. Preserve the latest
-				// value for this address and expose the exceptional coalescing event.
-				storePendingChange(change);
-				m_realtimeAutomationOverflows.fetch_add(1, std::memory_order_relaxed);
-			}
+		publishAutomationIntent(change);
+		// UI changes use exactly the same ordered publication path as host
+		// automation. A non-realtime caller may drain immediately, while a host
+		// callback only performs the bounded publication and returns.
+		if(_origin != pluginLib::Parameter::Origin::HostAutomation)
+			drainRealtimeParameterChanges(RealtimeAutomationCapacity, false);
+	}
+
+	uint8_t Controller::publicationValue(const uint64_t _publication)
+	{
+		return static_cast<uint8_t>(_publication & PublicationValueMask);
+	}
+
+	uint64_t Controller::publicationRevision(const uint64_t _publication)
+	{
+		return (_publication & PublicationRevisionMask) >> 8;
+	}
+
+	bool Controller::publicationIsDirty(const uint64_t _publication)
+	{
+		return (_publication & PublicationDirty) != 0;
+	}
+
+	uint64_t Controller::createPublication(const uint8_t _value, const bool _dirty)
+	{
+		const auto revision = m_nextAutomationRevision.fetch_add(
+			1, std::memory_order_relaxed);
+		return (_dirty ? PublicationDirty : 0)
+			| ((revision << 8) & PublicationRevisionMask)
+			| (_value & PublicationValueMask);
+	}
+
+	void Controller::publishAutomationIntent(
+		const md::automation::ParameterChange& _change)
+	{
+		const auto found = m_automationSlotIndices.find(
+			{_change.page, _change.track, _change.index});
+		if(found == m_automationSlotIndices.end())
 			return;
-		}
-		if(!m_automationReady.load(std::memory_order_acquire)
-			|| getAutomationBaseChannel() == 0x7f)
+
+		const auto publication = createPublication(_change.value, true);
+		m_automationSlots[found->second].publication.exchange(
+			publication, std::memory_order_acq_rel);
+		if(!m_realtimeAutomationChanges.tryPush(
+			{_change, found->second, publication}))
 		{
-			storePendingChange(change);
-			return;
+			// The atomic slot remains authoritative. A bounded slot scan will deliver
+			// it even when queue capacity or producer contention drops this hint.
+			m_realtimeAutomationOverflows.fetch_add(1, std::memory_order_relaxed);
 		}
-		transmitParameterChange(change);
 	}
 
 	Controller::AutomationSlot* Controller::findAutomationSlot(
@@ -314,19 +350,27 @@ namespace mdJucePlugin
 			? nullptr : &m_automationSlots[found->second];
 	}
 
-	void Controller::publishAutomationValue(const Address& _address,
-		const uint8_t _value)
+	uint8_t Controller::publishFirmwareValue(const Address& _address,
+		const uint8_t _value, const uint64_t _kitRequestRevision)
 	{
-		if(auto* const slot = findAutomationSlot(_address))
-			slot->snapshotValue.store(_value, std::memory_order_release);
-	}
+		auto* const slot = findAutomationSlot(_address);
+		if(slot == nullptr)
+			return _value;
 
-	void Controller::storePendingChange(
-		const md::automation::ParameterChange& _change)
-	{
-		if(auto* const slot = findAutomationSlot(
-			{_change.page, _change.track, _change.index}))
-			slot->pendingValue.store(_change.value, std::memory_order_release);
+		const auto desired = createPublication(_value, false);
+		auto observed = slot->publication.load(std::memory_order_acquire);
+		for(;;)
+		{
+			// An undelivered DAW/UI intent always survives a dump. For Kit dumps,
+			// direct changes observed after the request watermark survive as well.
+			if(publicationIsDirty(observed)
+				|| (_kitRequestRevision != 0
+					&& publicationRevision(observed) > _kitRequestRevision))
+				return publicationValue(observed);
+			if(slot->publication.compare_exchange_weak(observed, desired,
+				std::memory_order_release, std::memory_order_acquire))
+				return _value;
+		}
 	}
 
 	void Controller::transmitParameterChange(
@@ -335,19 +379,13 @@ namespace mdJucePlugin
 		if(const auto message = md::automation::encodeParameterChange(
 			m_model, _change, getAutomationBaseChannel()))
 		{
-			auto observed = m_transmittedAutomationDigest.load(std::memory_order_relaxed);
-			for(;;)
+			auto digest = m_transmittedAutomationDigest.load(std::memory_order_relaxed);
+			for(const auto byte : *message)
 			{
-				auto desired = observed;
-				for(const auto byte : *message)
-				{
-					desired ^= byte;
-					desired *= 1099511628211ull;
-				}
-				if(m_transmittedAutomationDigest.compare_exchange_weak(observed,
-					desired, std::memory_order_release, std::memory_order_relaxed))
-					break;
+				digest ^= byte;
+				digest *= 1099511628211ull;
 			}
+			m_transmittedAutomationDigest.store(digest, std::memory_order_release);
 			m_transmittedAutomationChanges.fetch_add(1, std::memory_order_release);
 			sendMidiEvent((*message)[0], (*message)[1], (*message)[2]);
 		}
@@ -365,28 +403,61 @@ namespace mdJucePlugin
 		if(!getProcessor().tryAddRealtimeMidiEvent(event))
 			return false;
 
-		auto observed = m_transmittedAutomationDigest.load(std::memory_order_relaxed);
-		for(;;)
+		auto digest = m_transmittedAutomationDigest.load(std::memory_order_relaxed);
+		for(const auto byte : *message)
 		{
-			auto desired = observed;
-			for(const auto byte : *message)
-			{
-				desired ^= byte;
-				desired *= 1099511628211ull;
-			}
-			if(m_transmittedAutomationDigest.compare_exchange_weak(observed, desired,
-				std::memory_order_release, std::memory_order_relaxed))
-				break;
+			digest ^= byte;
+			digest *= 1099511628211ull;
 		}
+		m_transmittedAutomationDigest.store(digest, std::memory_order_release);
 		m_transmittedAutomationChanges.fetch_add(1, std::memory_order_release);
+		return true;
+	}
+
+	bool Controller::deliverAutomationPublication(
+		const QueuedAutomationChange& _queued, const bool _realtime)
+	{
+		if(_queued.slotIndex >= m_automationSlots.size())
+			return true;
+		auto& slot = m_automationSlots[_queued.slotIndex];
+		auto observed = slot.publication.load(std::memory_order_acquire);
+		if(observed != _queued.publication || !publicationIsDirty(observed))
+			return true;
+		if(!m_automationReady.load(std::memory_order_acquire)
+			|| getAutomationBaseChannel() == 0x7f)
+			return true;
+
+		if(_realtime)
+		{
+			if(!transmitRealtimeParameterChange(_queued.change))
+				return false;
+		}
+		else
+		{
+			transmitParameterChange(_queued.change);
+		}
+
+		// Clear the delivery bit only if no newer publication replaced this one
+		// while MIDI was being queued. A failed CAS leaves that newer value dirty.
+		const auto delivered = observed & ~PublicationDirty;
+		slot.publication.compare_exchange_strong(observed, delivered,
+			std::memory_order_release, std::memory_order_acquire);
 		return true;
 	}
 
 	void Controller::drainRealtimeParameterChanges(const size_t _maximumChanges,
 		const bool _realtime)
 	{
-		if(m_realtimeAutomationDrain.test_and_set(std::memory_order_acquire))
-			return;
+		if(_realtime)
+		{
+			if(m_realtimeAutomationDrain.test_and_set(std::memory_order_acquire))
+				return;
+		}
+		else
+		{
+			while(m_realtimeAutomationDrain.test_and_set(std::memory_order_acquire))
+				std::this_thread::yield();
+		}
 		struct ClearFlag
 		{
 			std::atomic_flag& flag;
@@ -396,30 +467,40 @@ namespace mdJucePlugin
 		size_t processed = 0;
 		while(processed < _maximumChanges)
 		{
-			md::automation::ParameterChange change;
-			if(m_deferredRealtimeChange)
-				change = *m_deferredRealtimeChange;
-			else if(!m_realtimeAutomationChanges.tryPop(change))
+			QueuedAutomationChange queued;
+			if(!m_realtimeAutomationChanges.tryPop(queued))
 				break;
-
-			if(!m_automationReady.load(std::memory_order_acquire)
-				|| getAutomationBaseChannel() == 0x7f)
-			{
-				storePendingChange(change);
-				m_deferredRealtimeChange.reset();
-				++processed;
-				continue;
-			}
-
-			if(_realtime && !transmitRealtimeParameterChange(change))
-			{
-				m_deferredRealtimeChange = change;
-				break;
-			}
-			if(!_realtime)
-				transmitParameterChange(change);
-			m_deferredRealtimeChange.reset();
+			if(!deliverAutomationPublication(queued, _realtime))
+				return;
 			++processed;
+		}
+
+		if(processed >= _maximumChanges
+			|| !m_automationReady.load(std::memory_order_acquire)
+			|| getAutomationBaseChannel() == 0x7f || m_automationSlots.empty())
+			return;
+
+		// Queue overflow and producer contention only drop hints. Scan a bounded
+		// number of authoritative slots so every latest dirty publication remains
+		// deliverable without making the producer retry or wait.
+		size_t inspected = 0;
+		while(processed < _maximumChanges && inspected < m_automationSlots.size())
+		{
+			if(m_dirtyScanPosition >= m_automationSlots.size())
+				m_dirtyScanPosition = 0;
+			const auto slotIndex = m_dirtyScanPosition++;
+			auto& slot = m_automationSlots[slotIndex];
+			const auto publication = slot.publication.load(std::memory_order_acquire);
+			if(publicationIsDirty(publication))
+			{
+				const auto& address = slot.address;
+				if(!deliverAutomationPublication({
+					{address.page, address.track, address.index,
+						publicationValue(publication)}, slotIndex, publication}, _realtime))
+					return;
+			}
+			++processed;
+			++inspected;
 		}
 	}
 
@@ -431,19 +512,18 @@ namespace mdJucePlugin
 	void Controller::applyKitParameters(
 		const std::vector<md::automation::ParameterChange>& _changes)
 	{
+		const auto requestRevision = m_kitDumpRequestRevision.load(
+			std::memory_order_acquire);
 		for(const auto& change : _changes)
 		{
-			const auto* const slot = findAutomationSlot(
-				{change.page, change.track, change.index});
-			const auto pending = slot == nullptr ? -1
-				: slot->pendingValue.load(std::memory_order_acquire);
-			const auto value = static_cast<uint8_t>(pending >= 0 ? pending : change.value);
+			const auto value = publishFirmwareValue(
+				{change.page, change.track, change.index}, change.value,
+				requestRevision);
 			const auto& parameters = findSynthParam(change.track, change.page,
 				change.index);
 			for(auto* const parameter : parameters)
 				parameter->setValueFromSynth(value,
 					pluginLib::Parameter::Origin::PresetChange);
-			publishAutomationValue({change.page, change.track, change.index}, value);
 		}
 		getProcessor().updateHostDisplay(
 			juce::AudioProcessorListener::ChangeDetails().withProgramChanged(true));
@@ -451,9 +531,12 @@ namespace mdJucePlugin
 
 	void Controller::completeSynchronizationIfReady()
 	{
+		// Requests are withheld while the DSPs boot or project restore is pending.
+		// Once both strictly correlated replies arrive, those replies themselves are
+		// the readiness proof; consulting asynchronous hardware state again here can
+		// only delay publication of an otherwise coherent snapshot.
 		if(!m_haveGlobal.load(std::memory_order_acquire)
-			|| !m_haveKit.load(std::memory_order_acquire)
-			|| !firmwareReadyForAutomation())
+			|| !m_haveKit.load(std::memory_order_acquire))
 			return;
 		if(getAutomationBaseChannel() == 0x7f)
 		{
@@ -465,38 +548,12 @@ namespace mdJucePlugin
 			return;
 		}
 
-		// Writes can arrive on the host audio thread while a dump is being applied.
-		// Keep draining until no such write remains, then publish the lock-free ready
-		// state. This preserves the newest host value over the older firmware snapshot.
-		for(;;)
-		{
-			bool foundPending = false;
-			for(size_t index = 0; index < m_automationSlotCount; ++index)
-			{
-				auto& slot = m_automationSlots[index];
-				const auto pending = slot.pendingValue.exchange(-1,
-					std::memory_order_acq_rel);
-				if(pending < 0)
-					continue;
-				foundPending = true;
-				const auto clamped = static_cast<uint8_t>(pending);
-				const auto& address = slot.address;
-				const auto& parameters = findSynthParam(address.track, address.page,
-					address.index);
-				for(auto* const parameter : parameters)
-					parameter->setValueFromSynth(clamped,
-						pluginLib::Parameter::Origin::HostAutomation);
-				publishAutomationValue(address, clamped);
-				transmitParameterChange({address.page, address.track, address.index,
-					clamped});
-			}
-			if(!foundPending)
-			{
-				m_lastStatePollMs.store(milliseconds(), std::memory_order_release);
-				m_automationReady.store(true, std::memory_order_release);
-				return;
-			}
-		}
+		m_lastStatePollMs.store(milliseconds(), std::memory_order_release);
+		m_automationReady.store(true, std::memory_order_release);
+		// Once ready is visible, one serialized non-realtime drain delivers both
+		// queued hints and every dirty slot missed because the queue was full.
+		drainRealtimeParameterChanges(
+			RealtimeAutomationCapacity + m_automationSlots.size(), false);
 	}
 
 	bool Controller::firmwareReadyForAutomation() const
@@ -562,6 +619,13 @@ namespace mdJucePlugin
 					if(changed || requested == 0
 						|| now - requested >= g_dumpRequestRetryMs)
 					{
+						if(changed || requested == 0)
+						{
+							const auto next = m_nextAutomationRevision.load(
+								std::memory_order_acquire);
+							m_kitDumpRequestRevision.store(next > 0 ? next - 1 : 0,
+								std::memory_order_release);
+						}
 						m_kitDumpRequestMs.store(now, std::memory_order_release);
 						sendSynchronizationRequest(toPluginSysex(md::automation::sysex::kitRequest(
 							m_model, status->value)));
@@ -601,6 +665,7 @@ namespace mdJucePlugin
 			applyKitParameters(kit->parameters);
 			m_haveKit.store(true, std::memory_order_release);
 			m_kitDumpRequestMs.store(0, std::memory_order_release);
+			m_kitDumpRequestRevision.store(0, std::memory_order_release);
 			completeSynchronizationIfReady();
 			return true;
 		}
@@ -640,11 +705,11 @@ namespace mdJucePlugin
 			change->index);
 		if(parameters.empty())
 			return false;
+		const auto value = publishFirmwareValue(
+			{change->page, change->track, change->index}, change->value);
 		const auto origin = midiEventSourceToParameterOrigin(_event.source);
 		for(auto* const parameter : parameters)
-			parameter->setValueFromSynth(change->value, origin);
-		publishAutomationValue({change->page, change->track, change->index},
-			change->value);
+			parameter->setValueFromSynth(value, origin);
 		return true;
 	}
 

--- a/source/elektron/md/mdJucePlugin/mdController.h
+++ b/source/elektron/md/mdJucePlugin/mdController.h
@@ -60,6 +60,10 @@ namespace mdJucePlugin
 		{
 			return m_realtimeAutomationOverflows.load(std::memory_order_acquire);
 		}
+		uint64_t getSynchronizationRequestCount() const
+		{
+			return m_synchronizationRequests.load(std::memory_order_acquire);
+		}
 		void requestAutomationState();
 		std::vector<uint8_t> createAutomationSnapshot() const;
 		bool restoreAutomationSnapshot(const std::vector<uint8_t>& _snapshot);
@@ -87,6 +91,13 @@ namespace mdJucePlugin
 			// bit means that the value still needs to reach the firmware. Queue entries
 			// are only delivery hints and may safely be stale or absent.
 			std::atomic<uint64_t> publication{0};
+			// Publications older than this revision are intentionally superseded. UI
+			// edits and overflow advance the floor; ordinary DAW writes do not, so
+			// every queued host value retains its FIFO delivery semantics.
+			std::atomic<uint64_t> deliveryFloorRevision{0};
+			// Exact publication whose queue hint was dropped. A versioned marker avoids
+			// clearing a newer producer's recovery obligation after a concurrent scan.
+			std::atomic<uint64_t> scanPublication{0};
 		};
 
 		struct QueuedAutomationChange
@@ -115,7 +126,8 @@ namespace mdJucePlugin
 		bool deliverAutomationPublication(const QueuedAutomationChange& _queued,
 			bool _realtime);
 		uint64_t createPublication(uint8_t _value, bool _dirty);
-		void publishAutomationIntent(const md::automation::ParameterChange& _change);
+		void publishAutomationIntent(const md::automation::ParameterChange& _change,
+			bool _supersedeEarlier = false);
 		uint8_t publishFirmwareValue(const Address& _address, uint8_t _value,
 			uint64_t _kitRequestRevision = 0);
 		static uint8_t publicationValue(uint64_t _publication);
@@ -152,8 +164,10 @@ namespace mdJucePlugin
 		RealtimeQueue<QueuedAutomationChange,
 			RealtimeAutomationCapacity> m_realtimeAutomationChanges;
 		size_t m_dirtyScanPosition = 0;
+		bool m_minimumBudgetRecoveryTurn = true;
 		std::atomic_flag m_realtimeAutomationDrain = ATOMIC_FLAG_INIT;
 		std::atomic<uint64_t> m_realtimeAutomationOverflows{0};
+		mutable std::atomic<uint64_t> m_synchronizationRequests{0};
 		JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Controller)
 	};
 }

--- a/source/elektron/md/mdJucePlugin/mdController.h
+++ b/source/elektron/md/mdJucePlugin/mdController.h
@@ -3,10 +3,12 @@
 #include "jucePluginLib/controller.h"
 #include "mdLib/mdautomation.h"
 #include "mdLib/mdtypes.h"
+#include "mdRealtimeQueue.h"
 
+#include <array>
 #include <atomic>
 #include <map>
-#include <mutex>
+#include <optional>
 
 namespace mdJucePlugin
 {
@@ -26,6 +28,7 @@ namespace mdJucePlugin
 			synthLib::MidiEventSource) override;
 		bool parseControllerMessage(const synthLib::SMidiEvent& _event) override;
 		bool parseMidiMessage(const synthLib::SMidiEvent& _event) override;
+		void processRealtimeParameterChanges(size_t _maximumChanges) override;
 
 		void sendParameterChange(const pluginLib::Parameter& _parameter,
 			pluginLib::ParamValue _value, pluginLib::Parameter::Origin _origin) override;
@@ -54,6 +57,10 @@ namespace mdJucePlugin
 		{
 			return m_transmittedAutomationDigest.load(std::memory_order_acquire);
 		}
+		uint64_t getRealtimeAutomationOverflowCount() const
+		{
+			return m_realtimeAutomationOverflows.load(std::memory_order_acquire);
+		}
 		void requestAutomationState();
 		std::vector<uint8_t> createAutomationSnapshot() const;
 		bool restoreAutomationSnapshot(const std::vector<uint8_t>& _snapshot);
@@ -61,9 +68,9 @@ namespace mdJucePlugin
 	private:
 		struct Address
 		{
-			uint8_t page;
-			uint8_t track;
-			uint8_t index;
+			uint8_t page = 0;
+			uint8_t track = 0;
+			uint8_t index = 0;
 
 			bool operator<(const Address& _other) const
 			{
@@ -73,11 +80,31 @@ namespace mdJucePlugin
 			}
 		};
 
+		struct AutomationSlot
+		{
+			Address address;
+			std::atomic<int> pendingValue{-1};
+			std::atomic<uint8_t> snapshotValue{0};
+		};
+
+		static constexpr size_t MaxAutomationParameters = 416;
+		static constexpr size_t RealtimeAutomationCapacity = 4096;
+		static_assert(std::atomic<int>::is_always_lock_free
+			&& std::atomic<uint8_t>::is_always_lock_free,
+			"automation publication requires lock-free value atomics");
+
 		pluginLib::Parameter* createParameter(pluginLib::Controller& _controller,
 			const pluginLib::Description& _description, uint8_t _part, int _uid,
 			const pluginLib::Parameter::PartFormatter& _formatter) override;
 		void requestKitState();
 		void transmitParameterChange(const md::automation::ParameterChange& _change);
+		bool transmitRealtimeParameterChange(
+			const md::automation::ParameterChange& _change);
+		void drainRealtimeParameterChanges(size_t _maximumChanges, bool _realtime);
+		void storePendingChange(const md::automation::ParameterChange& _change);
+		AutomationSlot* findAutomationSlot(const Address& _address);
+		const AutomationSlot* findAutomationSlot(const Address& _address) const;
+		void publishAutomationValue(const Address& _address, uint8_t _value);
 		void completeSynchronizationIfReady();
 		bool firmwareReadyForAutomation() const;
 		void applyKitParameters(const std::vector<md::automation::ParameterChange>& _changes);
@@ -95,12 +122,19 @@ namespace mdJucePlugin
 		std::atomic<uint64_t> m_lastStatePollMs{0};
 		std::atomic<uint64_t> m_globalDumpRequestMs{0};
 		std::atomic<uint64_t> m_kitDumpRequestMs{0};
+		std::atomic<uint64_t> m_synchronizationEpoch{0};
 		std::atomic<uint64_t> m_transmittedAutomationChanges{0};
 		std::atomic<uint64_t> m_transmittedAutomationDigest{14695981039346656037ull};
 		std::atomic<uint8_t> m_currentGlobal{0xff};
 		std::atomic<uint8_t> m_currentKit{0xff};
-		std::mutex m_pendingMutex;
-		std::map<Address, pluginLib::ParamValue> m_pendingChanges;
+		std::array<AutomationSlot, MaxAutomationParameters> m_automationSlots{};
+		size_t m_automationSlotCount = 0;
+		std::map<Address, size_t> m_automationSlotIndices;
+		RealtimeQueue<md::automation::ParameterChange,
+			RealtimeAutomationCapacity> m_realtimeAutomationChanges;
+		std::optional<md::automation::ParameterChange> m_deferredRealtimeChange;
+		std::atomic_flag m_realtimeAutomationDrain = ATOMIC_FLAG_INIT;
+		std::atomic<uint64_t> m_realtimeAutomationOverflows{0};
 		JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Controller)
 	};
 }

--- a/source/elektron/md/mdJucePlugin/mdController.h
+++ b/source/elektron/md/mdJucePlugin/mdController.h
@@ -5,10 +5,9 @@
 #include "mdLib/mdtypes.h"
 #include "mdRealtimeQueue.h"
 
-#include <array>
 #include <atomic>
+#include <deque>
 #include <map>
-#include <optional>
 
 namespace mdJucePlugin
 {
@@ -83,15 +82,27 @@ namespace mdJucePlugin
 		struct AutomationSlot
 		{
 			Address address;
-			std::atomic<int> pendingValue{-1};
-			std::atomic<uint8_t> snapshotValue{0};
+			// One atomic publication is the source of truth for this address. The low
+			// byte is the value, the middle bits identify the publication, and the top
+			// bit means that the value still needs to reach the firmware. Queue entries
+			// are only delivery hints and may safely be stale or absent.
+			std::atomic<uint64_t> publication{0};
 		};
 
-		static constexpr size_t MaxAutomationParameters = 416;
+		struct QueuedAutomationChange
+		{
+			md::automation::ParameterChange change;
+			size_t slotIndex = 0;
+			uint64_t publication = 0;
+		};
+
 		static constexpr size_t RealtimeAutomationCapacity = 4096;
-		static_assert(std::atomic<int>::is_always_lock_free
-			&& std::atomic<uint8_t>::is_always_lock_free,
-			"automation publication requires lock-free value atomics");
+		static constexpr uint64_t PublicationDirty = uint64_t{1} << 63;
+		static constexpr uint64_t PublicationValueMask = 0x7f;
+		static constexpr uint64_t PublicationRevisionMask =
+			~(PublicationDirty | uint64_t{0xff});
+		static_assert(std::atomic<uint64_t>::is_always_lock_free,
+			"realtime automation requires lock-free 64-bit atomics");
 
 		pluginLib::Parameter* createParameter(pluginLib::Controller& _controller,
 			const pluginLib::Description& _description, uint8_t _part, int _uid,
@@ -101,10 +112,17 @@ namespace mdJucePlugin
 		bool transmitRealtimeParameterChange(
 			const md::automation::ParameterChange& _change);
 		void drainRealtimeParameterChanges(size_t _maximumChanges, bool _realtime);
-		void storePendingChange(const md::automation::ParameterChange& _change);
+		bool deliverAutomationPublication(const QueuedAutomationChange& _queued,
+			bool _realtime);
+		uint64_t createPublication(uint8_t _value, bool _dirty);
+		void publishAutomationIntent(const md::automation::ParameterChange& _change);
+		uint8_t publishFirmwareValue(const Address& _address, uint8_t _value,
+			uint64_t _kitRequestRevision = 0);
+		static uint8_t publicationValue(uint64_t _publication);
+		static uint64_t publicationRevision(uint64_t _publication);
+		static bool publicationIsDirty(uint64_t _publication);
 		AutomationSlot* findAutomationSlot(const Address& _address);
 		const AutomationSlot* findAutomationSlot(const Address& _address) const;
-		void publishAutomationValue(const Address& _address, uint8_t _value);
 		void completeSynchronizationIfReady();
 		bool firmwareReadyForAutomation() const;
 		void applyKitParameters(const std::vector<md::automation::ParameterChange>& _changes);
@@ -122,17 +140,18 @@ namespace mdJucePlugin
 		std::atomic<uint64_t> m_lastStatePollMs{0};
 		std::atomic<uint64_t> m_globalDumpRequestMs{0};
 		std::atomic<uint64_t> m_kitDumpRequestMs{0};
+		std::atomic<uint64_t> m_kitDumpRequestRevision{0};
 		std::atomic<uint64_t> m_synchronizationEpoch{0};
+		std::atomic<uint64_t> m_nextAutomationRevision{1};
 		std::atomic<uint64_t> m_transmittedAutomationChanges{0};
 		std::atomic<uint64_t> m_transmittedAutomationDigest{14695981039346656037ull};
 		std::atomic<uint8_t> m_currentGlobal{0xff};
 		std::atomic<uint8_t> m_currentKit{0xff};
-		std::array<AutomationSlot, MaxAutomationParameters> m_automationSlots{};
-		size_t m_automationSlotCount = 0;
+		std::deque<AutomationSlot> m_automationSlots;
 		std::map<Address, size_t> m_automationSlotIndices;
-		RealtimeQueue<md::automation::ParameterChange,
+		RealtimeQueue<QueuedAutomationChange,
 			RealtimeAutomationCapacity> m_realtimeAutomationChanges;
-		std::optional<md::automation::ParameterChange> m_deferredRealtimeChange;
+		size_t m_dirtyScanPosition = 0;
 		std::atomic_flag m_realtimeAutomationDrain = ATOMIC_FLAG_INIT;
 		std::atomic<uint64_t> m_realtimeAutomationOverflows{0};
 		JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Controller)

--- a/source/elektron/md/mdJucePlugin/mdRealtimeQueue.h
+++ b/source/elektron/md/mdJucePlugin/mdRealtimeQueue.h
@@ -9,8 +9,9 @@
 namespace mdJucePlugin
 {
 	// Bounded multi-producer/single-or-multi-consumer queue based on per-cell
-	// sequence numbers. Producers and consumers never wait, allocate, or take a
-	// lock; callers decide whether a full queue should be retried or reported.
+	// sequence numbers. Producers and consumers perform a fixed number of atomic
+	// attempts and never wait, allocate, or take a lock; callers treat capacity or
+	// contention failure as a dropped hint and retain their authoritative state.
 	template<typename T, size_t Capacity>
 	class RealtimeQueue
 	{
@@ -28,6 +29,8 @@ namespace mdJucePlugin
 		};
 
 	public:
+		static constexpr size_t MaximumAttempts = 8;
+
 		RealtimeQueue()
 		{
 			for(size_t index = 0; index < Capacity; ++index)
@@ -37,7 +40,7 @@ namespace mdJucePlugin
 		bool tryPush(const T& _value)
 		{
 			auto position = m_enqueuePosition.load(std::memory_order_relaxed);
-			for(;;)
+			for(size_t attempt = 0; attempt < MaximumAttempts; ++attempt)
 			{
 				auto& cell = m_cells[position & (Capacity - 1)];
 				const auto sequence = cell.sequence.load(std::memory_order_acquire);
@@ -62,12 +65,13 @@ namespace mdJucePlugin
 					position = m_enqueuePosition.load(std::memory_order_relaxed);
 				}
 			}
+			return false;
 		}
 
 		bool tryPop(T& _value)
 		{
 			auto position = m_dequeuePosition.load(std::memory_order_relaxed);
-			for(;;)
+			for(size_t attempt = 0; attempt < MaximumAttempts; ++attempt)
 			{
 				auto& cell = m_cells[position & (Capacity - 1)];
 				const auto sequence = cell.sequence.load(std::memory_order_acquire);
@@ -93,6 +97,7 @@ namespace mdJucePlugin
 					position = m_dequeuePosition.load(std::memory_order_relaxed);
 				}
 			}
+			return false;
 		}
 
 	private:

--- a/source/elektron/md/mdJucePlugin/mdRealtimeQueue.h
+++ b/source/elektron/md/mdJucePlugin/mdRealtimeQueue.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace mdJucePlugin
+{
+	// Bounded multi-producer/single-or-multi-consumer queue based on per-cell
+	// sequence numbers. Producers and consumers never wait, allocate, or take a
+	// lock; callers decide whether a full queue should be retried or reported.
+	template<typename T, size_t Capacity>
+	class RealtimeQueue
+	{
+		static_assert(Capacity > 1 && (Capacity & (Capacity - 1)) == 0,
+			"RealtimeQueue capacity must be a power of two");
+		static_assert(std::is_trivially_copyable_v<T>,
+			"RealtimeQueue entries must be trivially copyable");
+		static_assert(std::atomic<size_t>::is_always_lock_free,
+			"RealtimeQueue requires lock-free size_t atomics");
+
+		struct Cell
+		{
+			std::atomic<size_t> sequence{0};
+			T value{};
+		};
+
+	public:
+		RealtimeQueue()
+		{
+			for(size_t index = 0; index < Capacity; ++index)
+				m_cells[index].sequence.store(index, std::memory_order_relaxed);
+		}
+
+		bool tryPush(const T& _value)
+		{
+			auto position = m_enqueuePosition.load(std::memory_order_relaxed);
+			for(;;)
+			{
+				auto& cell = m_cells[position & (Capacity - 1)];
+				const auto sequence = cell.sequence.load(std::memory_order_acquire);
+				const auto difference = static_cast<intptr_t>(sequence)
+					- static_cast<intptr_t>(position);
+				if(difference == 0)
+				{
+					if(m_enqueuePosition.compare_exchange_weak(position, position + 1,
+						std::memory_order_relaxed, std::memory_order_relaxed))
+					{
+						cell.value = _value;
+						cell.sequence.store(position + 1, std::memory_order_release);
+						return true;
+					}
+				}
+				else if(difference < 0)
+				{
+					return false;
+				}
+				else
+				{
+					position = m_enqueuePosition.load(std::memory_order_relaxed);
+				}
+			}
+		}
+
+		bool tryPop(T& _value)
+		{
+			auto position = m_dequeuePosition.load(std::memory_order_relaxed);
+			for(;;)
+			{
+				auto& cell = m_cells[position & (Capacity - 1)];
+				const auto sequence = cell.sequence.load(std::memory_order_acquire);
+				const auto difference = static_cast<intptr_t>(sequence)
+					- static_cast<intptr_t>(position + 1);
+				if(difference == 0)
+				{
+					if(m_dequeuePosition.compare_exchange_weak(position, position + 1,
+						std::memory_order_relaxed, std::memory_order_relaxed))
+					{
+						_value = cell.value;
+						cell.sequence.store(position + Capacity,
+							std::memory_order_release);
+						return true;
+					}
+				}
+				else if(difference < 0)
+				{
+					return false;
+				}
+				else
+				{
+					position = m_dequeuePosition.load(std::memory_order_relaxed);
+				}
+			}
+		}
+
+	private:
+		// Do not give the owning Controller an over-aligned type: the plugin still
+		// supports deployment targets before macOS 10.13, where aligned new/delete
+		// are unavailable. Correctness only requires the atomics themselves to have
+		// their natural alignment; cache-line separation would be an optimization.
+		std::array<Cell, Capacity> m_cells{};
+		std::atomic<size_t> m_enqueuePosition{0};
+		std::atomic<size_t> m_dequeuePosition{0};
+	};
+}

--- a/source/elektron/md/mdLib/mdsysexautomation.cpp
+++ b/source/elektron/md/mdLib/mdsysexautomation.cpp
@@ -184,7 +184,10 @@ namespace md::automation::sysex
 	{
 		if(!validDump(_model, _message, g_globalDump))
 			return std::nullopt;
-		const auto slot = _message[7];
+		// Dump headers are command, format version, revision, original position.
+		// The request correlation identity is the original position, not the format
+		// version (which happens to be a small in-range value on both machines).
+		const auto slot = _message[9];
 		if(slot >= 8)
 			return std::nullopt;
 
@@ -213,7 +216,7 @@ namespace md::automation::sysex
 	{
 		if(!validDump(_model, _message, g_kitDump))
 			return std::nullopt;
-		const auto slot = _message[7];
+		const auto slot = _message[9];
 		if(slot >= (_model == MachineModel::Monomachine ? 128 : 64))
 			return std::nullopt;
 

--- a/source/elektron/md/mdLib/mdsysexautomation.cpp
+++ b/source/elektron/md/mdLib/mdsysexautomation.cpp
@@ -1,6 +1,7 @@
 #include "mdsysexautomation.h"
 
 #include <algorithm>
+#include <utility>
 
 namespace md::automation::sysex
 {
@@ -11,6 +12,7 @@ namespace md::automation::sysex
 		constexpr uint8_t g_kitDump = 0x52;
 		constexpr uint8_t g_kitRequest = 0x53;
 		constexpr uint8_t g_statusRequest = 0x70;
+		constexpr uint8_t g_setStatus = 0x71;
 		constexpr uint8_t g_statusResponse = 0x72;
 
 		uint8_t product(const MachineModel _model)
@@ -56,6 +58,39 @@ namespace md::automation::sysex
 			const auto length = static_cast<uint16_t>(
 				(_message[checksumPosition + 2] << 7) | _message[checksumPosition + 3]);
 			return length == _message.size() - 10;
+		}
+
+		bool validStatusValue(const MachineModel _model,
+			const StatusParameter _parameter, const uint8_t _value)
+		{
+			switch(_parameter)
+			{
+			case StatusParameter::Global:
+				return _value < 8;
+			case StatusParameter::Kit:
+				return _value < (_model == MachineModel::Monomachine ? 128 : 64);
+			case StatusParameter::Pattern:
+				return _value < 128;
+			}
+			return false;
+		}
+
+		std::optional<StatusResponse> parseStatus(const MachineModel _model,
+			const MessageView _message, const uint8_t _command)
+		{
+			if(_message.size() != 10 || !hasHeader(_model, _message, _command)
+				|| std::any_of(_message.begin() + 1, _message.end() - 1,
+					[](const uint8_t _value) { return _value > 0x7f; }))
+				return std::nullopt;
+			const auto parameter = _message[7];
+			if(parameter != static_cast<uint8_t>(StatusParameter::Global)
+				&& parameter != static_cast<uint8_t>(StatusParameter::Kit)
+				&& parameter != static_cast<uint8_t>(StatusParameter::Pattern))
+				return std::nullopt;
+			const auto typedParameter = static_cast<StatusParameter>(parameter);
+			return validStatusValue(_model, typedParameter, _message[8])
+				? std::optional<StatusResponse>(StatusResponse{typedParameter, _message[8]})
+				: std::nullopt;
 		}
 
 		std::optional<std::vector<uint8_t>> decodeMonomachinePayload(
@@ -135,20 +170,22 @@ namespace md::automation::sysex
 	std::optional<StatusResponse> parseStatusResponse(const MachineModel _model,
 		const MessageView _message)
 	{
-		if(_message.size() != 10 || !hasHeader(_model, _message, g_statusResponse))
-			return std::nullopt;
-		const auto parameter = _message[7];
-		if(parameter != static_cast<uint8_t>(StatusParameter::Global)
-			&& parameter != static_cast<uint8_t>(StatusParameter::Kit)
-			&& parameter != static_cast<uint8_t>(StatusParameter::Pattern))
-			return std::nullopt;
-		return StatusResponse{static_cast<StatusParameter>(parameter), _message[8]};
+		return parseStatus(_model, _message, g_statusResponse);
 	}
 
-	std::optional<uint8_t> parseBaseChannel(const MachineModel _model,
+	std::optional<StatusResponse> parseSetStatus(const MachineModel _model,
+		const MessageView _message)
+	{
+		return parseStatus(_model, _message, g_setStatus);
+	}
+
+	std::optional<GlobalDump> parseGlobalDump(const MachineModel _model,
 		const MessageView _message)
 	{
 		if(!validDump(_model, _message, g_globalDump))
+			return std::nullopt;
+		const auto slot = _message[7];
+		if(slot >= 8)
 			return std::nullopt;
 
 		uint8_t channel = 0;
@@ -168,13 +205,16 @@ namespace md::automation::sysex
 		}
 
 		return channel < 16 || channel == 0x7f
-			? std::optional<uint8_t>(channel) : std::nullopt;
+			? std::optional<GlobalDump>(GlobalDump{slot, channel}) : std::nullopt;
 	}
 
-	std::optional<std::vector<ParameterChange>> parseKitParameters(
+	std::optional<KitDump> parseKitDump(
 		const MachineModel _model, const MessageView _message)
 	{
 		if(!validDump(_model, _message, g_kitDump))
+			return std::nullopt;
+		const auto slot = _message[7];
+		if(slot >= (_model == MachineModel::Monomachine ? 128 : 64))
 			return std::nullopt;
 
 		std::vector<ParameterChange> result;
@@ -199,7 +239,7 @@ namespace md::automation::sysex
 				result.push_back({machinedrum::Level, track, 0,
 					_message[levelPosition + track]});
 			}
-			return result;
+			return KitDump{slot, std::move(result)};
 		}
 
 		const auto decoded = decodeMonomachinePayload(_message);
@@ -225,6 +265,6 @@ namespace md::automation::sysex
 			result.push_back({monomachine::Level, track, 0,
 				(*decoded)[levelPosition + track]});
 		}
-		return result;
+		return KitDump{slot, std::move(result)};
 	}
 }

--- a/source/elektron/md/mdLib/mdsysexautomation.h
+++ b/source/elektron/md/mdLib/mdsysexautomation.h
@@ -40,6 +40,18 @@ namespace md::automation::sysex
 		uint8_t value;
 	};
 
+	struct GlobalDump
+	{
+		uint8_t slot;
+		uint8_t baseChannel;
+	};
+
+	struct KitDump
+	{
+		uint8_t slot;
+		std::vector<ParameterChange> parameters;
+	};
+
 	Message statusRequest(MachineModel _model, StatusParameter _parameter);
 	Message globalRequest(MachineModel _model, uint8_t _slot);
 	Message kitRequest(MachineModel _model, uint8_t _slot);
@@ -49,8 +61,10 @@ namespace md::automation::sysex
 
 	std::optional<StatusResponse> parseStatusResponse(MachineModel _model,
 		MessageView _message);
-	std::optional<uint8_t> parseBaseChannel(MachineModel _model,
+	std::optional<StatusResponse> parseSetStatus(MachineModel _model,
 		MessageView _message);
-	std::optional<std::vector<ParameterChange>> parseKitParameters(
+	std::optional<GlobalDump> parseGlobalDump(MachineModel _model,
+		MessageView _message);
+	std::optional<KitDump> parseKitDump(
 		MachineModel _model, MessageView _message);
 }

--- a/source/elektron/md/mdLibTest/automationMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/automationMidiTest.cpp
@@ -193,10 +193,10 @@ namespace
 	}
 
 	md::automation::sysex::Message makeMmDump(const uint8_t _command,
-		const std::vector<uint8_t>& _decoded)
+		const std::vector<uint8_t>& _decoded, const uint8_t _slot = 0x02)
 	{
 		md::automation::sysex::Message result{
-			0xf0, 0x00, 0x20, 0x3c, 0x03, 0x00, _command, 0x02, 0x01, 0x00};
+			0xf0, 0x00, 0x20, 0x3c, 0x03, 0x00, _command, _slot, 0x01, 0x00};
 		const auto rle = rleEncode(_decoded);
 		const auto packed = pack7Bit(rle);
 		result.insert(result.end(), packed.begin(), packed.end());
@@ -247,6 +247,34 @@ namespace
 		require(!isReadOnlyRequest(md::MachineModel::Monomachine,
 			statusRequest(md::MachineModel::Machinedrum, StatusParameter::Kit)),
 			"wrong-product query was classified as read-only");
+
+		const Message strictSetStatus{0xf0, 0x00, 0x20, 0x3c, 0x03, 0x00,
+			0x71, 0x02, 0x37, 0xf7};
+		const auto parsedSetStatus = parseSetStatus(md::MachineModel::Monomachine,
+			strictSetStatus);
+		require(parsedSetStatus && parsedSetStatus->parameter == StatusParameter::Kit
+			&& parsedSetStatus->value == 0x37, "could not parse SET STATUS");
+		for(const auto position : {size_t{1}, size_t{2}, size_t{3}, size_t{4},
+			size_t{5}, size_t{6}, size_t{9}})
+		{
+			auto malformed = strictSetStatus;
+			malformed[position] ^= 1;
+			require(!parseSetStatus(md::MachineModel::Monomachine, malformed),
+				"accepted malformed SET STATUS framing");
+		}
+		auto malformed = strictSetStatus;
+		malformed[8] = 0x80;
+		require(!parseSetStatus(md::MachineModel::Monomachine, malformed),
+			"accepted non-7-bit SET STATUS value");
+		malformed = setStatus;
+		malformed[7] = 0x7f;
+		require(!parseSetStatus(md::MachineModel::Monomachine, malformed),
+			"accepted unknown SET STATUS parameter");
+		malformed = setStatus;
+		malformed[4] = 0x02;
+		malformed[8] = 64;
+		require(!parseSetStatus(md::MachineModel::Machinedrum, malformed),
+			"accepted out-of-range MD Kit slot");
 	}
 
 	void testMidiRunningStatus()
@@ -296,13 +324,22 @@ namespace
 		global.resize(0xb0, 0);
 		global[0xad] = 11;
 		finishDump(global);
-		require(parseBaseChannel(md::MachineModel::Machinedrum, global) == 11,
+		const auto parsedGlobal = parseGlobalDump(md::MachineModel::Machinedrum, global);
+		require(parsedGlobal && parsedGlobal->slot == 5
+			&& parsedGlobal->baseChannel == 11,
 			"wrong MD base channel");
 		global[0xad] = 0x7f;
 		global.resize(global.size() - 5);
 		finishDump(global);
-		require(parseBaseChannel(md::MachineModel::Machinedrum, global) == 0x7f,
+		const auto parsedNone = parseGlobalDump(md::MachineModel::Machinedrum, global);
+		require(parsedNone && parsedNone->slot == 5
+			&& parsedNone->baseChannel == 0x7f,
 			"MD MIDI NONE should be a valid persisted setting");
+		global[7] = 8;
+		global.resize(global.size() - 5);
+		finishDump(global);
+		require(!parseGlobalDump(md::MachineModel::Machinedrum, global),
+			"accepted out-of-range MD Global slot");
 
 		Message kit{0xf0, 0x00, 0x20, 0x3c, 0x02, 0x00,
 			0x52, 0x04, 0x01, 0x00};
@@ -315,14 +352,17 @@ namespace
 			kit[0x19a + track] = static_cast<uint8_t>(100 + track);
 		}
 		finishDump(kit);
-		const auto values = parseKitParameters(md::MachineModel::Machinedrum, kit);
-		require(values && values->size() == 400, "wrong MD Kit parameter count");
-		require((*values)[0] == ParameterChange{machinedrum::Synthesis, 0, 0, 0},
+		const auto parsedKit = parseKitDump(md::MachineModel::Machinedrum, kit);
+		require(parsedKit && parsedKit->slot == 4
+			&& parsedKit->parameters.size() == 400, "wrong MD Kit parameter count");
+		require(parsedKit->parameters[0]
+			== ParameterChange{machinedrum::Synthesis, 0, 0, 0},
 			"wrong first MD Kit parameter");
-		require((*values)[399] == ParameterChange{machinedrum::Level, 15, 0, 115},
+		require(parsedKit->parameters[399]
+			== ParameterChange{machinedrum::Level, 15, 0, 115},
 			"wrong last MD Kit parameter");
 		kit[100] ^= 1;
-		require(!parseKitParameters(md::MachineModel::Machinedrum, kit),
+		require(!parseKitDump(md::MachineModel::Machinedrum, kit),
 			"accepted corrupt MD Kit checksum");
 	}
 
@@ -334,7 +374,9 @@ namespace
 		globalData[0] = 0x91;
 		globalData[1] = 5;
 		auto global = makeMmDump(0x50, globalData);
-		require(parseBaseChannel(md::MachineModel::Monomachine, global) == 5,
+		const auto parsedGlobal = parseGlobalDump(md::MachineModel::Monomachine, global);
+		require(parsedGlobal && parsedGlobal->slot == 2
+			&& parsedGlobal->baseChannel == 5,
 			"wrong MM base channel or broken 7-bit/RLE decode");
 
 		std::vector<uint8_t> kitData(698, 0);
@@ -347,14 +389,17 @@ namespace
 		}
 		kitData.back() = 0xe5;
 		auto kit = makeMmDump(0x52, kitData);
-		const auto values = parseKitParameters(md::MachineModel::Monomachine, kit);
-		require(values && values->size() == 342, "wrong MM Kit parameter count");
-		require((*values)[0] == ParameterChange{monomachine::Synthesis, 0, 0, 0},
+		const auto parsedKit = parseKitDump(md::MachineModel::Monomachine, kit);
+		require(parsedKit && parsedKit->slot == 2
+			&& parsedKit->parameters.size() == 342, "wrong MM Kit parameter count");
+		require(parsedKit->parameters[0]
+			== ParameterChange{monomachine::Synthesis, 0, 0, 0},
 			"wrong first MM Kit parameter");
-		require((*values)[341] == ParameterChange{monomachine::Level, 5, 0, 95},
+		require(parsedKit->parameters[341]
+			== ParameterChange{monomachine::Level, 5, 0, 95},
 			"wrong last MM Kit parameter");
 		kit[12] ^= 1;
-		require(!parseKitParameters(md::MachineModel::Monomachine, kit),
+		require(!parseKitDump(md::MachineModel::Monomachine, kit),
 			"accepted corrupt MM Kit checksum");
 	}
 
@@ -379,13 +424,13 @@ namespace
 				bytes.begin() + end + 1);
 			if(message.size() > 6 && message[6] == 0x50)
 			{
-				require(md::automation::sysex::parseBaseChannel(_model, message)
+				require(md::automation::sysex::parseGlobalDump(_model, message)
 					.has_value(), "could not parse real Global dump");
 				++globalCount;
 			}
 			else if(message.size() > 6 && message[6] == 0x52)
 			{
-				require(md::automation::sysex::parseKitParameters(_model, message)
+				require(md::automation::sysex::parseKitDump(_model, message)
 					.has_value(), "could not parse real Kit dump");
 				++kitCount;
 			}

--- a/source/elektron/md/mdLibTest/automationMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/automationMidiTest.cpp
@@ -196,7 +196,7 @@ namespace
 		const std::vector<uint8_t>& _decoded, const uint8_t _slot = 0x02)
 	{
 		md::automation::sysex::Message result{
-			0xf0, 0x00, 0x20, 0x3c, 0x03, 0x00, _command, _slot, 0x01, 0x00};
+			0xf0, 0x00, 0x20, 0x3c, 0x03, 0x00, _command, 0x01, 0x01, _slot};
 		const auto rle = rleEncode(_decoded);
 		const auto packed = pack7Bit(rle);
 		result.insert(result.end(), packed.begin(), packed.end());
@@ -320,7 +320,7 @@ namespace
 		using namespace md::automation;
 		using namespace md::automation::sysex;
 		Message global{0xf0, 0x00, 0x20, 0x3c, 0x02, 0x00,
-			0x50, 0x05, 0x01, 0x00};
+			0x50, 0x06, 0x01, 0x05};
 		global.resize(0xb0, 0);
 		global[0xad] = 11;
 		finishDump(global);
@@ -335,14 +335,14 @@ namespace
 		require(parsedNone && parsedNone->slot == 5
 			&& parsedNone->baseChannel == 0x7f,
 			"MD MIDI NONE should be a valid persisted setting");
-		global[7] = 8;
+		global[9] = 8;
 		global.resize(global.size() - 5);
 		finishDump(global);
 		require(!parseGlobalDump(md::MachineModel::Machinedrum, global),
 			"accepted out-of-range MD Global slot");
 
 		Message kit{0xf0, 0x00, 0x20, 0x3c, 0x02, 0x00,
-			0x52, 0x04, 0x01, 0x00};
+			0x52, 0x04, 0x01, 0x04};
 		kit.resize(1228, 0);
 		for(uint8_t track = 0; track < machinedrum::TrackCount; ++track)
 		{
@@ -424,14 +424,19 @@ namespace
 				bytes.begin() + end + 1);
 			if(message.size() > 6 && message[6] == 0x50)
 			{
-				require(md::automation::sysex::parseGlobalDump(_model, message)
-					.has_value(), "could not parse real Global dump");
+				const auto parsed = md::automation::sysex::parseGlobalDump(
+					_model, message);
+				require(parsed.has_value(), "could not parse real Global dump");
+				require(parsed->slot == message[9],
+					"real Global dump reported its format version as its slot");
 				++globalCount;
 			}
 			else if(message.size() > 6 && message[6] == 0x52)
 			{
-				require(md::automation::sysex::parseKitDump(_model, message)
-					.has_value(), "could not parse real Kit dump");
+				const auto parsed = md::automation::sysex::parseKitDump(_model, message);
+				require(parsed.has_value(), "could not parse real Kit dump");
+				require(parsed->slot == message[9],
+					"real Kit dump reported its format version as its slot");
 				++kitCount;
 			}
 			begin = end + 1;

--- a/source/framework/juce/jucePluginLib/CMakeLists.txt
+++ b/source/framework/juce/jucePluginLib/CMakeLists.txt
@@ -78,3 +78,13 @@ if(UNIX AND NOT APPLE)
 	find_package(Threads REQUIRED)
 	target_link_libraries(jucePluginLib PRIVATE Threads::Threads)
 endif()
+
+if(BUILD_TESTING)
+	add_executable(midiOutputDispatcherTest midiOutputDispatcherTest.cpp)
+	target_link_libraries(midiOutputDispatcherTest PRIVATE
+		jucePluginLib juce_plugin_modules)
+	target_compile_definitions(midiOutputDispatcherTest
+		PRIVATE JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1)
+	add_test(NAME midiOutputDispatcherTest COMMAND midiOutputDispatcherTest)
+	set_property(TARGET midiOutputDispatcherTest PROPERTY FOLDER "Tests")
+endif()

--- a/source/framework/juce/jucePluginLib/controller.h
+++ b/source/framework/juce/jucePluginLib/controller.h
@@ -73,6 +73,11 @@ namespace pluginLib
 
 		virtual bool parseMidiMessage(const synthLib::SMidiEvent& _e);
 
+		// Called from Processor::processBlock before the synth consumes MIDI. Device
+		// controllers may drain bounded host-parameter work here; implementations
+		// must not wait, allocate, or call message-thread-only APIs.
+		virtual void processRealtimeParameterChanges(size_t) {}
+
 		virtual void onStateLoaded() = 0;
 
         // Blocking/growing batch ingress for non-realtime callers.

--- a/source/framework/juce/jucePluginLib/midiOutputDispatcherTest.cpp
+++ b/source/framework/juce/jucePluginLib/midiOutputDispatcherTest.cpp
@@ -1,0 +1,261 @@
+#include "midiports.h"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <functional>
+#include <iostream>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+namespace
+{
+	using namespace std::chrono_literals;
+
+	void require(const bool _condition, const char* const _message)
+	{
+		if(!_condition)
+			throw std::runtime_error(_message);
+	}
+
+	struct SinkState
+	{
+		std::mutex mutex;
+		std::condition_variable condition;
+		bool running = false;
+		bool stopped = false;
+		bool block = false;
+		bool released = false;
+		size_t entered = 0;
+		std::vector<std::array<uint8_t, 3>> messages;
+	};
+
+	class ControlledSink final : public pluginLib::MidiOutputSink
+	{
+	public:
+		ControlledSink(std::shared_ptr<SinkState> _state, juce::String _identifier)
+			: state(std::move(_state)), identifier(std::move(_identifier)) {}
+
+		juce::String getIdentifier() const override { return identifier; }
+		void start() override
+		{
+			const std::lock_guard lock(state->mutex);
+			state->running = true;
+		}
+		void stop() override
+		{
+			const std::lock_guard lock(state->mutex);
+			state->running = false;
+			state->stopped = true;
+		}
+		bool isRunning() const override
+		{
+			const std::lock_guard lock(state->mutex);
+			return state->running;
+		}
+		void sendMessageNow(const juce::MidiMessage& _message) override
+		{
+			std::unique_lock lock(state->mutex);
+			++state->entered;
+			state->condition.notify_all();
+			state->condition.wait(lock, [this]
+			{
+				return !state->block || state->released;
+			});
+			std::array<uint8_t, 3> bytes{};
+			const auto count = std::min(3, _message.getRawDataSize());
+			std::copy_n(_message.getRawData(), count, bytes.begin());
+			state->messages.push_back(bytes);
+			state->condition.notify_all();
+		}
+
+	private:
+		std::shared_ptr<SinkState> state;
+		juce::String identifier;
+	};
+
+	std::unique_ptr<ControlledSink> sink(const std::shared_ptr<SinkState>& _state,
+		const char* const _identifier)
+	{
+		return std::make_unique<ControlledSink>(_state, _identifier);
+	}
+
+	bool waitFor(const std::shared_ptr<SinkState>& _state,
+		const std::function<bool(const SinkState&)>& _predicate)
+	{
+		std::unique_lock lock(_state->mutex);
+		return _state->condition.wait_for(lock, 3s,
+			[&] { return _predicate(*_state); });
+	}
+
+	void release(const std::shared_ptr<SinkState>& _state)
+	{
+		{
+			const std::lock_guard lock(_state->mutex);
+			_state->released = true;
+		}
+		_state->condition.notify_all();
+	}
+
+	juce::MidiMessage message(const int _ordinal)
+	{
+		return juce::MidiMessage::controllerEvent(
+			1 + (_ordinal / 128) % 16, _ordinal % 128, (_ordinal * 37) % 128);
+	}
+
+	void testSaturationAndBlockingSend()
+	{
+		pluginLib::MidiOutputDispatcher dispatcher;
+		auto state = std::make_shared<SinkState>();
+		state->block = true;
+		require(dispatcher.setOutput(sink(state, "saturated")),
+			"controlled output did not open");
+		require(dispatcher.trySend(message(0)), "first realtime send failed");
+		require(waitFor(state, [](const SinkState& value) { return value.entered == 1; }),
+			"sender did not enter controlled sink");
+
+		for(size_t index = 0; index < pluginLib::MidiOutputDispatcher::Capacity; ++index)
+			require(dispatcher.trySend(message(static_cast<int>(index + 1))),
+				"realtime send failed before fixed queue reached capacity");
+		require(!dispatcher.trySend(message(1000)),
+			"realtime send did not report fixed-capacity saturation");
+
+		auto blocked = std::async(std::launch::async, [&dispatcher]
+		{
+			dispatcher.send(message(1001));
+		});
+		const auto status = blocked.wait_for(30ms);
+		release(state);
+		require(status == std::future_status::timeout,
+			"non-realtime send did not wait behind a full queue");
+		require(blocked.wait_for(3s) == std::future_status::ready,
+			"non-realtime send did not resume after capacity became available");
+		require(waitFor(state, [](const SinkState& value)
+		{
+			return value.messages.size()
+				== pluginLib::MidiOutputDispatcher::Capacity + 2;
+		}), "queued MIDI messages did not drain completely");
+		dispatcher.close();
+		require(dispatcher.trySend(message(2)),
+			"an absent physical output should remain a successful no-op");
+	}
+
+	void testReplacementAndShutdown()
+	{
+		pluginLib::MidiOutputDispatcher dispatcher;
+		auto oldState = std::make_shared<SinkState>();
+		oldState->block = true;
+		dispatcher.setOutput(sink(oldState, "old"));
+		dispatcher.send(message(10));
+		require(waitFor(oldState,
+			[](const SinkState& value) { return value.entered == 1; }),
+			"old sink did not begin its send");
+
+		auto newState = std::make_shared<SinkState>();
+		auto replacement = std::async(std::launch::async,
+			[&dispatcher, output = sink(newState, "new")]() mutable
+			{
+				return dispatcher.setOutput(std::move(output));
+			});
+		const auto replacementStatus = replacement.wait_for(30ms);
+		release(oldState);
+		require(replacementStatus == std::future_status::timeout,
+			"output replacement destroyed a sink with an active send");
+		require(replacement.wait_for(3s) == std::future_status::ready
+			&& replacement.get(), "output replacement did not complete");
+		require(dispatcher.getOutputId() == "new", "replacement identifier is stale");
+		dispatcher.send(message(11));
+		require(waitFor(newState,
+			[](const SinkState& value) { return value.messages.size() == 1; }),
+			"replacement sink did not receive subsequent output");
+		{
+			const std::lock_guard lock(oldState->mutex);
+			require(oldState->stopped && oldState->messages.size() == 1,
+				"old sink lifecycle or delivery boundary was incorrect");
+		}
+
+		newState->block = true;
+		newState->released = false;
+		dispatcher.send(message(12));
+		require(waitFor(newState,
+			[](const SinkState& value) { return value.entered == 2; }),
+			"shutdown probe did not enter replacement sink");
+		auto shutdown = std::async(std::launch::async,
+			[&dispatcher] { dispatcher.close(); });
+		const auto shutdownStatus = shutdown.wait_for(30ms);
+		release(newState);
+		require(shutdownStatus == std::future_status::timeout,
+			"shutdown destroyed a sink with an active send");
+		require(shutdown.wait_for(3s) == std::future_status::ready,
+			"shutdown did not complete after active output returned");
+		const std::lock_guard lock(newState->mutex);
+		require(newState->stopped && !newState->running,
+			"shutdown did not stop the physical output sink");
+	}
+
+	void testConcurrentProducers()
+	{
+		pluginLib::MidiOutputDispatcher dispatcher;
+		auto state = std::make_shared<SinkState>();
+		state->block = true;
+		dispatcher.setOutput(sink(state, "concurrent"));
+		require(dispatcher.trySend(message(2000)), "sentinel send failed");
+		require(waitFor(state,
+			[](const SinkState& value) { return value.entered == 1; }),
+			"sentinel did not block the consumer");
+
+		constexpr int ProducerCount = 4;
+		constexpr int MessagesPerProducer = 24;
+		std::array<std::thread, ProducerCount> producers;
+		for(int producer = 0; producer < ProducerCount; ++producer)
+		{
+			producers[producer] = std::thread([&dispatcher, producer]
+			{
+				for(int index = 0; index < MessagesPerProducer; ++index)
+				{
+					const auto ordinal = 3000 + producer * MessagesPerProducer + index;
+					while(!dispatcher.trySend(message(ordinal)))
+						std::this_thread::yield();
+				}
+			});
+		}
+		for(auto& producer : producers)
+			producer.join();
+		release(state);
+		require(waitFor(state, [](const SinkState& value)
+		{
+			return value.messages.size() == 1 + ProducerCount * MessagesPerProducer;
+		}), "concurrent producer messages did not all reach the sink");
+
+		std::vector<std::array<uint8_t, 3>> delivered;
+		{
+			const std::lock_guard lock(state->mutex);
+			delivered = state->messages;
+		}
+		std::sort(delivered.begin() + 1, delivered.end());
+		require(std::adjacent_find(delivered.begin() + 1, delivered.end())
+			== delivered.end(), "concurrent producers duplicated an output message");
+		dispatcher.close();
+	}
+}
+
+int main()
+{
+	try
+	{
+		testSaturationAndBlockingSend();
+		testReplacementAndShutdown();
+		testConcurrentProducers();
+		std::cout << "midiOutputDispatcherTest: PASS\n";
+		return 0;
+	}
+	catch(const std::exception& error)
+	{
+		std::cerr << "midiOutputDispatcherTest: " << error.what() << '\n';
+		return 1;
+	}
+}

--- a/source/framework/juce/jucePluginLib/midiports.cpp
+++ b/source/framework/juce/jucePluginLib/midiports.cpp
@@ -12,6 +12,179 @@
 
 namespace pluginLib
 {
+	namespace
+	{
+		class JuceMidiOutputSink final : public MidiOutputSink
+		{
+		public:
+			explicit JuceMidiOutputSink(std::unique_ptr<juce::MidiOutput> _output)
+				: m_output(std::move(_output)) {}
+
+			juce::String getIdentifier() const override
+			{
+				return m_output->getIdentifier();
+			}
+			void start() override { m_output->startBackgroundThread(); }
+			void stop() override
+			{
+				if(m_output->isBackgroundThreadRunning())
+					m_output->stopBackgroundThread();
+			}
+			bool isRunning() const override
+			{
+				return m_output->isBackgroundThreadRunning();
+			}
+			void sendMessageNow(const juce::MidiMessage& _message) override
+			{
+				m_output->sendMessageNow(_message);
+			}
+
+		private:
+			std::unique_ptr<juce::MidiOutput> m_output;
+		};
+	}
+
+	MidiOutputDispatcher::~MidiOutputDispatcher()
+	{
+		close();
+	}
+
+	void MidiOutputDispatcher::push(juce::MidiMessage&& _message)
+	{
+		assert(!outputQueueFull());
+		m_messages[m_write] = std::move(_message);
+		m_write = (m_write + 1) % Capacity;
+		++m_count;
+	}
+
+	juce::MidiMessage MidiOutputDispatcher::pop()
+	{
+		assert(m_count > 0);
+		auto result = std::move(m_messages[m_read]);
+		m_read = (m_read + 1) % Capacity;
+		--m_count;
+		return result;
+	}
+
+	void MidiOutputDispatcher::clear()
+	{
+		m_read = 0;
+		m_write = 0;
+		m_count = 0;
+	}
+
+	void MidiOutputDispatcher::send(juce::MidiMessage&& _message)
+	{
+		std::unique_lock lock(m_mutex);
+		if(m_output == nullptr || m_stopping)
+			return;
+		m_condition.wait(lock, [this]
+		{
+			return !outputQueueFull() || m_stopping || m_output == nullptr;
+		});
+		if(m_output == nullptr || m_stopping)
+			return;
+		push(std::move(_message));
+		lock.unlock();
+		m_condition.notify_one();
+	}
+
+	void MidiOutputDispatcher::send(const juce::MidiMessage& _message)
+	{
+		auto copy = _message;
+		send(std::move(copy));
+	}
+
+	bool MidiOutputDispatcher::trySend(juce::MidiMessage&& _message)
+	{
+		std::unique_lock lock(m_mutex, std::try_to_lock);
+		if(!lock.owns_lock() || m_stopping)
+			return false;
+		if(m_output == nullptr)
+			return true;
+		if(outputQueueFull())
+			return false;
+		push(std::move(_message));
+		lock.unlock();
+		m_condition.notify_one();
+		return true;
+	}
+
+	bool MidiOutputDispatcher::setOutput(std::unique_ptr<MidiOutputSink> _output)
+	{
+		const std::lock_guard configurationLock(m_configurationMutex);
+		{
+			std::lock_guard lock(m_mutex);
+			m_stopping = true;
+		}
+		m_condition.notify_all();
+
+		if(m_thread)
+		{
+			m_thread->join();
+			m_thread.reset();
+		}
+
+		{
+			std::lock_guard lock(m_mutex);
+			if(m_output != nullptr && m_output->isRunning())
+				m_output->stop();
+			m_output.reset();
+			clear();
+		}
+
+		if(_output != nullptr)
+			_output->start();
+		const auto opened = _output != nullptr;
+		{
+			std::lock_guard lock(m_mutex);
+			m_output = std::move(_output);
+			m_stopping = false;
+		}
+		if(opened)
+			m_thread = std::make_unique<std::thread>([this] { senderThread(); });
+		return opened;
+	}
+
+	void MidiOutputDispatcher::close()
+	{
+		(void)setOutput({});
+	}
+
+	bool MidiOutputDispatcher::isValid() const
+	{
+		const std::lock_guard lock(m_mutex);
+		return m_output != nullptr && !m_stopping;
+	}
+
+	juce::String MidiOutputDispatcher::getOutputId() const
+	{
+		const std::lock_guard lock(m_mutex);
+		return m_output != nullptr ? m_output->getIdentifier() : juce::String();
+	}
+
+	void MidiOutputDispatcher::senderThread()
+	{
+		dsp56k::ThreadTools::setCurrentThreadName("MidiOutputSender");
+		for(;;)
+		{
+			std::unique_lock lock(m_mutex);
+			m_condition.wait(lock, [this]
+			{
+				return m_stopping || m_count > 0;
+			});
+			if(m_stopping)
+				return;
+
+			auto message = pop();
+			auto* const output = m_output.get();
+			lock.unlock();
+			m_condition.notify_all();
+			if(output != nullptr)
+				output->sendMessageNow(message);
+		}
+	}
+
 	MidiPorts::MidiPorts(Processor& _processor) : m_processor(_processor)
 	{
 	}
@@ -34,8 +207,7 @@ namespace pluginLib
 
 	juce::String MidiPorts::getOutputId() const
 	{
-		const std::lock_guard lock(m_mutexOutput);
-		return m_midiOutput != nullptr ? m_midiOutput->getIdentifier() : juce::String();
+		return m_midiOutput.getOutputId();
 	}
 
 	void MidiPorts::saveChunkData(baseLib::BinaryStream& _binaryStream) const
@@ -46,13 +218,7 @@ namespace pluginLib
 			_binaryStream.write(m_midiInput->getIdentifier().toStdString());
 		else
 			_binaryStream.write(std::string());
-		{
-			const std::lock_guard lock(m_mutexOutput);
-			if(m_midiOutput)
-				_binaryStream.write(m_midiOutput->getIdentifier().toStdString());
-			else
-				_binaryStream.write(std::string());
-		}
+		_binaryStream.write(m_midiOutput.getOutputId().toStdString());
 	}
 
 	void MidiPorts::loadChunkData(baseLib::ChunkReader& _cr)
@@ -90,44 +256,9 @@ namespace pluginLib
 	    return {_e.a, _e.b, _e.c, 0.0};
 	}
 
-	void MidiPorts::pushOutputMessage(juce::MidiMessage&& _message)
-	{
-		assert(!outputQueueFull());
-		m_midiOutMessages[m_midiOutWrite] = std::move(_message);
-		m_midiOutWrite = (m_midiOutWrite + 1) % MidiOutCapacity;
-		++m_midiOutCount;
-	}
-
-	juce::MidiMessage MidiPorts::popOutputMessage()
-	{
-		assert(m_midiOutCount > 0);
-		auto result = std::move(m_midiOutMessages[m_midiOutRead]);
-		m_midiOutRead = (m_midiOutRead + 1) % MidiOutCapacity;
-		--m_midiOutCount;
-		return result;
-	}
-
-	void MidiPorts::clearOutputMessages()
-	{
-		m_midiOutRead = 0;
-		m_midiOutWrite = 0;
-		m_midiOutCount = 0;
-	}
-
 	void MidiPorts::send(juce::MidiMessage&& _message)
 	{
-		std::unique_lock lock(m_mutexOutput);
-		if(m_midiOutput == nullptr || m_outputStopping)
-			return;
-		m_outputCondition.wait(lock, [this]
-		{
-			return !outputQueueFull() || m_outputStopping || m_midiOutput == nullptr;
-		});
-		if(m_midiOutput == nullptr || m_outputStopping)
-			return;
-		pushOutputMessage(std::move(_message));
-		lock.unlock();
-		m_outputCondition.notify_one();
+		m_midiOutput.send(std::move(_message));
 	}
 
 	void MidiPorts::send(const juce::MidiMessage& _message)
@@ -142,63 +273,21 @@ namespace pluginLib
 		// conversion owns variable-size storage and belongs on send().
 		if(!_message.sysex.empty())
 			return false;
-		std::unique_lock lock(m_mutexOutput, std::try_to_lock);
-		if(!lock.owns_lock() || m_outputStopping)
-			return false;
-		if(m_midiOutput == nullptr)
-			return true;
-		if(outputQueueFull())
-			return false;
-		pushOutputMessage(toJuceMidiMessage(_message));
-		lock.unlock();
-		m_outputCondition.notify_one();
-		return true;
+		return m_midiOutput.trySend(toJuceMidiMessage(_message));
 	}
 
 	bool MidiPorts::isMidiOutValid() const
 	{
-		const std::lock_guard lock(m_mutexOutput);
-		return m_midiOutput != nullptr && !m_outputStopping;
+		return m_midiOutput.isValid();
 	}
 
 	bool MidiPorts::setMidiOutput(const juce::String& _out)
 	{
-		const std::lock_guard configurationLock(m_mutexOutputConfiguration);
-		{
-			std::lock_guard lock(m_mutexOutput);
-			m_outputStopping = true;
-		}
-		m_outputCondition.notify_all();
-
-		if (m_threadOutput)
-		{
-			m_threadOutput->join();
-			m_threadOutput.reset();
-		}
-
-		{
-			std::lock_guard lock(m_mutexOutput);
-			if(m_midiOutput != nullptr && m_midiOutput->isBackgroundThreadRunning())
-				m_midiOutput->stopBackgroundThread();
-			m_midiOutput.reset();
-			clearOutputMessages();
-		}
-
 		std::unique_ptr<juce::MidiOutput> output;
 		if(!_out.isEmpty())
 			output = juce::MidiOutput::openDevice(_out);
-		if(output != nullptr)
-			output->startBackgroundThread();
-
-		const auto opened = output != nullptr;
-		{
-			std::lock_guard lock(m_mutexOutput);
-			m_midiOutput = std::move(output);
-			m_outputStopping = false;
-		}
-		if(opened)
-			m_threadOutput.reset(new std::thread([this] { senderThread(); }));
-		return opened;
+		return m_midiOutput.setOutput(output == nullptr ? nullptr
+			: std::make_unique<JuceMidiOutputSink>(std::move(output)));
 	}
 
 	bool MidiPorts::setMidiInput(const juce::String& _in)
@@ -232,26 +321,4 @@ namespace pluginLib
 		m_processor.handleIncomingMidiMessage(_source, _message);
 	}
 
-	void MidiPorts::senderThread()
-	{
-		dsp56k::ThreadTools::setCurrentThreadName("MIdiOutputSender");
-
-		for(;;)
-		{
-			std::unique_lock lock(m_mutexOutput);
-			m_outputCondition.wait(lock, [this]
-			{
-				return m_outputStopping || m_midiOutCount > 0;
-			});
-			if(m_outputStopping)
-				return;
-
-			auto msg = popOutputMessage();
-			auto* const out = m_midiOutput.get();
-			lock.unlock();
-			m_outputCondition.notify_all();
-			if(out != nullptr)
-				out->sendMessageNow(msg);
-		}
-	}
 }

--- a/source/framework/juce/jucePluginLib/midiports.cpp
+++ b/source/framework/juce/jucePluginLib/midiports.cpp
@@ -8,6 +8,8 @@
 
 #include "synthLib/midiBufferParser.h"
 
+#include <cassert>
+
 namespace pluginLib
 {
 	MidiPorts::MidiPorts(Processor& _processor) : m_processor(_processor)
@@ -18,11 +20,6 @@ namespace pluginLib
 	{
 		close();
 		m_deviceManager.reset();
-	}
-
-	juce::MidiOutput *MidiPorts::getMidiOutput() const
-	{
-		return m_midiOutput.get();
 	}
 
 	juce::MidiInput *MidiPorts::getMidiInput() const
@@ -37,7 +34,8 @@ namespace pluginLib
 
 	juce::String MidiPorts::getOutputId() const
 	{
-		return getMidiOutput() != nullptr ? getMidiOutput()->getIdentifier() : juce::String();
+		const std::lock_guard lock(m_mutexOutput);
+		return m_midiOutput != nullptr ? m_midiOutput->getIdentifier() : juce::String();
 	}
 
 	void MidiPorts::saveChunkData(baseLib::BinaryStream& _binaryStream) const
@@ -48,10 +46,13 @@ namespace pluginLib
 			_binaryStream.write(m_midiInput->getIdentifier().toStdString());
 		else
 			_binaryStream.write(std::string());
-		if(m_midiOutput)
-			_binaryStream.write(m_midiOutput->getIdentifier().toStdString());
-		else
-			_binaryStream.write(std::string());
+		{
+			const std::lock_guard lock(m_mutexOutput);
+			if(m_midiOutput)
+				_binaryStream.write(m_midiOutput->getIdentifier().toStdString());
+			else
+				_binaryStream.write(std::string());
+		}
 	}
 
 	void MidiPorts::loadChunkData(baseLib::ChunkReader& _cr)
@@ -89,20 +90,85 @@ namespace pluginLib
 	    return {_e.a, _e.b, _e.c, 0.0};
 	}
 
+	void MidiPorts::pushOutputMessage(juce::MidiMessage&& _message)
+	{
+		assert(!outputQueueFull());
+		m_midiOutMessages[m_midiOutWrite] = std::move(_message);
+		m_midiOutWrite = (m_midiOutWrite + 1) % MidiOutCapacity;
+		++m_midiOutCount;
+	}
+
+	juce::MidiMessage MidiPorts::popOutputMessage()
+	{
+		assert(m_midiOutCount > 0);
+		auto result = std::move(m_midiOutMessages[m_midiOutRead]);
+		m_midiOutRead = (m_midiOutRead + 1) % MidiOutCapacity;
+		--m_midiOutCount;
+		return result;
+	}
+
+	void MidiPorts::clearOutputMessages()
+	{
+		m_midiOutRead = 0;
+		m_midiOutWrite = 0;
+		m_midiOutCount = 0;
+	}
+
+	void MidiPorts::send(juce::MidiMessage&& _message)
+	{
+		std::unique_lock lock(m_mutexOutput);
+		if(m_midiOutput == nullptr || m_outputStopping)
+			return;
+		m_outputCondition.wait(lock, [this]
+		{
+			return !outputQueueFull() || m_outputStopping || m_midiOutput == nullptr;
+		});
+		if(m_midiOutput == nullptr || m_outputStopping)
+			return;
+		pushOutputMessage(std::move(_message));
+		lock.unlock();
+		m_outputCondition.notify_one();
+	}
+
+	void MidiPorts::send(const juce::MidiMessage& _message)
+	{
+		auto copy = _message;
+		send(std::move(copy));
+	}
+
+	bool MidiPorts::trySend(const synthLib::SMidiEvent& _message)
+	{
+		// The realtime path is only for fixed-size channel messages. SysEx
+		// conversion owns variable-size storage and belongs on send().
+		if(!_message.sysex.empty())
+			return false;
+		std::unique_lock lock(m_mutexOutput, std::try_to_lock);
+		if(!lock.owns_lock() || m_outputStopping)
+			return false;
+		if(m_midiOutput == nullptr)
+			return true;
+		if(outputQueueFull())
+			return false;
+		pushOutputMessage(toJuceMidiMessage(_message));
+		lock.unlock();
+		m_outputCondition.notify_one();
+		return true;
+	}
+
+	bool MidiPorts::isMidiOutValid() const
+	{
+		const std::lock_guard lock(m_mutexOutput);
+		return m_midiOutput != nullptr && !m_outputStopping;
+	}
+
 	bool MidiPorts::setMidiOutput(const juce::String& _out)
 	{
+		const std::lock_guard configurationLock(m_mutexOutputConfiguration);
 		{
 			std::lock_guard lock(m_mutexOutput);
-			if (m_midiOutput != nullptr)
-			{
-				if (m_midiOutput->isBackgroundThreadRunning())
-					m_midiOutput->stopBackgroundThread();
-			}
-			m_midiOutput = nullptr;
-
-			// send dummy to wakeup thread
-			m_midiOutMessages.push_back(juce::MidiMessage());
+			m_outputStopping = true;
 		}
+		m_outputCondition.notify_all();
 
 		if (m_threadOutput)
 		{
@@ -110,19 +176,29 @@ namespace pluginLib
 			m_threadOutput.reset();
 		}
 
-		if(_out.isEmpty())
-			return false;
-
-		std::lock_guard lock(m_mutexOutput);
-
-		m_midiOutput = juce::MidiOutput::openDevice(_out);
-		if (m_midiOutput != nullptr)
 		{
-			m_midiOutput->startBackgroundThread();
-			m_threadOutput.reset(new std::thread([this] { senderThread(); }));
-			return true;
+			std::lock_guard lock(m_mutexOutput);
+			if(m_midiOutput != nullptr && m_midiOutput->isBackgroundThreadRunning())
+				m_midiOutput->stopBackgroundThread();
+			m_midiOutput.reset();
+			clearOutputMessages();
 		}
-		return false;
+
+		std::unique_ptr<juce::MidiOutput> output;
+		if(!_out.isEmpty())
+			output = juce::MidiOutput::openDevice(_out);
+		if(output != nullptr)
+			output->startBackgroundThread();
+
+		const auto opened = output != nullptr;
+		{
+			std::lock_guard lock(m_mutexOutput);
+			m_midiOutput = std::move(output);
+			m_outputStopping = false;
+		}
+		if(opened)
+			m_threadOutput.reset(new std::thread([this] { senderThread(); }));
+		return opened;
 	}
 
 	bool MidiPorts::setMidiInput(const juce::String& _in)
@@ -160,21 +236,22 @@ namespace pluginLib
 	{
 		dsp56k::ThreadTools::setCurrentThreadName("MIdiOutputSender");
 
-		while (true)
+		for(;;)
 		{
-			auto msg = m_midiOutMessages.pop_front();
-
-			std::lock_guard lock(m_mutexOutput);
-
-			auto* out = m_midiOutput.get();
-			if (!out)
+			std::unique_lock lock(m_mutexOutput);
+			m_outputCondition.wait(lock, [this]
 			{
-				while (!m_midiOutMessages.empty())
-					m_midiOutMessages.pop_front();
-				break;
-			}
+				return m_outputStopping || m_midiOutCount > 0;
+			});
+			if(m_outputStopping)
+				return;
 
-			out->sendMessageNow(msg);
+			auto msg = popOutputMessage();
+			auto* const out = m_midiOutput.get();
+			lock.unlock();
+			m_outputCondition.notify_all();
+			if(out != nullptr)
+				out->sendMessageNow(msg);
 		}
 	}
 }

--- a/source/framework/juce/jucePluginLib/midiports.h
+++ b/source/framework/juce/jucePluginLib/midiports.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <array>
+#include <condition_variable>
 #include <memory>
 #include <mutex>
-
-#include "dsp56kBase/ringbuffer.h"
+#include <thread>
 
 #include "juce_audio_devices/juce_audio_devices.h"
 
@@ -41,7 +42,6 @@ namespace pluginLib
 
 		auto& getProcessor() const { return m_processor; }
 
-		juce::MidiOutput* getMidiOutput() const;
 		juce::MidiInput* getMidiInput() const;
 
 		bool setMidiOutput(const juce::String& _out);
@@ -53,54 +53,30 @@ namespace pluginLib
 		void saveChunkData(baseLib::BinaryStream& _binaryStream) const;
 		void loadChunkData(baseLib::ChunkReader& _cr);
 
-		void send(juce::MidiMessage&& _message)
-		{
-			const std::lock_guard lock(m_mutexOutput);
-			if(m_midiOutput == nullptr)
-				return;
-			m_midiOutMessages.push_back(std::move(_message));
-		}
-
-		void send(const juce::MidiMessage& _message)
-		{
-			const std::lock_guard lock(m_mutexOutput);
-			if(m_midiOutput == nullptr)
-				return;
-			m_midiOutMessages.push_back(_message);
-		}
+		void send(juce::MidiMessage&& _message);
+		void send(const juce::MidiMessage& _message);
 
 		void send(const synthLib::SMidiEvent& _message)
 		{
 			return send(toJuceMidiMessage(_message));
 		}
 
-		bool trySend(const synthLib::SMidiEvent& _message)
-		{
-			const std::unique_lock lock(m_mutexOutput, std::try_to_lock);
-			if(!lock.owns_lock())
-				return false;
-			if(m_midiOutput == nullptr)
-				return true;
-			if(m_midiOutMessages.full())
-				return false;
-			m_midiOutMessages.push_back(toJuceMidiMessage(_message));
-			return true;
-		}
+		bool trySend(const synthLib::SMidiEvent& _message);
 
 		void close();
 
 		static juce::MidiMessage toJuceMidiMessage(const synthLib::SMidiEvent& _e);
 
-		bool isMidiOutValid()
-		{
-			std::lock_guard lock(m_mutexOutput);
-			return m_midiOutput != nullptr;
-		}
+		bool isMidiOutValid() const;
 
 	private:
 	    void handleIncomingMidiMessage(juce::MidiInput* _source, const juce::MidiMessage& _message) override;
 
 		void senderThread();
+		bool outputQueueFull() const { return m_midiOutCount == MidiOutCapacity; }
+		void pushOutputMessage(juce::MidiMessage&& _message);
+		juce::MidiMessage popOutputMessage();
+		void clearOutputMessages();
 
 		Processor& m_processor;
 
@@ -108,8 +84,15 @@ namespace pluginLib
 		std::unique_ptr<juce::MidiInput> m_midiInput{};
 		std::unique_ptr<juce::AudioDeviceManager> m_deviceManager;
 
-		dsp56k::RingBuffer<juce::MidiMessage, 128, true> m_midiOutMessages;
-		std::mutex m_mutexOutput;
+		static constexpr size_t MidiOutCapacity = 128;
+		std::array<juce::MidiMessage, MidiOutCapacity> m_midiOutMessages;
+		size_t m_midiOutRead = 0;
+		size_t m_midiOutWrite = 0;
+		size_t m_midiOutCount = 0;
+		mutable std::mutex m_mutexOutput;
+		std::mutex m_mutexOutputConfiguration;
+		std::condition_variable m_outputCondition;
+		bool m_outputStopping = false;
 		std::unique_ptr<std::thread> m_threadOutput;
 	};
 }

--- a/source/framework/juce/jucePluginLib/midiports.h
+++ b/source/framework/juce/jucePluginLib/midiports.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 
 #include "dsp56kBase/ringbuffer.h"
 
@@ -54,14 +55,16 @@ namespace pluginLib
 
 		void send(juce::MidiMessage&& _message)
 		{
-			if(!isMidiOutValid())
+			const std::lock_guard lock(m_mutexOutput);
+			if(m_midiOutput == nullptr)
 				return;
 			m_midiOutMessages.push_back(std::move(_message));
 		}
 
 		void send(const juce::MidiMessage& _message)
 		{
-			if (!isMidiOutValid())
+			const std::lock_guard lock(m_mutexOutput);
+			if(m_midiOutput == nullptr)
 				return;
 			m_midiOutMessages.push_back(_message);
 		}
@@ -69,6 +72,19 @@ namespace pluginLib
 		void send(const synthLib::SMidiEvent& _message)
 		{
 			return send(toJuceMidiMessage(_message));
+		}
+
+		bool trySend(const synthLib::SMidiEvent& _message)
+		{
+			const std::unique_lock lock(m_mutexOutput, std::try_to_lock);
+			if(!lock.owns_lock())
+				return false;
+			if(m_midiOutput == nullptr)
+				return true;
+			if(m_midiOutMessages.full())
+				return false;
+			m_midiOutMessages.push_back(toJuceMidiMessage(_message));
+			return true;
 		}
 
 		void close();

--- a/source/framework/juce/jucePluginLib/midiports.h
+++ b/source/framework/juce/jucePluginLib/midiports.h
@@ -27,6 +27,58 @@ namespace juce
 namespace pluginLib
 {
 	class Processor;
+	class MidiOutputSink
+	{
+	public:
+		virtual ~MidiOutputSink() = default;
+		virtual juce::String getIdentifier() const = 0;
+		virtual void start() = 0;
+		virtual void stop() = 0;
+		virtual bool isRunning() const = 0;
+		virtual void sendMessageNow(const juce::MidiMessage& _message) = 0;
+	};
+
+	// Fixed-capacity asynchronous output shared by physical MIDI and its controlled
+	// tests. Realtime producers only try the queue lock and never wait; lifecycle
+	// changes stop and join the sole consumer before replacing its sink.
+	class MidiOutputDispatcher
+	{
+	public:
+		static constexpr size_t Capacity = 128;
+
+		MidiOutputDispatcher() = default;
+		~MidiOutputDispatcher();
+		MidiOutputDispatcher(const MidiOutputDispatcher&) = delete;
+		MidiOutputDispatcher(MidiOutputDispatcher&&) = delete;
+		MidiOutputDispatcher& operator=(const MidiOutputDispatcher&) = delete;
+		MidiOutputDispatcher& operator=(MidiOutputDispatcher&&) = delete;
+
+		void send(juce::MidiMessage&& _message);
+		void send(const juce::MidiMessage& _message);
+		bool trySend(juce::MidiMessage&& _message);
+		bool setOutput(std::unique_ptr<MidiOutputSink> _output);
+		void close();
+		bool isValid() const;
+		juce::String getOutputId() const;
+
+	private:
+		void senderThread();
+		bool outputQueueFull() const { return m_count == Capacity; }
+		void push(juce::MidiMessage&& _message);
+		juce::MidiMessage pop();
+		void clear();
+
+		std::unique_ptr<MidiOutputSink> m_output;
+		std::array<juce::MidiMessage, Capacity> m_messages;
+		size_t m_read = 0;
+		size_t m_write = 0;
+		size_t m_count = 0;
+		mutable std::mutex m_mutex;
+		std::mutex m_configurationMutex;
+		std::condition_variable m_condition;
+		bool m_stopping = false;
+		std::unique_ptr<std::thread> m_thread;
+	};
 
 	class MidiPorts : juce::MidiInputCallback
 	{
@@ -72,27 +124,10 @@ namespace pluginLib
 	private:
 	    void handleIncomingMidiMessage(juce::MidiInput* _source, const juce::MidiMessage& _message) override;
 
-		void senderThread();
-		bool outputQueueFull() const { return m_midiOutCount == MidiOutCapacity; }
-		void pushOutputMessage(juce::MidiMessage&& _message);
-		juce::MidiMessage popOutputMessage();
-		void clearOutputMessages();
-
 		Processor& m_processor;
 
-		std::unique_ptr<juce::MidiOutput> m_midiOutput{};
+		MidiOutputDispatcher m_midiOutput;
 		std::unique_ptr<juce::MidiInput> m_midiInput{};
 		std::unique_ptr<juce::AudioDeviceManager> m_deviceManager;
-
-		static constexpr size_t MidiOutCapacity = 128;
-		std::array<juce::MidiMessage, MidiOutCapacity> m_midiOutMessages;
-		size_t m_midiOutRead = 0;
-		size_t m_midiOutWrite = 0;
-		size_t m_midiOutCount = 0;
-		mutable std::mutex m_mutexOutput;
-		std::mutex m_mutexOutputConfiguration;
-		std::condition_variable m_outputCondition;
-		bool m_outputStopping = false;
-		std::unique_ptr<std::thread> m_threadOutput;
 	};
 }

--- a/source/framework/juce/jucePluginLib/processor.cpp
+++ b/source/framework/juce/jucePluginLib/processor.cpp
@@ -97,6 +97,11 @@ namespace pluginLib
 		// Physical output is attempted first: once queued, insertion into the local
 		// synth is allocation-free because prepareToPlay reserves both the normal
 		// ingress capacity and the controller's bounded realtime batch.
+		// Plugin::processMidiInEvents runs before the controller drain in processBlock.
+		// Consequently, a synchronization request queued by the controller/message
+		// thread is already in the device FIFO before a later host publication is
+		// inserted here. Equal-offset insertions append, preserving that wire order;
+		// dump-request revision watermarks rely on this ordering.
 		if(m_midiRoutingMatrix.enabled(_ev, synthLib::MidiEventSource::Physical)
 			&& !m_midiPorts.trySend(_ev))
 			return false;

--- a/source/framework/juce/jucePluginLib/processor.cpp
+++ b/source/framework/juce/jucePluginLib/processor.cpp
@@ -92,6 +92,19 @@ namespace pluginLib
 			m_midiPorts.send(_ev);
 	}
 
+	bool Processor::tryAddRealtimeMidiEvent(const synthLib::SMidiEvent& _ev)
+	{
+		// Physical output is attempted first: once queued, insertion into the local
+		// synth is allocation-free because prepareToPlay reserves both the normal
+		// ingress capacity and the controller's bounded realtime batch.
+		if(m_midiRoutingMatrix.enabled(_ev, synthLib::MidiEventSource::Physical)
+			&& !m_midiPorts.trySend(_ev))
+			return false;
+		if(m_midiRoutingMatrix.enabled(_ev, synthLib::MidiEventSource::Device))
+			getPlugin().insertMidiEvent(_ev);
+		return true;
+	}
+
 	void Processor::handleIncomingMidiMessage(juce::MidiInput *_source, const juce::MidiMessage &_message)
 	{
 		synthLib::SMidiEvent sm(synthLib::MidiEventSource::Physical);
@@ -632,7 +645,8 @@ namespace pluginLib
 
 		getPlugin().setHostSamplerate(static_cast<float>(sampleRate), m_preferredDeviceSamplerate);
 		getPlugin().setBlockSize(samplesPerBlock);
-		getPlugin().reserveMidiEventCapacity();
+		getPlugin().reserveMidiEventCapacity(
+			synthLib::Plugin::RealtimeMidiEventCapacity * 4);
 		getController().prepareRealtimeMidiIngress(synthLib::Plugin::RealtimeMidiEventCapacity);
 		m_midiOut.reserve(synthLib::Plugin::RealtimeMidiEventCapacity);
 		{
@@ -776,6 +790,9 @@ namespace pluginLib
 		}
 
 		midiMessages.clear();
+
+		getController().processRealtimeParameterChanges(
+			synthLib::Plugin::RealtimeMidiEventCapacity);
 
 		bool isPlaying = true;
 		float bpm = 0.0f;

--- a/source/framework/juce/jucePluginLib/processor.h
+++ b/source/framework/juce/jucePluginLib/processor.h
@@ -69,6 +69,7 @@ namespace pluginLib
 		~Processor() override;
 
 		void addMidiEvent(const synthLib::SMidiEvent& _ev);
+		bool tryAddRealtimeMidiEvent(const synthLib::SMidiEvent& _ev);
 
 		void handleIncomingMidiMessage(juce::MidiInput* _source, const juce::MidiMessage& _message);
 


### PR DESCRIPTION
## Summary

- correlate Global and Kit dumps with the active slot and an outstanding request, and strictly validate SET STATUS framing and ranges
- move host automation callbacks onto a fixed-capacity lock-free queue with bounded audio-thread delivery and nonblocking physical MIDI output
- publish snapshot values atomically, reject snapshots during incomplete synchronization, and preserve/replay host intent while the MIDI base channel is NONE
- add MD/MM regression coverage for malformed messages, stale and wrong-slot dumps, queue concurrency/capacity, snapshot publication, and NONE-to-enabled replay
- preserve the newly merged UW read-only synchronization-request path during the rebase

## Validation

- mdAutomationMidiTest: PASS
- mdAutomationParameterTest: PASS
- mdAutomationRobustnessTest: compiled and linked successfully against the current release tip
- git diff --check: PASS

The local firmware-backed executable could not reach the pre-existing isAudioReady boot checkpoint on this host, even after 180,000 emulated blocks with shared-memory JIT enabled. It timed out before any Global/Kit request or changed test assertion ran, so firmware-backed execution remains unverified here.

## Remaining limitations

- Elektron dump messages have no transaction ID. Slot plus outstanding-request correlation rejects wrong-slot and unsolicited late dumps, but a delayed response for the same slot is indistinguishable from the current response; periodic Global refresh provides convergence.
- The realtime queue is deliberately bounded at 4,096 changes. Exceptional overflow coalesces to the newest value per parameter and increments exposed telemetry, so intermediate values can be dropped under a producer flood.
- Host-specific automation-lane behavior still needs a manual pass in the target DAWs.