### PR TITLE
Add Machinedrum +Drive emulation and project storage

### DIFF
--- a/.github/workflows/mdmm-core.yml
+++ b/.github/workflows/mdmm-core.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Build asset-free core tests
         run: >-
           cmake --build build --config Release --parallel 3
-          --target dsp56kTestRunner mdLibTest mdProfileWorkload
+          --target dsp56kTestRunner mdLibTest mdPlusDriveTest mdStateTest mdProfileWorkload
 
       - name: Build ColdFire divide regression test
         if: runner.os != 'Windows'
@@ -83,7 +83,7 @@ jobs:
       - name: Run asset-free core tests
         run: >-
           ctest --test-dir build -C Release --output-on-failure
-          --tests-regex "^(dsp56300_unitTests|mc68kColdFireDivideTest|mdLibTests|mdProfileWorkload(Bounded)?Tests)$"
+          --tests-regex "^(dsp56300_unitTests|mc68kColdFireDivideTest|mdLibTests|mdPlusDriveTest|mdStateTest|mdProfileWorkload(Bounded)?Tests)$"
 
   apple-pgo:
     name: Apple PGO generate and use
@@ -147,6 +147,6 @@ jobs:
       - name: Build and test profile use
         run: |
           cmake --build build-use --config Release --parallel 3 \
-            --target mdLibTest mdProfileWorkload
+            --target mdLibTest mdPlusDriveTest mdStateTest mdProfileWorkload
           ctest --test-dir build-use -C Release --output-on-failure \
-            --tests-regex "^(mdLibTests|mdProfileWorkload(Bounded)?Tests)$"
+            --tests-regex "^(mdLibTests|mdPlusDriveTest|mdStateTest|mdProfileWorkload(Bounded)?Tests)$"

--- a/doc/machinedrum_plusdrive_persistence.md
+++ b/doc/machinedrum_plusdrive_persistence.md
@@ -1,0 +1,48 @@
+# Machinedrum +Drive persistence
+
+The emulated Machinedrum has two intentionally different persistence owners:
+
+- A plug-in instance keeps its +Drive inside the host project state. It never
+  writes an implicit external mirror, so two projects cannot overwrite one
+  another's machine data.
+- The standalone application keeps one fixed checkpoint in the Machinedrum user
+  data directory. One process owns that file for its whole session. Additional
+  standalone processes are read-only and explain that they must be restarted
+  after the writer closes before they can persist changes.
+
+On the first launch after upgrading, the standalone imports the +Drive contained
+in JUCE's existing `filterState` setting if no dedicated checkpoint exists. Once
+the checkpoint has been created, it is authoritative and a stale `filterState`
+cannot roll it back on later launches.
+
+Standalone writes settle for about one second and are then atomically replaced.
+A clean quit performs a final flush. A forced termination during the settling
+window may lose only the newest unsettled change; it must leave the preceding
+checkpoint valid. An invalid checkpoint is preserved and blocks automatic writes
+until the user explicitly imports a valid image or creates a blank +Drive.
+
+## State-size bound
+
+The sparse MDPD format uses 16 bytes plus 516 bytes for each stored 512-byte
+sector. Its defensive serialized-image limit is 512 MiB. The largest valid image
+below that limit contains 1,040,447 records and is 536,870,668 bytes. With the
+1 MiB battery-backed machine snapshot and the version-4 header, the corresponding
+minimal-flash project payload is 537,919,304 bytes (just under 513 MiB), before
+the small outer plug-in envelope.
+
+That is a safety bound, not a recommended working size. Host-specific plug-in
+state limits can be lower, and a heavily populated +Drive also requires multiple
+in-memory copies while a project is saved or restored. Normal freshly formatted
+and selectively populated sparse images are much smaller. Users approaching very
+large images should export an `.mdpd` backup and verify the intended DAW's save and
+reload behavior.
+
+The opt-in `mdPlusDriveStateWorkload` target constructs the exact bounded maximum,
+encodes it into project state, decodes it, and reports byte counts, timings, and
+peak resident memory where the platform exposes it. It is deliberately not a
+normal CTest because its purpose is to exercise the roughly 513 MiB boundary.
+
+On the 2026-09-01 arm64 macOS Release validation run, the maximum workload encoded
+in 4.245 seconds, decoded and verified in 4.298 seconds, and reported a peak
+resident set of 1,639,645,184 bytes (about 1.53 GiB). These are diagnostic numbers,
+not a cross-platform performance promise.

--- a/scripts/macos/build_mdmm.sh
+++ b/scripts/macos/build_mdmm.sh
@@ -51,10 +51,11 @@ cmake --build "${build_dir}" --parallel 4 --target \
   mdJucePlugin_Standalone \
   mmJucePlugin_Standalone \
   pluginTester \
-  mdLibTest
+  mdLibTest \
+  mdStandalonePlusDrivePersistenceTest
 
 ctest --test-dir "${build_dir}" -C Release --output-on-failure \
-  --tests-regex '^mdLibTests$'
+  --tests-regex '^(mdLibTests|mdStandalonePlusDrivePersistenceTest)$'
 
 artifact_root="${source_dir}/bin/plugins/Release"
 md_app="${artifact_root}/Standalone/Gearmulator MD.app"

--- a/scripts/windows/build_mdmm.ps1
+++ b/scripts/windows/build_mdmm.ps1
@@ -144,7 +144,10 @@ if (-not $TestOnly) {
         'mmJucePlugin_Standalone',
         'pluginTester'
     )
-    if ($WithTests) { $targets += 'mdLibTest' }
+    if ($WithTests) {
+        $targets += 'mdLibTest'
+        $targets += 'mdStandalonePlusDrivePersistenceTest'
+    }
     Invoke-Native -FilePath $cmake -Arguments (@(
         '--build', $BuildDir,
         '--config', $Configuration,
@@ -161,7 +164,7 @@ if ($WithTests) {
         '--test-dir', $BuildDir,
         '-C', $Configuration,
         '--output-on-failure',
-        '--tests-regex', '^mdLibTests$'
+        '--tests-regex', '^(mdLibTests|mdStandalonePlusDrivePersistenceTest)$'
     )
 }
 

--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -131,6 +131,7 @@ if(BUILD_TESTING)
 	set_property(TARGET mdStandalonePlusDrivePersistenceTest PROPERTY FOLDER "Elektron/test")
 	add_test(NAME mdStandalonePlusDrivePersistenceTest
 		COMMAND mdStandalonePlusDrivePersistenceTest)
+	set_tests_properties(mdStandalonePlusDrivePersistenceTest PROPERTIES TIMEOUT 60)
 
 	option(MD_AUTOMATION_REGISTER_FULL_SOAK_TEST
 		"Register the full MD/MM automation soak with CTest" OFF)

--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES
 	mdProductSkinPolicy.h
 	mdProductSkins.h
 	mdPluginProcessor.cpp mdPluginProcessor.h
+	mdStandalonePlusDrivePersistence.cpp mdStandalonePlusDrivePersistence.h
 	mdStorageImage.cpp mdStorageImage.h
 	mdPluginEntry.cpp
 
@@ -118,6 +119,18 @@ if(BUILD_TESTING)
 		--soak-writes=256 --multi-writes=128)
 	set_tests_properties(mdAutomationSoakTest PROPERTIES
 		LABELS "Integration" TIMEOUT 300)
+
+	add_executable(mdStandalonePlusDrivePersistenceTest
+		mdStandalonePlusDrivePersistenceTest.cpp)
+	target_link_libraries(mdStandalonePlusDrivePersistenceTest PRIVATE
+		mdJucePlugin jucePluginEditorLib mdLib juce_plugin_modules)
+	target_include_directories(mdStandalonePlusDrivePersistenceTest PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+	target_compile_definitions(mdStandalonePlusDrivePersistenceTest PRIVATE
+		JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1)
+	set_property(TARGET mdStandalonePlusDrivePersistenceTest PROPERTY FOLDER "Elektron/test")
+	add_test(NAME mdStandalonePlusDrivePersistenceTest
+		COMMAND mdStandalonePlusDrivePersistenceTest)
 
 	option(MD_AUTOMATION_REGISTER_FULL_SOAK_TEST
 		"Register the full MD/MM automation soak with CTest" OFF)

--- a/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
@@ -1,7 +1,13 @@
 #include "mdAutomationTestSupport.h"
 
+#include "mdLib/mdplusdrive.h"
+
+#include "baseLib/filesystem.h"
+
+#include <chrono>
 #include <iostream>
 #include <string>
+#include <thread>
 
 namespace
 {
@@ -12,6 +18,192 @@ namespace
 		auto* const result = _controller.getParameter("Level", 0);
 		require(result != nullptr, "test parameter was not registered");
 		return *result;
+	}
+
+	std::vector<uint8_t> makePlusDriveImage(const uint32_t _sector,
+		const uint8_t _value)
+	{
+		md::PlusDrive drive;
+		auto image = drive.copyStorage();
+		image[15] = 1;
+		image.push_back(static_cast<uint8_t>(_sector >> 24));
+		image.push_back(static_cast<uint8_t>(_sector >> 16));
+		image.push_back(static_cast<uint8_t>(_sector >> 8));
+		image.push_back(static_cast<uint8_t>(_sector));
+		image.insert(image.end(), 512, _value);
+		require(md::PlusDrive::validateStorage(image),
+			"test +Drive image was invalid");
+		return image;
+	}
+
+	std::vector<uint8_t> copyPlusDrive(Harness& _harness)
+	{
+		std::vector<uint8_t> result;
+		require(_harness.processor.getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				if(!device)
+					return false;
+				result = device->getHardware().copyPlusDriveData();
+				return true;
+			}), "could not capture +Drive data");
+		return result;
+	}
+
+	void installPlusDrive(Harness& _harness, const std::vector<uint8_t>& _image)
+	{
+		require(_harness.processor.getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				return device && device->getHardware().replacePlusDriveData(_image, true);
+			}), "could not install test +Drive data");
+	}
+
+	bool firmwareAudioReady(Harness& _harness)
+	{
+		bool ready = false;
+		_harness.processor.getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
+			{
+				if(const auto* const device = dynamic_cast<md::Device*>(_device))
+					ready = device->getHardware().isAudioReady();
+			});
+		return ready;
+	}
+
+	struct MdBootStatus
+	{
+		bool audioReady = false;
+		bool factoryFlashReady = false;
+		size_t plusDriveSectors = 0;
+		uint64_t plusDriveCommands = 0;
+	};
+
+	MdBootStatus mdBootStatus(Harness& _harness)
+	{
+		MdBootStatus status;
+		_harness.processor.getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
+			{
+				if(auto* const device = dynamic_cast<md::Device*>(_device))
+				{
+					auto& hardware = device->getHardware();
+					status.audioReady = hardware.isAudioReady();
+					status.factoryFlashReady = hardware.factoryFlashCacheReady();
+					status.plusDriveSectors = hardware.getUC().getSim()
+						.getPlusDrive().storedSectorCount();
+					status.plusDriveCommands = hardware.getUC().getSim()
+						.getPlusDrive().commandCount();
+				}
+			});
+		return status;
+	}
+
+	void verifyPlusDriveLifecycle(Harness& _harness)
+	{
+		const auto imageA = makePlusDriveImage(7, 0x5a);
+		const auto imageB = makePlusDriveImage(9, 0x27);
+		installPlusDrive(_harness, imageA);
+
+		// A second running instance must own an independent image even when both
+		// devices started from the same one-time legacy migration source.
+		Harness second(md::MachineModel::Machinedrum);
+		if(second.hasLocalFirmware())
+		{
+			const auto secondBefore = copyPlusDrive(second);
+			installPlusDrive(_harness, imageB);
+			require(copyPlusDrive(second) == secondBefore,
+				"one MD instance changed another instance's +Drive");
+			installPlusDrive(_harness, imageA);
+		}
+
+		const auto nonce = std::chrono::steady_clock::now()
+			.time_since_epoch().count();
+		const auto directory = juce::File::getCurrentWorkingDirectory();
+		const auto exported = directory.getChildFile(
+			"gearmulator-md-plusdrive-export-" + juce::String(nonce) + ".mdpd");
+		const auto mirror = directory.getChildFile(
+			"gearmulator-md-plusdrive-mirror-" + juce::String(nonce) + ".mdpd");
+		struct Cleanup final
+		{
+			mdJucePlugin::AudioPluginAudioProcessor& processor;
+			const juce::File& first;
+			const juce::File& second;
+			~Cleanup()
+			{
+				processor.disablePlusDriveAutoSave();
+				first.deleteFile();
+				second.deleteFile();
+			}
+		} cleanup{_harness.processor, exported, mirror};
+		exported.deleteFile();
+		mirror.deleteFile();
+
+		juce::String result;
+		require(_harness.processor.exportPlusDriveImage(exported, result),
+			"explicit +Drive export failed: " + result.toStdString());
+		installPlusDrive(_harness, imageB);
+		require(_harness.processor.importPlusDriveImage(exported, result),
+			"explicit +Drive import failed: " + result.toStdString());
+		require(copyPlusDrive(_harness) == imageA,
+			"import did not restore the exported +Drive image");
+
+		const std::vector<uint8_t> corrupt{1, 2, 3, 4};
+		require(baseLib::filesystem::writeFileAtomic(
+			exported.getFullPathName().toStdString(), corrupt),
+			"could not create corrupt +Drive test input");
+		require(!_harness.processor.importPlusDriveImage(exported, result),
+			"corrupt +Drive import was accepted");
+		require(copyPlusDrive(_harness) == imageA,
+			"failed +Drive import changed live storage");
+
+		require(_harness.processor.enablePlusDriveAutoSave(mirror, result),
+			"could not enable +Drive mirror: " + result.toStdString());
+		{
+			Harness competing(md::MachineModel::Machinedrum);
+			if(competing.hasLocalFirmware())
+			{
+				juce::String competingResult;
+				require(!competing.processor.enablePlusDriveAutoSave(
+					mirror, competingResult),
+					"two running instances claimed the same +Drive mirror");
+			}
+		}
+		installPlusDrive(_harness, imageB);
+		std::vector<uint8_t> mirrored;
+		for(int attempt = 0; attempt < 80; ++attempt)
+		{
+			if(baseLib::filesystem::readFile(
+				mirrored, mirror.getFullPathName().toStdString()) && mirrored == imageB)
+				break;
+			std::this_thread::sleep_for(std::chrono::milliseconds(50));
+		}
+		require(mirrored == imageB,
+			"debounced +Drive mirror did not reach the newest generation");
+		installPlusDrive(_harness, imageA);
+		_harness.processor.disablePlusDriveAutoSave();
+		mirrored.clear();
+		require(baseLib::filesystem::readFile(
+			mirrored, mirror.getFullPathName().toStdString()) && mirrored == imageA,
+			"disabling the mirror lost a write inside the debounce window");
+
+		// Reboot must retain all battery-backed Snapshot bytes (kits, patterns,
+		// songs and globals), UW flash, and the project-owned +Drive.
+		std::vector<uint8_t> stateBefore;
+		require(_harness.processor.getPlugin().getState(
+			stateBefore, synthLib::StateTypeGlobal),
+			"could not capture state before reboot");
+		require(_harness.processor.rebootDevice(),
+			"transactional Machinedrum reboot failed");
+		std::vector<uint8_t> stateAfter;
+		require(_harness.processor.getPlugin().getState(
+			stateAfter, synthLib::StateTypeGlobal),
+			"could not capture state after reboot");
+		require(stateAfter == stateBefore,
+			"reboot changed project-owned Machinedrum storage");
+
 	}
 
 	void verifyModel(const md::MachineModel _model)
@@ -28,6 +220,48 @@ namespace
 
 		auto& audioProcessor = harness.audioProcessor;
 		auto& controller = harness.controller;
+		if(_model == md::MachineModel::Machinedrum)
+		{
+			// A blank +Drive is formatted during the first 1.63 boot. The original
+			// automation request predates that work, and the firmware asks for a
+			// reboot afterward. Preserve the newly formatted project drive across that
+			// reboot, then ask for automation state again.
+			MdBootStatus firstBoot;
+			MdBootStatus previousBoot;
+			int stableIntervals = 0;
+			for(int attempt = 0; attempt < 30; ++attempt)
+			{
+				harness.process(1000);
+				firstBoot = mdBootStatus(harness);
+				if(firstBoot.plusDriveSectors != 0
+					&& firstBoot.plusDriveSectors == previousBoot.plusDriveSectors
+					&& firstBoot.plusDriveCommands == previousBoot.plusDriveCommands)
+					++stableIntervals;
+				else
+					stableIntervals = 0;
+				previousBoot = firstBoot;
+				if(firstBoot.audioReady && firstBoot.factoryFlashReady
+					&& stableIntervals >= 2)
+					break;
+			}
+			std::cerr << "MD first boot: audio " << firstBoot.audioReady
+				<< ", factory flash " << firstBoot.factoryFlashReady
+				<< ", +Drive sectors " << firstBoot.plusDriveSectors
+				<< ", commands " << firstBoot.plusDriveCommands << '\n';
+			require(firstBoot.audioReady && firstBoot.factoryFlashReady
+				&& stableIntervals >= 2,
+				"Machinedrum did not finish formatting its blank +Drive");
+			require(harness.processor.rebootDevice(),
+				"post-format Machinedrum reboot failed");
+			require(mdBootStatus(harness).factoryFlashReady,
+				"Machinedrum reboot discarded its validated in-memory UW factory cache");
+			// Audio-ready goes true before the main CPU has finished the +Drive boot
+			// path. Match the 20-second firmware acceptance test before sending SysEx.
+			harness.process(9000);
+				require(firmwareAudioReady(harness),
+					"Machinedrum audio did not become ready after +Drive format");
+			controller.requestAutomationState();
+		}
 		require(harness.synchronize(),
 			"initial firmware synchronization timed out (global "
 			+ std::to_string(controller.hasAutomationGlobalSnapshot()) + ", kit "
@@ -118,6 +352,8 @@ namespace
 		require(controller.getTransmittedAutomationChangeCount()
 			>= beforeRestoreFlush + audioProcessor.getParameters().size(),
 			"DAW-state automation snapshot was not flushed back to firmware");
+		if(_model == md::MachineModel::Machinedrum)
+			verifyPlusDriveLifecycle(harness);
 
 		std::cout << "mdAutomationFirmwareTest: "
 			<< modelName(_model)

--- a/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
@@ -7,6 +7,8 @@
 #include <chrono>
 #include <iostream>
 #include <string>
+#include <thread>
+#include <utility>
 
 namespace
 {
@@ -50,6 +52,22 @@ namespace
 		return result;
 	}
 
+	std::vector<uint8_t> copyPlusDrive(
+		mdJucePlugin::AudioPluginAudioProcessor& _processor)
+	{
+		std::vector<uint8_t> result;
+		require(_processor.getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				if(!device)
+					return false;
+				result = device->getHardware().copyPlusDriveData();
+				return true;
+			}), "could not capture standalone +Drive data");
+		return result;
+	}
+
 	void installPlusDrive(Harness& _harness, const std::vector<uint8_t>& _image)
 	{
 		require(_harness.processor.getPlugin().withDeviceLocked(
@@ -58,6 +76,89 @@ namespace
 				auto* const device = dynamic_cast<md::Device*>(_device);
 				return device && device->getHardware().replacePlusDriveData(_image, true);
 			}), "could not install test +Drive data");
+	}
+
+	void installPlusDrive(mdJucePlugin::AudioPluginAudioProcessor& _processor,
+		const std::vector<uint8_t>& _image)
+	{
+		require(_processor.getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				return device && device->getHardware().replacePlusDriveData(_image, true);
+			}), "could not install standalone test +Drive data");
+	}
+
+	bool waitForImage(const juce::File& _file,
+		const std::vector<uint8_t>& _expected)
+	{
+		for(int attempt = 0; attempt < 100; ++attempt)
+		{
+			std::vector<uint8_t> actual;
+			if(baseLib::filesystem::readFile(actual,
+				_file.getFullPathName().toStdString()) && actual == _expected)
+				return true;
+			std::this_thread::sleep_for(std::chrono::milliseconds(50));
+		}
+		return false;
+	}
+
+	void verifyStandaloneFilterStateMigration(Harness& _harness,
+		const std::vector<uint8_t>& _imageA,
+		const std::vector<uint8_t>& _imageB)
+	{
+		installPlusDrive(_harness, _imageA);
+		juce::MemoryBlock legacyFilterState;
+		_harness.audioProcessor.getStateInformation(legacyFilterState);
+		require(!legacyFilterState.isEmpty(),
+			"could not capture legacy JUCE standalone filterState");
+
+		const auto directory = juce::File::getCurrentWorkingDirectory()
+			.getNonexistentChildFile("gearmulator-md-filterstate-migration", {}, false);
+		require(directory.createDirectory().wasOk(),
+			"could not create isolated standalone migration directory");
+		struct Cleanup final
+		{
+			juce::File directory;
+			~Cleanup() { directory.deleteRecursively(); }
+		} cleanup{directory};
+		const auto checkpoint = directory.getChildFile("standalone.mdpd");
+
+		{
+			mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig config;
+			config.standalonePlusDriveFile = checkpoint;
+			mdJucePlugin::AudioPluginAudioProcessor standalone(
+				md::MachineModel::Machinedrum, std::move(config), false);
+			static_cast<juce::AudioProcessor&>(standalone).setStateInformation(
+				legacyFilterState.getData(),
+				static_cast<int>(legacyFilterState.getSize()));
+			require(waitForImage(checkpoint, _imageA),
+				"first standalone launch did not migrate JUCE filterState into its checkpoint");
+
+			installPlusDrive(standalone, _imageB);
+		}
+		require(waitForImage(checkpoint, _imageB),
+			"clean standalone quit did not flush the unsettled +Drive change");
+
+		{
+			mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig config;
+			config.standalonePlusDriveFile = checkpoint;
+			mdJucePlugin::AudioPluginAudioProcessor relaunched(
+				md::MachineModel::Machinedrum, std::move(config), false);
+			require(copyPlusDrive(relaunched) == _imageB,
+				"standalone relaunch did not restore the dedicated checkpoint");
+
+			// JUCE's StandalonePluginHolder reloads filterState after constructing the
+			// processor. Once the dedicated checkpoint exists, that older blob must not
+			// roll the +Drive back during every launch.
+			static_cast<juce::AudioProcessor&>(relaunched).setStateInformation(
+				legacyFilterState.getData(),
+				static_cast<int>(legacyFilterState.getSize()));
+			require(copyPlusDrive(relaunched) == _imageB,
+				"stale JUCE filterState overrode the standalone checkpoint");
+			require(waitForImage(checkpoint, _imageB),
+				"stale JUCE filterState changed the standalone checkpoint");
+		}
 	}
 
 	bool firmwareAudioReady(Harness& _harness)
@@ -166,6 +267,7 @@ namespace
 		require(stateAfter == stateBefore,
 			"reboot changed project-owned Machinedrum storage");
 
+		verifyStandaloneFilterStateMigration(_harness, imageA, imageB);
 	}
 
 	void verifyModel(const md::MachineModel _model)

--- a/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
@@ -7,7 +7,6 @@
 #include <chrono>
 #include <iostream>
 #include <string>
-#include <thread>
 
 namespace
 {
@@ -124,22 +123,15 @@ namespace
 		const auto directory = juce::File::getCurrentWorkingDirectory();
 		const auto exported = directory.getChildFile(
 			"gearmulator-md-plusdrive-export-" + juce::String(nonce) + ".mdpd");
-		const auto mirror = directory.getChildFile(
-			"gearmulator-md-plusdrive-mirror-" + juce::String(nonce) + ".mdpd");
 		struct Cleanup final
 		{
-			mdJucePlugin::AudioPluginAudioProcessor& processor;
-			const juce::File& first;
-			const juce::File& second;
+			const juce::File& file;
 			~Cleanup()
 			{
-				processor.disablePlusDriveAutoSave();
-				first.deleteFile();
-				second.deleteFile();
+				file.deleteFile();
 			}
-		} cleanup{_harness.processor, exported, mirror};
+		} cleanup{exported};
 		exported.deleteFile();
-		mirror.deleteFile();
 
 		juce::String result;
 		require(_harness.processor.exportPlusDriveImage(exported, result),
@@ -158,36 +150,6 @@ namespace
 			"corrupt +Drive import was accepted");
 		require(copyPlusDrive(_harness) == imageA,
 			"failed +Drive import changed live storage");
-
-		require(_harness.processor.enablePlusDriveAutoSave(mirror, result),
-			"could not enable +Drive mirror: " + result.toStdString());
-		{
-			Harness competing(md::MachineModel::Machinedrum);
-			if(competing.hasLocalFirmware())
-			{
-				juce::String competingResult;
-				require(!competing.processor.enablePlusDriveAutoSave(
-					mirror, competingResult),
-					"two running instances claimed the same +Drive mirror");
-			}
-		}
-		installPlusDrive(_harness, imageB);
-		std::vector<uint8_t> mirrored;
-		for(int attempt = 0; attempt < 80; ++attempt)
-		{
-			if(baseLib::filesystem::readFile(
-				mirrored, mirror.getFullPathName().toStdString()) && mirrored == imageB)
-				break;
-			std::this_thread::sleep_for(std::chrono::milliseconds(50));
-		}
-		require(mirrored == imageB,
-			"debounced +Drive mirror did not reach the newest generation");
-		installPlusDrive(_harness, imageA);
-		_harness.processor.disablePlusDriveAutoSave();
-		mirrored.clear();
-		require(baseLib::filesystem::readFile(
-			mirrored, mirror.getFullPathName().toStdString()) && mirrored == imageA,
-			"disabling the mirror lost a write inside the debounce window");
 
 		// Reboot must retain all battery-backed Snapshot bytes (kits, patterns,
 		// songs and globals), UW flash, and the project-owned +Drive.

--- a/source/elektron/md/mdJucePlugin/mdController.cpp
+++ b/source/elektron/md/mdJucePlugin/mdController.cpp
@@ -205,10 +205,9 @@ namespace mdJucePlugin
 		// these exact read-only requests and keeps them factory-baseline-neutral.
 		synthLib::SMidiEvent event(synthLib::MidiEventSource::Editor);
 		event.sysex = _message;
-		// These are private firmware queries, not editor-originated MIDI. Keep the
-		// Internal tag so they cannot disqualify the UW factory-flash baseline, but
-		// bypass the user routing matrix: its default intentionally does not route
-		// generic Internal traffic to the device.
+		// These are private, read-only firmware queries. Keep the Editor tag used by
+		// Hardware to recognize them as baseline-neutral, but bypass the user routing
+		// matrix so synchronization does not depend on its current configuration.
 		getProcessor().getPlugin().addMidiEvent(event);
 	}
 

--- a/source/elektron/md/mdJucePlugin/mdController.cpp
+++ b/source/elektron/md/mdJucePlugin/mdController.cpp
@@ -205,7 +205,11 @@ namespace mdJucePlugin
 		// these exact read-only requests and keeps them factory-baseline-neutral.
 		synthLib::SMidiEvent event(synthLib::MidiEventSource::Editor);
 		event.sysex = _message;
-		sendMidiEvent(event);
+		// These are private firmware queries, not editor-originated MIDI. Keep the
+		// Internal tag so they cannot disqualify the UW factory-flash baseline, but
+		// bypass the user routing matrix: its default intentionally does not route
+		// generic Internal traffic to the device.
+		getProcessor().getPlugin().addMidiEvent(event);
 	}
 
 	void Controller::onControllerTimer()

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -1133,6 +1133,196 @@ namespace mdJucePlugin
 			_message.toStdString(), getRmlComponent());
 	}
 
+	void Editor::choosePlusDriveImport()
+	{
+		choosePlusDriveFile(PlusDriveFileOperation::Import);
+	}
+
+	void Editor::choosePlusDriveExport()
+	{
+		choosePlusDriveFile(PlusDriveFileOperation::Export);
+	}
+
+	void Editor::choosePlusDriveAutoSave()
+	{
+		choosePlusDriveFile(PlusDriveFileOperation::AutoSave);
+	}
+
+	void Editor::choosePlusDriveFile(const PlusDriveFileOperation _operation)
+	{
+		if(m_model != md::MachineModel::Machinedrum)
+			return;
+		if(!jucePluginEditorLib::fileChooserFlow::tryBegin(m_storageImageFlow,
+			StorageImageFlow::None, StorageImageFlow::Choosing))
+		{
+			showPlusDriveOperationResult(false,
+				"Finish the open +Drive image dialog first.");
+			return;
+		}
+
+		auto* const processor = dynamic_cast<AudioPluginAudioProcessor*>(&getProcessor());
+		juce::File initial;
+		if(processor && _operation == PlusDriveFileOperation::AutoSave
+			&& processor->plusDriveAutoSaveEnabled())
+			initial = processor->getPlusDriveAutoSaveFile();
+		if(initial == juce::File())
+		{
+			const auto lastDirectory = getProcessor().getConfig().getValue(
+				"mdPlusDriveImageLastDirectory");
+			initial = lastDirectory.isNotEmpty()
+				? juce::File(lastDirectory)
+				: juce::File::getSpecialLocation(juce::File::userDocumentsDirectory);
+		}
+		if(_operation != PlusDriveFileOperation::Import && initial.isDirectory())
+			initial = initial.getChildFile("Machinedrum-PlusDrive.mdpd");
+
+		const char* title = _operation == PlusDriveFileOperation::Import
+			? "Import a sparse Machinedrum +Drive image"
+			: (_operation == PlusDriveFileOperation::Export
+				? "Export this project's Machinedrum +Drive"
+				: "Choose an automatic +Drive mirror image");
+		m_storageFileChooser = std::make_unique<juce::FileChooser>(
+			title, initial, "*.mdpd;*.bin", true);
+		const auto safeRoot =
+			juce::Component::SafePointer<juceRmlUi::RmlComponent>(getRmlComponent());
+		const std::function<void(const juce::FileChooser&)> completion =
+			jucePluginEditorLib::fileChooserFlow::makeGuardedCompletion(
+				safeRoot, &m_storageImageFlow, StorageImageFlow::Choosing,
+				StorageImageFlow::None,
+				[this, _operation](const juce::FileChooser& _chooser)
+				{
+					auto file = _chooser.getResult();
+					if(file == juce::File())
+						return;
+					if(_operation != PlusDriveFileOperation::Import
+						&& file.getFileExtension().isEmpty())
+						file = file.withFileExtension(".mdpd");
+					auto& config = getProcessor().getConfig();
+					config.setValue("mdPlusDriveImageLastDirectory",
+						file.getParentDirectory().getFullPathName());
+					config.saveIfNeeded();
+					if(_operation == PlusDriveFileOperation::Import)
+					{
+						if(file.existsAsFile())
+							confirmPlusDriveImport(file);
+						return;
+					}
+					auto* const processor = dynamic_cast<AudioPluginAudioProcessor*>(
+						&getProcessor());
+					if(!processor)
+						return;
+					juce::String result;
+					const bool success = _operation == PlusDriveFileOperation::Export
+						? processor->exportPlusDriveImage(file, result)
+						: processor->enablePlusDriveAutoSave(file, result);
+					showPlusDriveOperationResult(success, result);
+				});
+		const auto flags = _operation == PlusDriveFileOperation::Import
+			? juce::FileBrowserComponent::openMode
+				| juce::FileBrowserComponent::canSelectFiles
+			: juce::FileBrowserComponent::saveMode
+				| juce::FileBrowserComponent::canSelectFiles
+				| juce::FileBrowserComponent::warnAboutOverwriting;
+		m_storageFileChooser->launchAsync(flags, completion);
+	}
+
+	void Editor::confirmPlusDriveImport(const juce::File& _file)
+	{
+		if(!jucePluginEditorLib::fileChooserFlow::tryBegin(m_storageImageFlow,
+			StorageImageFlow::None, StorageImageFlow::AwaitingConfirmation))
+			return;
+		const auto safeRoot =
+			juce::Component::SafePointer<juceRmlUi::RmlComponent>(getRmlComponent());
+		const genericUI::MessageBox::Callback completion =
+			jucePluginEditorLib::fileChooserFlow::makeGuardedCompletion(
+				safeRoot, &m_storageImageFlow,
+				StorageImageFlow::AwaitingConfirmation, StorageImageFlow::None,
+				[this, file = _file](const genericUI::MessageBox::Result _answer)
+				{
+					if(_answer != genericUI::MessageBox::Result::Yes)
+						return;
+					auto* const processor = dynamic_cast<AudioPluginAudioProcessor*>(
+						&getProcessor());
+					if(!processor)
+						return;
+					juce::String result;
+					const bool success = processor->importPlusDriveImage(file, result);
+					showPlusDriveOperationResult(success, result);
+				});
+		genericUI::MessageBox::showYesNo(genericUI::MessageBox::Icon::Warning,
+			"Replace project +Drive?",
+			("Import '" + _file.getFileName()
+				+ "'?\n\nThis replaces every +Drive Snapshot and sample bank in this plug-in instance, then reboots the Machinedrum. Export the current +Drive first if you need a separate recovery image.")
+				.toStdString(), completion);
+	}
+
+	void Editor::disablePlusDriveAutoSave()
+	{
+		if(auto* const processor = dynamic_cast<AudioPluginAudioProcessor*>(&getProcessor()))
+		{
+			processor->disablePlusDriveAutoSave();
+			const auto status = processor->getPlusDrivePersistenceStatus();
+			showPlusDriveOperationResult(!status.containsIgnoreCase("failed"), status);
+		}
+	}
+
+	void Editor::resetPlusDrive()
+	{
+		if(!jucePluginEditorLib::fileChooserFlow::tryBegin(m_storageImageFlow,
+			StorageImageFlow::None, StorageImageFlow::AwaitingConfirmation))
+			return;
+		const auto safeRoot =
+			juce::Component::SafePointer<juceRmlUi::RmlComponent>(getRmlComponent());
+		const genericUI::MessageBox::Callback completion =
+			jucePluginEditorLib::fileChooserFlow::makeGuardedCompletion(
+				safeRoot, &m_storageImageFlow,
+				StorageImageFlow::AwaitingConfirmation, StorageImageFlow::None,
+				[this](const genericUI::MessageBox::Result _answer)
+				{
+					if(_answer != genericUI::MessageBox::Result::Yes)
+						return;
+					auto* const processor = dynamic_cast<AudioPluginAudioProcessor*>(
+						&getProcessor());
+					if(!processor)
+						return;
+					juce::String result;
+					const bool success = processor->resetPlusDrive(result);
+					showPlusDriveOperationResult(success, result);
+				});
+		genericUI::MessageBox::showYesNo(genericUI::MessageBox::Icon::Warning,
+			"Create blank +Drive?",
+			"This erases every +Drive Snapshot and sample bank in this plug-in instance, then reboots the Machinedrum. The firmware will format the blank drive and may ask for one more reboot.",
+			completion);
+	}
+
+	void Editor::rebootMachinedrum()
+	{
+		if(auto* const processor = dynamic_cast<AudioPluginAudioProcessor*>(&getProcessor()))
+		{
+			juce::String result;
+			const bool success = processor->rebootMachinedrum(result);
+			showPlusDriveOperationResult(success, result);
+		}
+	}
+
+	std::string Editor::plusDriveStatusText() const
+	{
+		if(auto* const processor = dynamic_cast<const AudioPluginAudioProcessor*>(
+			&getProcessor()))
+			return processor->getPlusDrivePersistenceStatus().toStdString();
+		return "PROJECT-OWNED +DRIVE";
+	}
+
+	void Editor::showPlusDriveOperationResult(const bool _success,
+		const juce::String& _message)
+	{
+		genericUI::MessageBox::showOk(_success
+				? genericUI::MessageBox::Icon::Info
+				: genericUI::MessageBox::Icon::Warning,
+			_success ? "+Drive operation complete" : "+Drive unchanged",
+			_message.toStdString(), getRmlComponent());
+	}
+
 	void Editor::createMasterVolume()
 	{
 		m_masterVolume = findChild<juceRmlUi::ElemKnob>("encMaster", false);

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -1143,11 +1143,6 @@ namespace mdJucePlugin
 		choosePlusDriveFile(PlusDriveFileOperation::Export);
 	}
 
-	void Editor::choosePlusDriveAutoSave()
-	{
-		choosePlusDriveFile(PlusDriveFileOperation::AutoSave);
-	}
-
 	void Editor::choosePlusDriveFile(const PlusDriveFileOperation _operation)
 	{
 		if(m_model != md::MachineModel::Machinedrum)
@@ -1160,27 +1155,18 @@ namespace mdJucePlugin
 			return;
 		}
 
-		auto* const processor = dynamic_cast<AudioPluginAudioProcessor*>(&getProcessor());
 		juce::File initial;
-		if(processor && _operation == PlusDriveFileOperation::AutoSave
-			&& processor->plusDriveAutoSaveEnabled())
-			initial = processor->getPlusDriveAutoSaveFile();
-		if(initial == juce::File())
-		{
-			const auto lastDirectory = getProcessor().getConfig().getValue(
-				"mdPlusDriveImageLastDirectory");
-			initial = lastDirectory.isNotEmpty()
-				? juce::File(lastDirectory)
-				: juce::File::getSpecialLocation(juce::File::userDocumentsDirectory);
-		}
+		const auto lastDirectory = getProcessor().getConfig().getValue(
+			"mdPlusDriveImageLastDirectory");
+		initial = lastDirectory.isNotEmpty()
+			? juce::File(lastDirectory)
+			: juce::File::getSpecialLocation(juce::File::userDocumentsDirectory);
 		if(_operation != PlusDriveFileOperation::Import && initial.isDirectory())
 			initial = initial.getChildFile("Machinedrum-PlusDrive.mdpd");
 
 		const char* title = _operation == PlusDriveFileOperation::Import
 			? "Import a sparse Machinedrum +Drive image"
-			: (_operation == PlusDriveFileOperation::Export
-				? "Export this project's Machinedrum +Drive"
-				: "Choose an automatic +Drive mirror image");
+			: "Export this project's Machinedrum +Drive";
 		m_storageFileChooser = std::make_unique<juce::FileChooser>(
 			title, initial, "*.mdpd;*.bin", true);
 		const auto safeRoot =
@@ -1212,9 +1198,7 @@ namespace mdJucePlugin
 					if(!processor)
 						return;
 					juce::String result;
-					const bool success = _operation == PlusDriveFileOperation::Export
-						? processor->exportPlusDriveImage(file, result)
-						: processor->enablePlusDriveAutoSave(file, result);
+					const bool success = processor->exportPlusDriveImage(file, result);
 					showPlusDriveOperationResult(success, result);
 				});
 		const auto flags = _operation == PlusDriveFileOperation::Import
@@ -1254,16 +1238,6 @@ namespace mdJucePlugin
 			("Import '" + _file.getFileName()
 				+ "'?\n\nThis replaces every +Drive Snapshot and sample bank in this plug-in instance, then reboots the Machinedrum. Export the current +Drive first if you need a separate recovery image.")
 				.toStdString(), completion);
-	}
-
-	void Editor::disablePlusDriveAutoSave()
-	{
-		if(auto* const processor = dynamic_cast<AudioPluginAudioProcessor*>(&getProcessor()))
-		{
-			processor->disablePlusDriveAutoSave();
-			const auto status = processor->getPlusDrivePersistenceStatus();
-			showPlusDriveOperationResult(!status.containsIgnoreCase("failed"), status);
-		}
 	}
 
 	void Editor::resetPlusDrive()

--- a/source/elektron/md/mdJucePlugin/mdEditor.h
+++ b/source/elektron/md/mdJucePlugin/mdEditor.h
@@ -71,8 +71,6 @@ namespace mdJucePlugin
 		bool hasStorageRecoveryImage() const;
 		void choosePlusDriveImport();
 		void choosePlusDriveExport();
-		void choosePlusDriveAutoSave();
-		void disablePlusDriveAutoSave();
 		void resetPlusDrive();
 		void rebootMachinedrum();
 		std::string plusDriveStatusText() const;
@@ -139,7 +137,7 @@ namespace mdJucePlugin
 		void confirmStorageImage(const juce::File& _file,
 			StorageImageBookmark _bookmark);
 		void showStorageOperationResult(bool _success, const juce::String& _message);
-		enum class PlusDriveFileOperation { Import, Export, AutoSave };
+		enum class PlusDriveFileOperation { Import, Export };
 		void choosePlusDriveFile(PlusDriveFileOperation _operation);
 		void confirmPlusDriveImport(const juce::File& _file);
 		void showPlusDriveOperationResult(bool _success, const juce::String& _message);

--- a/source/elektron/md/mdJucePlugin/mdEditor.h
+++ b/source/elektron/md/mdJucePlugin/mdEditor.h
@@ -69,6 +69,13 @@ namespace mdJucePlugin
 		void chooseStorageImage();
 		void restorePreviousStorage();
 		bool hasStorageRecoveryImage() const;
+		void choosePlusDriveImport();
+		void choosePlusDriveExport();
+		void choosePlusDriveAutoSave();
+		void disablePlusDriveAutoSave();
+		void resetPlusDrive();
+		void rebootMachinedrum();
+		std::string plusDriveStatusText() const;
 		void chooseSysexFile();
 		void sendSysexFile(const juce::File& _file);
 		std::string sysexTransferStatusText() const;
@@ -132,6 +139,10 @@ namespace mdJucePlugin
 		void confirmStorageImage(const juce::File& _file,
 			StorageImageBookmark _bookmark);
 		void showStorageOperationResult(bool _success, const juce::String& _message);
+		enum class PlusDriveFileOperation { Import, Export, AutoSave };
+		void choosePlusDriveFile(PlusDriveFileOperation _operation);
+		void confirmPlusDriveImport(const juce::File& _file);
+		void showPlusDriveOperationResult(bool _success, const juce::String& _message);
 
 		enum class StorageImageFlow
 		{

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
@@ -9,6 +9,7 @@
 #include "jucePluginLib/processorPropertiesInit.h"
 
 #include "mdLib/mddevice.h"
+#include "mdLib/mdplusdrive.h"
 #include "mdLib/mdromloader.h"
 #include "mdLib/mdstate.h"
 
@@ -17,6 +18,8 @@
 #include "baseLib/binarystream.h"
 
 #include <utility>
+#include <chrono>
+#include <unordered_map>
 
 namespace
 {
@@ -34,6 +37,51 @@ namespace
 	const char* dataFolderName(const md::MachineModel _model)
 	{
 		return _model == md::MachineModel::Monomachine ? "Monomachine" : "Machinedrum";
+	}
+
+	std::mutex g_plusDriveMirrorOwnersMutex;
+	std::unordered_map<std::string, const mdJucePlugin::AudioPluginAudioProcessor*>
+		g_plusDriveMirrorOwners;
+
+	bool claimPlusDriveMirror(const std::string& _path,
+		const mdJucePlugin::AudioPluginAudioProcessor* const _owner)
+	{
+		std::lock_guard lock(g_plusDriveMirrorOwnersMutex);
+		if(const auto existing = g_plusDriveMirrorOwners.find(_path);
+			existing != g_plusDriveMirrorOwners.end() && existing->second != _owner)
+			return false;
+		g_plusDriveMirrorOwners[_path] = _owner;
+		return true;
+	}
+
+	void releasePlusDriveMirror(const std::string& _path,
+		const mdJucePlugin::AudioPluginAudioProcessor* const _owner)
+	{
+		std::lock_guard lock(g_plusDriveMirrorOwnersMutex);
+		const auto existing = g_plusDriveMirrorOwners.find(_path);
+		if(existing != g_plusDriveMirrorOwners.end() && existing->second == _owner)
+			g_plusDriveMirrorOwners.erase(existing);
+	}
+
+	void releasePlusDriveMirror(
+		const mdJucePlugin::AudioPluginAudioProcessor* const _owner)
+	{
+		std::lock_guard lock(g_plusDriveMirrorOwnersMutex);
+		for(auto it = g_plusDriveMirrorOwners.begin();
+			it != g_plusDriveMirrorOwners.end();)
+		{
+			if(it->second == _owner)
+				it = g_plusDriveMirrorOwners.erase(it);
+			else
+				++it;
+		}
+	}
+
+	juce::String plusDriveMirrorLockName(const std::string& _path)
+	{
+		return "gearmulator-md-plusdrive-"
+			+ juce::String::toHexString(
+				juce::String::fromUTF8(_path.c_str()).hashCode64());
 	}
 
 	juce::PropertiesFile::Options getOptions(const md::MachineModel _model,
@@ -102,6 +150,20 @@ namespace mdJucePlugin
 			auto& controller = dynamic_cast<Controller&>(getController());
 			(void)controller.restoreAutomationSnapshot(snapshot);
 		});
+	}
+
+	bool AudioPluginAudioProcessor::loadCustomData(
+		const std::vector<uint8_t>& _sourceBuffer)
+	{
+		const bool loaded = jucePluginEditorLib::Processor::loadCustomData(_sourceBuffer);
+		if(loaded && m_model == md::MachineModel::Machinedrum)
+		{
+			std::lock_guard lock(m_plusDrivePersistenceMutex);
+			if(!m_plusDriveAutoSavePath.empty())
+				++m_plusDriveFlushRequest;
+		}
+		m_plusDrivePersistenceCv.notify_all();
+		return loaded;
 	}
 
 	AudioPluginAudioProcessor::AudioPluginAudioProcessor()
@@ -272,6 +334,554 @@ namespace mdJucePlugin
 		return true;
 	}
 
+	bool AudioPluginAudioProcessor::replacePlusDrive(
+		std::vector<uint8_t> _replacement, const juce::String& _operation,
+		juce::String& _result)
+	{
+		_result.clear();
+		if(m_model != md::MachineModel::Machinedrum)
+		{
+			_result = "+Drive images are only supported by Gearmulator MD";
+			return false;
+		}
+		if(_replacement.size() > md::g_plusDriveMaxSerializedBytes
+			|| !md::PlusDrive::validateStorage(_replacement))
+		{
+			_result = "The replacement is not a valid bounded sparse +Drive image";
+			return false;
+		}
+		std::unique_lock operationLock(m_storageLoadMutex, std::try_to_lock);
+		if(!operationLock.owns_lock())
+		{
+			_result = "Another machine-storage operation is already running";
+			return false;
+		}
+
+		md::Device* liveDevice = nullptr;
+		uint64_t liveEpoch = 0;
+		std::vector<uint8_t> originalState;
+		std::vector<uint8_t> factoryFlashCache;
+		std::shared_ptr<const md::Device::PreparationContext> preparationContext;
+		const bool captured = getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				if(!device || device->getModel() != md::MachineModel::Machinedrum)
+					return false;
+				liveDevice = device;
+				liveEpoch = device->hardwareEpoch();
+				preparationContext = device->getPreparationContext();
+				factoryFlashCache = device->getHardware().copyFactoryFlashCache();
+				return device->getState(originalState, synthLib::StateTypeGlobal);
+			});
+		if(!captured || !preparationContext)
+		{
+			_result = "The local Machinedrum state could not be captured";
+			return false;
+		}
+
+		auto replacementState = originalState;
+		if(!md::replacePlusDriveState(replacementState, _replacement))
+		{
+			_result = "The current project state could not accept the +Drive image";
+			return false;
+		}
+		auto prepared = md::Device::prepareState(preparationContext, replacementState,
+			synthLib::StateTypeGlobal, factoryFlashCache);
+		if(!prepared)
+		{
+			_result = "The replacement machine could not be prepared";
+			return false;
+		}
+
+		juce::String commitError;
+		const bool committed = getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				if(device != liveDevice || !device || device->hardwareEpoch() != liveEpoch)
+				{
+					commitError = "The machine changed while the replacement was preparing";
+					return false;
+				}
+				std::vector<uint8_t> currentState;
+				if(!device->getState(currentState, synthLib::StateTypeGlobal)
+					|| currentState != originalState)
+				{
+					commitError = "Machine storage was edited while the replacement was preparing; try again";
+					return false;
+				}
+				return device->commitPreparedState(*prepared);
+			});
+		if(!committed)
+		{
+			_result = _operation + " was not applied. " + commitError;
+			return false;
+		}
+		prepared.reset();
+		if(hasController())
+			getController().onStateLoaded();
+		{
+			std::lock_guard lock(m_plusDrivePersistenceMutex);
+			if(!m_plusDriveAutoSavePath.empty())
+				++m_plusDriveFlushRequest;
+		}
+		m_plusDrivePersistenceCv.notify_all();
+		_result = _operation + " applied; the Machinedrum rebooted";
+		return true;
+	}
+
+	bool AudioPluginAudioProcessor::importPlusDriveImage(const juce::File& _source,
+		juce::String& _result)
+	{
+		std::vector<uint8_t> replacement;
+		if(!storageImage::readPlusDrive(_source, replacement, _result))
+			return false;
+		return replacePlusDrive(std::move(replacement),
+			"+Drive image '" + _source.getFileName() + "'", _result);
+	}
+
+	bool AudioPluginAudioProcessor::exportPlusDriveImage(const juce::File& _target,
+		juce::String& _result)
+	{
+		std::unique_lock operationLock(m_storageLoadMutex, std::try_to_lock);
+		if(!operationLock.owns_lock())
+		{
+			_result = "Another machine-storage operation is already running";
+			return false;
+		}
+		return exportPlusDriveImageUnlocked(_target, _result);
+	}
+
+	bool AudioPluginAudioProcessor::exportPlusDriveImageUnlocked(
+		const juce::File& _target, juce::String& _result)
+	{
+		_result.clear();
+		if(m_model != md::MachineModel::Machinedrum)
+		{
+			_result = "+Drive images are only supported by Gearmulator MD";
+			return false;
+		}
+		md::Device* capturedDevice = nullptr;
+		uint64_t capturedEpoch = 0;
+		uint64_t capturedGeneration = 0;
+		std::vector<uint8_t> data;
+		const bool captured = getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				if(!device || device->getModel() != md::MachineModel::Machinedrum)
+					return false;
+				capturedDevice = device;
+				capturedEpoch = device->hardwareEpoch();
+				capturedGeneration = device->getHardware().plusDriveGeneration();
+				data = device->getHardware().copyPlusDriveData();
+				return true;
+			});
+		if(!captured)
+		{
+			_result = "The local +Drive could not be captured";
+			return false;
+		}
+		if(!storageImage::writePlusDriveAtomically(_target, data, _result))
+			return false;
+		std::string mirrorPath;
+		{
+			std::lock_guard lock(m_plusDrivePersistenceMutex);
+			mirrorPath = m_plusDriveAutoSavePath;
+		}
+		if(mirrorPath == _target.getFullPathName().toStdString())
+			getPlugin().withDeviceLocked([&](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				if(device == capturedDevice && device
+					&& device->hardwareEpoch() == capturedEpoch)
+					device->getHardware().markPlusDrivePersisted(capturedGeneration);
+			});
+		_result = "+Drive image exported atomically to " + _target.getFullPathName();
+		return true;
+	}
+
+	bool AudioPluginAudioProcessor::resetPlusDrive(juce::String& _result)
+	{
+		md::PlusDrive blank;
+		return replacePlusDrive(blank.copyStorage(), "Blank +Drive", _result);
+	}
+
+	bool AudioPluginAudioProcessor::rebootMachinedrum(juce::String& _result)
+	{
+		_result.clear();
+		if(m_model != md::MachineModel::Machinedrum)
+		{
+			_result = "Reboot is only available for Gearmulator MD";
+			return false;
+		}
+		std::unique_lock operationLock(m_storageLoadMutex, std::try_to_lock);
+		if(!operationLock.owns_lock())
+		{
+			_result = "Another machine-storage operation is already running";
+			return false;
+		}
+
+		md::Device* liveDevice = nullptr;
+		uint64_t liveEpoch = 0;
+		std::vector<uint8_t> originalState;
+		std::vector<uint8_t> factoryFlashCache;
+		std::shared_ptr<const md::Device::PreparationContext> preparationContext;
+		const bool captured = getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				if(!device || device->getModel() != md::MachineModel::Machinedrum)
+					return false;
+				liveDevice = device;
+				liveEpoch = device->hardwareEpoch();
+				preparationContext = device->getPreparationContext();
+				factoryFlashCache = device->getHardware().copyFactoryFlashCache();
+				return device->getState(originalState, synthLib::StateTypeGlobal);
+			});
+		if(!captured || !preparationContext)
+		{
+			_result = "The project-owned Machinedrum state could not be captured";
+			return false;
+		}
+		auto prepared = md::Device::prepareState(preparationContext, originalState,
+			synthLib::StateTypeGlobal, factoryFlashCache);
+		if(!prepared)
+		{
+			_result = "The replacement Machinedrum could not be prepared";
+			return false;
+		}
+
+		juce::String commitError;
+		const bool committed = getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				if(device != liveDevice || !device || device->hardwareEpoch() != liveEpoch)
+				{
+					commitError = "The machine changed while the reboot was preparing";
+					return false;
+				}
+				std::vector<uint8_t> currentState;
+				if(!device->getState(currentState, synthLib::StateTypeGlobal)
+					|| currentState != originalState)
+				{
+					commitError = "Machine storage was edited while the reboot was preparing; try again";
+					return false;
+				}
+				return device->commitPreparedState(*prepared);
+			});
+		if(!committed)
+		{
+			_result = "The Machinedrum was not rebooted. " + commitError;
+			return false;
+		}
+		prepared.reset();
+		if(hasController())
+			getController().onStateLoaded();
+		{
+			std::lock_guard lock(m_plusDrivePersistenceMutex);
+			if(!m_plusDriveAutoSavePath.empty())
+				++m_plusDriveFlushRequest;
+		}
+		m_plusDrivePersistenceCv.notify_all();
+		_result = "The Machinedrum rebooted with its project-owned +Drive";
+		return true;
+	}
+
+	bool AudioPluginAudioProcessor::rebootDevice()
+	{
+		if(m_model != md::MachineModel::Machinedrum)
+			return jucePluginEditorLib::Processor::rebootDevice();
+		juce::String result;
+		return rebootMachinedrum(result);
+	}
+
+	bool AudioPluginAudioProcessor::enablePlusDriveAutoSave(const juce::File& _target,
+		juce::String& _result)
+	{
+		stopPlusDrivePersistenceThread();
+		std::string oldPath;
+		{
+			std::lock_guard lock(m_plusDrivePersistenceMutex);
+			oldPath = m_plusDriveAutoSavePath;
+		}
+		std::unique_lock operationLock(m_storageLoadMutex, std::try_to_lock);
+		if(!operationLock.owns_lock())
+		{
+			if(!oldPath.empty())
+				startPlusDrivePersistenceThread();
+			_result = "Another machine-storage operation is already running";
+			return false;
+		}
+		const auto targetPath = _target.getFullPathName().toStdString();
+		const bool changingTarget = targetPath != oldPath;
+		std::unique_ptr<juce::InterProcessLock> candidateLock;
+		bool candidateEntered = false;
+		if(changingTarget)
+		{
+			if(!claimPlusDriveMirror(targetPath, this))
+			{
+				if(!oldPath.empty())
+					startPlusDrivePersistenceThread();
+				_result = "Another running plug-in instance already owns this auto-save mirror";
+				return false;
+			}
+			candidateLock = std::make_unique<juce::InterProcessLock>(
+				plusDriveMirrorLockName(targetPath));
+			candidateEntered = candidateLock->enter(0);
+			if(!candidateEntered)
+			{
+				releasePlusDriveMirror(targetPath, this);
+				if(!oldPath.empty())
+					startPlusDrivePersistenceThread();
+				_result = "Another process already owns this auto-save mirror";
+				return false;
+			}
+		}
+		if(!exportPlusDriveImageUnlocked(_target, _result))
+		{
+			if(changingTarget)
+			{
+				releasePlusDriveMirror(targetPath, this);
+				candidateLock->exit();
+			}
+			if(!oldPath.empty())
+				startPlusDrivePersistenceThread();
+			return false;
+		}
+		if(changingTarget)
+		{
+			if(!oldPath.empty())
+				releasePlusDriveMirror(oldPath, this);
+			m_plusDriveInterprocessLock.reset();
+			m_plusDriveInterprocessLock = std::move(candidateLock);
+		}
+		{
+			std::lock_guard lock(m_plusDrivePersistenceMutex);
+			m_plusDriveAutoSavePath = targetPath;
+			m_plusDrivePersistenceStatus = "Auto-save mirror is current: "
+				+ _target.getFullPathName();
+		}
+		startPlusDrivePersistenceThread();
+		m_plusDrivePersistenceCv.notify_all();
+		_result = "+Drive auto-save mirror enabled at " + _target.getFullPathName();
+		return true;
+	}
+
+	void AudioPluginAudioProcessor::disablePlusDriveAutoSave()
+	{
+		stopPlusDrivePersistenceThread();
+		{
+			std::lock_guard lock(m_plusDrivePersistenceMutex);
+			m_plusDriveAutoSavePath.clear();
+			m_plusDriveFlushedRequest = m_plusDriveFlushRequest;
+			if(m_plusDrivePersistenceStatus.startsWith(
+				"Final auto-save mirror failed:"))
+				m_plusDrivePersistenceStatus = "Auto-save mirror disabled; "
+					+ m_plusDrivePersistenceStatus;
+			else
+				m_plusDrivePersistenceStatus =
+					"Project-owned +Drive; auto-save mirror disabled";
+		}
+		releasePlusDriveMirror(this);
+		m_plusDriveInterprocessLock.reset();
+	}
+
+	bool AudioPluginAudioProcessor::plusDriveAutoSaveEnabled() const
+	{
+		std::lock_guard lock(m_plusDrivePersistenceMutex);
+		return !m_plusDriveAutoSavePath.empty();
+	}
+
+	juce::File AudioPluginAudioProcessor::getPlusDriveAutoSaveFile() const
+	{
+		std::lock_guard lock(m_plusDrivePersistenceMutex);
+		return juce::File(juce::String::fromUTF8(m_plusDriveAutoSavePath.c_str()));
+	}
+
+	juce::String AudioPluginAudioProcessor::getPlusDrivePersistenceStatus() const
+	{
+		std::lock_guard lock(m_plusDrivePersistenceMutex);
+		return m_plusDrivePersistenceStatus;
+	}
+
+	void AudioPluginAudioProcessor::startPlusDrivePersistenceThread()
+	{
+		std::lock_guard lock(m_plusDrivePersistenceMutex);
+		if(m_plusDrivePersistenceThread.joinable())
+			return;
+		m_plusDrivePersistenceStop = false;
+		m_plusDrivePersistenceThread = std::thread(
+			[this] { plusDrivePersistenceLoop(); });
+	}
+
+	void AudioPluginAudioProcessor::stopPlusDrivePersistenceThread()
+	{
+		{
+			std::lock_guard lock(m_plusDrivePersistenceMutex);
+			m_plusDrivePersistenceStop = true;
+		}
+		m_plusDrivePersistenceCv.notify_all();
+		if(m_plusDrivePersistenceThread.joinable())
+			m_plusDrivePersistenceThread.join();
+	}
+
+	void AudioPluginAudioProcessor::plusDrivePersistenceLoop()
+	{
+		using Clock = std::chrono::steady_clock;
+		md::Device* observedDevice = nullptr;
+		uint64_t observedEpoch = 0;
+		uint64_t observedGeneration = 0;
+		auto flushAfter = Clock::now();
+		while(true)
+		{
+			std::string targetPath;
+			uint64_t flushRequest = 0;
+			bool forced = false;
+			bool stopping = false;
+			{
+				std::unique_lock lock(m_plusDrivePersistenceMutex);
+				m_plusDrivePersistenceCv.wait_for(lock, std::chrono::milliseconds(250),
+					[this] { return m_plusDrivePersistenceStop; });
+				stopping = m_plusDrivePersistenceStop;
+				targetPath = m_plusDriveAutoSavePath;
+				flushRequest = m_plusDriveFlushRequest;
+				forced = flushRequest != m_plusDriveFlushedRequest;
+			}
+			if(targetPath.empty())
+			{
+				if(stopping)
+					return;
+				continue;
+			}
+
+			// A disabled, replaced or destroyed mirror gets one final current image.
+			// This bypasses the debounce but retains the same atomic write and
+			// generation-aware acknowledgement as a normal background flush.
+			if(stopping)
+			{
+				std::unique_lock operationLock(m_storageLoadMutex);
+				md::Device* deviceIdentity = nullptr;
+				uint64_t epoch = 0;
+				uint64_t generation = 0;
+				std::vector<uint8_t> data;
+				const bool captured = getPlugin().withDeviceLocked(
+					[&](synthLib::Device* const _device)
+					{
+						auto* const device = dynamic_cast<md::Device*>(_device);
+						if(!device
+							|| device->getModel() != md::MachineModel::Machinedrum)
+							return false;
+						deviceIdentity = device;
+						epoch = device->hardwareEpoch();
+						generation = device->getHardware().plusDriveGeneration();
+						data = device->getHardware().copyPlusDriveData();
+						return true;
+					});
+				juce::String error;
+				const juce::File target(
+					juce::String::fromUTF8(targetPath.c_str()));
+				const bool written = captured
+					&& storageImage::writePlusDriveAtomically(target, data, error);
+				{
+					std::lock_guard lock(m_plusDrivePersistenceMutex);
+					m_plusDrivePersistenceStatus = written
+						? "Auto-save mirror is current: " + target.getFullPathName()
+						: "Final auto-save mirror failed: "
+							+ (captured ? error : "local Machinedrum unavailable");
+					if(written && m_plusDriveAutoSavePath == targetPath)
+						m_plusDriveFlushedRequest = flushRequest;
+				}
+				if(written)
+					getPlugin().withDeviceLocked([&](synthLib::Device* const _device)
+					{
+						auto* const device = dynamic_cast<md::Device*>(_device);
+						if(device == deviceIdentity && device
+							&& device->hardwareEpoch() == epoch)
+							device->getHardware().markPlusDrivePersisted(generation);
+					});
+				return;
+			}
+
+			md::Device* deviceIdentity = nullptr;
+			uint64_t epoch = 0;
+			uint64_t generation = 0;
+			bool dirty = false;
+			getPlugin().withDeviceLocked([&](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				if(!device || device->getModel() != md::MachineModel::Machinedrum)
+					return;
+				deviceIdentity = device;
+				epoch = device->hardwareEpoch();
+				generation = device->getHardware().plusDriveGeneration();
+				dirty = device->getHardware().plusDriveDirty();
+			});
+			if(!deviceIdentity || (!dirty && !forced))
+				continue;
+
+			const auto now = Clock::now();
+			if(deviceIdentity != observedDevice || epoch != observedEpoch
+				|| generation != observedGeneration)
+			{
+				observedDevice = deviceIdentity;
+				observedEpoch = epoch;
+				observedGeneration = generation;
+				flushAfter = now + std::chrono::seconds(1);
+				continue;
+			}
+			if(now < flushAfter)
+				continue;
+			std::unique_lock operationLock(m_storageLoadMutex, std::try_to_lock);
+			if(!operationLock.owns_lock())
+				continue;
+
+			std::vector<uint8_t> data;
+			const bool snapshotValid = getPlugin().withDeviceLocked(
+				[&](synthLib::Device* const _device)
+				{
+					auto* const device = dynamic_cast<md::Device*>(_device);
+					if(device != deviceIdentity || !device
+						|| device->hardwareEpoch() != epoch
+						|| device->getHardware().plusDriveGeneration() != generation)
+						return false;
+					data = device->getHardware().copyPlusDriveData();
+					return true;
+				});
+			if(!snapshotValid)
+				continue;
+
+			juce::String error;
+			const juce::File target(juce::String::fromUTF8(targetPath.c_str()));
+			const bool written = storageImage::writePlusDriveAtomically(target, data, error);
+			bool sameTarget = false;
+			{
+				std::lock_guard lock(m_plusDrivePersistenceMutex);
+				sameTarget = m_plusDriveAutoSavePath == targetPath;
+				m_plusDrivePersistenceStatus = written
+					? "Auto-save mirror is current: " + target.getFullPathName()
+					: "Auto-save mirror failed: " + error;
+				if(written && sameTarget
+					&& flushRequest > m_plusDriveFlushedRequest)
+					m_plusDriveFlushedRequest = flushRequest;
+			}
+			if(written && sameTarget)
+			{
+				getPlugin().withDeviceLocked([&](synthLib::Device* const _device)
+				{
+					auto* const device = dynamic_cast<md::Device*>(_device);
+					if(device == deviceIdentity && device
+						&& device->hardwareEpoch() == epoch)
+						device->getHardware().markPlusDrivePersisted(generation);
+				});
+			}
+			flushAfter = Clock::now() + (written
+				? std::chrono::seconds(1) : std::chrono::seconds(2));
+		}
+	}
+
 	AudioPluginAudioProcessor::AudioPluginAudioProcessor(const md::MachineModel _model)
 		: AudioPluginAudioProcessor(_model, std::vector<uint8_t>{})
 	{
@@ -330,6 +940,9 @@ namespace mdJucePlugin
 	AudioPluginAudioProcessor::~AudioPluginAudioProcessor()
 	{
 		destroyEditorState();
+		stopPlusDrivePersistenceThread();
+		releasePlusDriveMirror(this);
+		m_plusDriveInterprocessLock.reset();
 	}
 
 	jucePluginEditorLib::PluginEditorState* AudioPluginAudioProcessor::createEditorState()

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
@@ -2,6 +2,7 @@
 
 #include "mdController.h"
 #include "mdPluginEditorState.h"
+#include "mdStandalonePlusDrivePersistence.h"
 #include "mdStorageImage.h"
 
 // ReSharper disable once CppUnusedIncludeDirective
@@ -18,8 +19,6 @@
 #include "baseLib/binarystream.h"
 
 #include <utility>
-#include <chrono>
-#include <unordered_map>
 
 namespace
 {
@@ -37,51 +36,6 @@ namespace
 	const char* dataFolderName(const md::MachineModel _model)
 	{
 		return _model == md::MachineModel::Monomachine ? "Monomachine" : "Machinedrum";
-	}
-
-	std::mutex g_plusDriveMirrorOwnersMutex;
-	std::unordered_map<std::string, const mdJucePlugin::AudioPluginAudioProcessor*>
-		g_plusDriveMirrorOwners;
-
-	bool claimPlusDriveMirror(const std::string& _path,
-		const mdJucePlugin::AudioPluginAudioProcessor* const _owner)
-	{
-		std::lock_guard lock(g_plusDriveMirrorOwnersMutex);
-		if(const auto existing = g_plusDriveMirrorOwners.find(_path);
-			existing != g_plusDriveMirrorOwners.end() && existing->second != _owner)
-			return false;
-		g_plusDriveMirrorOwners[_path] = _owner;
-		return true;
-	}
-
-	void releasePlusDriveMirror(const std::string& _path,
-		const mdJucePlugin::AudioPluginAudioProcessor* const _owner)
-	{
-		std::lock_guard lock(g_plusDriveMirrorOwnersMutex);
-		const auto existing = g_plusDriveMirrorOwners.find(_path);
-		if(existing != g_plusDriveMirrorOwners.end() && existing->second == _owner)
-			g_plusDriveMirrorOwners.erase(existing);
-	}
-
-	void releasePlusDriveMirror(
-		const mdJucePlugin::AudioPluginAudioProcessor* const _owner)
-	{
-		std::lock_guard lock(g_plusDriveMirrorOwnersMutex);
-		for(auto it = g_plusDriveMirrorOwners.begin();
-			it != g_plusDriveMirrorOwners.end();)
-		{
-			if(it->second == _owner)
-				it = g_plusDriveMirrorOwners.erase(it);
-			else
-				++it;
-		}
-	}
-
-	juce::String plusDriveMirrorLockName(const std::string& _path)
-	{
-		return "gearmulator-md-plusdrive-"
-			+ juce::String::toHexString(
-				juce::String::fromUTF8(_path.c_str()).hashCode64());
 	}
 
 	juce::PropertiesFile::Options getOptions(const md::MachineModel _model,
@@ -155,14 +109,51 @@ namespace mdJucePlugin
 	bool AudioPluginAudioProcessor::loadCustomData(
 		const std::vector<uint8_t>& _sourceBuffer)
 	{
-		const bool loaded = jucePluginEditorLib::Processor::loadCustomData(_sourceBuffer);
-		if(loaded && m_model == md::MachineModel::Machinedrum)
+		std::unique_lock<std::mutex> operationLock;
+		uint64_t preservedEpoch = 0;
+		uint64_t preservedGeneration = 0;
+		bool preservedDirty = false;
+		std::vector<uint8_t> preservedDrive;
+		bool preserveStandaloneDrive = false;
+		bool wasAuthoritative = false;
+		if(m_standalonePlusDrive)
 		{
-			std::lock_guard lock(m_plusDrivePersistenceMutex);
-			if(!m_plusDriveAutoSavePath.empty())
-				++m_plusDriveFlushRequest;
+			operationLock = std::unique_lock<std::mutex>(m_storageLoadMutex);
+			wasAuthoritative = m_standalonePlusDrive->authoritative();
+			if(capturePlusDrivePersistenceSnapshot(true, preservedEpoch,
+				preservedGeneration, preservedDirty, preservedDrive))
+				preserveStandaloneDrive = wasAuthoritative;
 		}
-		m_plusDrivePersistenceCv.notify_all();
+
+		const bool loaded = jucePluginEditorLib::Processor::loadCustomData(_sourceBuffer);
+		if(!loaded || !m_standalonePlusDrive)
+			return loaded;
+
+		if(preserveStandaloneDrive)
+		{
+			const bool restored = getPlugin().withDeviceLocked(
+				[&](synthLib::Device* const _device)
+				{
+					auto* const device = dynamic_cast<md::Device*>(_device);
+					return device && device->getModel() == md::MachineModel::Machinedrum
+						&& device->getHardware().replacePlusDriveData(
+							preservedDrive, preservedDirty);
+				});
+			if(!restored)
+			{
+				m_standalonePlusDrive->blockWrites(
+					"Standalone state loaded, but its authoritative +Drive could not be restored");
+				return false;
+			}
+			if(preservedDirty || !wasAuthoritative)
+				m_standalonePlusDrive->requestFlush(true);
+		}
+		else
+		{
+			// First launch migration: when no dedicated checkpoint exists, adopt the
+			// +Drive from JUCE's legacy standalone filterState exactly once.
+			m_standalonePlusDrive->requestFlush(true);
+		}
 		return loaded;
 	}
 
@@ -350,6 +341,11 @@ namespace mdJucePlugin
 			_result = "The replacement is not a valid bounded sparse +Drive image";
 			return false;
 		}
+		if(m_standalonePlusDrive && !m_standalonePlusDrive->ownsWriter())
+		{
+			_result = "Another standalone instance owns the persistent +Drive. This instance cannot replace it";
+			return false;
+		}
 		std::unique_lock operationLock(m_storageLoadMutex, std::try_to_lock);
 		if(!operationLock.owns_lock())
 		{
@@ -421,12 +417,8 @@ namespace mdJucePlugin
 		prepared.reset();
 		if(hasController())
 			getController().onStateLoaded();
-		{
-			std::lock_guard lock(m_plusDrivePersistenceMutex);
-			if(!m_plusDriveAutoSavePath.empty())
-				++m_plusDriveFlushRequest;
-		}
-		m_plusDrivePersistenceCv.notify_all();
+		if(m_standalonePlusDrive)
+			m_standalonePlusDrive->allowReplacementAndFlush();
 		_result = _operation + " applied; the Machinedrum rebooted";
 		return true;
 	}
@@ -462,9 +454,6 @@ namespace mdJucePlugin
 			_result = "+Drive images are only supported by Gearmulator MD";
 			return false;
 		}
-		md::Device* capturedDevice = nullptr;
-		uint64_t capturedEpoch = 0;
-		uint64_t capturedGeneration = 0;
 		std::vector<uint8_t> data;
 		const bool captured = getPlugin().withDeviceLocked(
 			[&](synthLib::Device* const _device)
@@ -472,9 +461,6 @@ namespace mdJucePlugin
 				auto* const device = dynamic_cast<md::Device*>(_device);
 				if(!device || device->getModel() != md::MachineModel::Machinedrum)
 					return false;
-				capturedDevice = device;
-				capturedEpoch = device->hardwareEpoch();
-				capturedGeneration = device->getHardware().plusDriveGeneration();
 				data = device->getHardware().copyPlusDriveData();
 				return true;
 			});
@@ -485,19 +471,6 @@ namespace mdJucePlugin
 		}
 		if(!storageImage::writePlusDriveAtomically(_target, data, _result))
 			return false;
-		std::string mirrorPath;
-		{
-			std::lock_guard lock(m_plusDrivePersistenceMutex);
-			mirrorPath = m_plusDriveAutoSavePath;
-		}
-		if(mirrorPath == _target.getFullPathName().toStdString())
-			getPlugin().withDeviceLocked([&](synthLib::Device* const _device)
-			{
-				auto* const device = dynamic_cast<md::Device*>(_device);
-				if(device == capturedDevice && device
-					&& device->hardwareEpoch() == capturedEpoch)
-					device->getHardware().markPlusDrivePersisted(capturedGeneration);
-			});
 		_result = "+Drive image exported atomically to " + _target.getFullPathName();
 		return true;
 	}
@@ -580,13 +553,7 @@ namespace mdJucePlugin
 		prepared.reset();
 		if(hasController())
 			getController().onStateLoaded();
-		{
-			std::lock_guard lock(m_plusDrivePersistenceMutex);
-			if(!m_plusDriveAutoSavePath.empty())
-				++m_plusDriveFlushRequest;
-		}
-		m_plusDrivePersistenceCv.notify_all();
-		_result = "The Machinedrum rebooted with its project-owned +Drive";
+		_result = "The Machinedrum rebooted with its active +Drive";
 		return true;
 	}
 
@@ -598,288 +565,79 @@ namespace mdJucePlugin
 		return rebootMachinedrum(result);
 	}
 
-	bool AudioPluginAudioProcessor::enablePlusDriveAutoSave(const juce::File& _target,
-		juce::String& _result)
-	{
-		stopPlusDrivePersistenceThread();
-		std::string oldPath;
-		{
-			std::lock_guard lock(m_plusDrivePersistenceMutex);
-			oldPath = m_plusDriveAutoSavePath;
-		}
-		std::unique_lock operationLock(m_storageLoadMutex, std::try_to_lock);
-		if(!operationLock.owns_lock())
-		{
-			if(!oldPath.empty())
-				startPlusDrivePersistenceThread();
-			_result = "Another machine-storage operation is already running";
-			return false;
-		}
-		const auto targetPath = _target.getFullPathName().toStdString();
-		const bool changingTarget = targetPath != oldPath;
-		std::unique_ptr<juce::InterProcessLock> candidateLock;
-		bool candidateEntered = false;
-		if(changingTarget)
-		{
-			if(!claimPlusDriveMirror(targetPath, this))
-			{
-				if(!oldPath.empty())
-					startPlusDrivePersistenceThread();
-				_result = "Another running plug-in instance already owns this auto-save mirror";
-				return false;
-			}
-			candidateLock = std::make_unique<juce::InterProcessLock>(
-				plusDriveMirrorLockName(targetPath));
-			candidateEntered = candidateLock->enter(0);
-			if(!candidateEntered)
-			{
-				releasePlusDriveMirror(targetPath, this);
-				if(!oldPath.empty())
-					startPlusDrivePersistenceThread();
-				_result = "Another process already owns this auto-save mirror";
-				return false;
-			}
-		}
-		if(!exportPlusDriveImageUnlocked(_target, _result))
-		{
-			if(changingTarget)
-			{
-				releasePlusDriveMirror(targetPath, this);
-				candidateLock->exit();
-			}
-			if(!oldPath.empty())
-				startPlusDrivePersistenceThread();
-			return false;
-		}
-		if(changingTarget)
-		{
-			if(!oldPath.empty())
-				releasePlusDriveMirror(oldPath, this);
-			m_plusDriveInterprocessLock.reset();
-			m_plusDriveInterprocessLock = std::move(candidateLock);
-		}
-		{
-			std::lock_guard lock(m_plusDrivePersistenceMutex);
-			m_plusDriveAutoSavePath = targetPath;
-			m_plusDrivePersistenceStatus = "Auto-save mirror is current: "
-				+ _target.getFullPathName();
-		}
-		startPlusDrivePersistenceThread();
-		m_plusDrivePersistenceCv.notify_all();
-		_result = "+Drive auto-save mirror enabled at " + _target.getFullPathName();
-		return true;
-	}
-
-	void AudioPluginAudioProcessor::disablePlusDriveAutoSave()
-	{
-		stopPlusDrivePersistenceThread();
-		{
-			std::lock_guard lock(m_plusDrivePersistenceMutex);
-			m_plusDriveAutoSavePath.clear();
-			m_plusDriveFlushedRequest = m_plusDriveFlushRequest;
-			if(m_plusDrivePersistenceStatus.startsWith(
-				"Final auto-save mirror failed:"))
-				m_plusDrivePersistenceStatus = "Auto-save mirror disabled; "
-					+ m_plusDrivePersistenceStatus;
-			else
-				m_plusDrivePersistenceStatus =
-					"Project-owned +Drive; auto-save mirror disabled";
-		}
-		releasePlusDriveMirror(this);
-		m_plusDriveInterprocessLock.reset();
-	}
-
-	bool AudioPluginAudioProcessor::plusDriveAutoSaveEnabled() const
-	{
-		std::lock_guard lock(m_plusDrivePersistenceMutex);
-		return !m_plusDriveAutoSavePath.empty();
-	}
-
-	juce::File AudioPluginAudioProcessor::getPlusDriveAutoSaveFile() const
-	{
-		std::lock_guard lock(m_plusDrivePersistenceMutex);
-		return juce::File(juce::String::fromUTF8(m_plusDriveAutoSavePath.c_str()));
-	}
-
 	juce::String AudioPluginAudioProcessor::getPlusDrivePersistenceStatus() const
 	{
-		std::lock_guard lock(m_plusDrivePersistenceMutex);
-		return m_plusDrivePersistenceStatus;
+		return m_standalonePlusDrive
+			? m_standalonePlusDrive->status()
+			: "Project-owned +Drive; saved with the host project";
 	}
 
-	void AudioPluginAudioProcessor::startPlusDrivePersistenceThread()
+	void AudioPluginAudioProcessor::initializeStandalonePlusDrivePersistence()
 	{
-		std::lock_guard lock(m_plusDrivePersistenceMutex);
-		if(m_plusDrivePersistenceThread.joinable())
+		if(m_model != md::MachineModel::Machinedrum
+			|| wrapperType != juce::AudioProcessor::wrapperType_Standalone)
 			return;
-		m_plusDrivePersistenceStop = false;
-		m_plusDrivePersistenceThread = std::thread(
-			[this] { plusDrivePersistenceLoop(); });
+		const auto file = juce::File(juce::String::fromUTF8(getDataFolder().c_str()))
+			.getChildFile("nvram").getChildFile("md-plusdrive-standalone-v1.mdpd");
+		m_standalonePlusDrive = std::make_unique<StandalonePlusDrivePersistence>(
+			file, m_storageLoadMutex,
+			[this](const bool _includeData,
+				StandalonePlusDrivePersistence::Snapshot& _snapshot)
+			{
+				return capturePlusDrivePersistenceSnapshot(_includeData,
+					_snapshot.hardwareEpoch, _snapshot.generation, _snapshot.dirty,
+					_snapshot.data);
+			},
+			[this](const uint64_t _epoch, const uint64_t _generation)
+			{
+				acknowledgePlusDrivePersistence(_epoch, _generation);
+			});
+		const auto started = m_standalonePlusDrive->start();
+		if(!started.hasInitialImage)
+			return;
+		const bool installed = getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				return device && device->getModel() == md::MachineModel::Machinedrum
+					&& device->getHardware().replacePlusDriveData(
+						started.initialImage, false);
+			});
+		if(!installed)
+			m_standalonePlusDrive->blockWrites(
+				"The standalone +Drive checkpoint was valid but could not be installed");
 	}
 
-	void AudioPluginAudioProcessor::stopPlusDrivePersistenceThread()
+	bool AudioPluginAudioProcessor::capturePlusDrivePersistenceSnapshot(
+		const bool _includeData, uint64_t& _epoch, uint64_t& _generation,
+		bool& _dirty, std::vector<uint8_t>& _data)
 	{
-		{
-			std::lock_guard lock(m_plusDrivePersistenceMutex);
-			m_plusDrivePersistenceStop = true;
-		}
-		m_plusDrivePersistenceCv.notify_all();
-		if(m_plusDrivePersistenceThread.joinable())
-			m_plusDrivePersistenceThread.join();
-	}
-
-	void AudioPluginAudioProcessor::plusDrivePersistenceLoop()
-	{
-		using Clock = std::chrono::steady_clock;
-		md::Device* observedDevice = nullptr;
-		uint64_t observedEpoch = 0;
-		uint64_t observedGeneration = 0;
-		auto flushAfter = Clock::now();
-		while(true)
-		{
-			std::string targetPath;
-			uint64_t flushRequest = 0;
-			bool forced = false;
-			bool stopping = false;
-			{
-				std::unique_lock lock(m_plusDrivePersistenceMutex);
-				m_plusDrivePersistenceCv.wait_for(lock, std::chrono::milliseconds(250),
-					[this] { return m_plusDrivePersistenceStop; });
-				stopping = m_plusDrivePersistenceStop;
-				targetPath = m_plusDriveAutoSavePath;
-				flushRequest = m_plusDriveFlushRequest;
-				forced = flushRequest != m_plusDriveFlushedRequest;
-			}
-			if(targetPath.empty())
-			{
-				if(stopping)
-					return;
-				continue;
-			}
-
-			// A disabled, replaced or destroyed mirror gets one final current image.
-			// This bypasses the debounce but retains the same atomic write and
-			// generation-aware acknowledgement as a normal background flush.
-			if(stopping)
-			{
-				std::unique_lock operationLock(m_storageLoadMutex);
-				md::Device* deviceIdentity = nullptr;
-				uint64_t epoch = 0;
-				uint64_t generation = 0;
-				std::vector<uint8_t> data;
-				const bool captured = getPlugin().withDeviceLocked(
-					[&](synthLib::Device* const _device)
-					{
-						auto* const device = dynamic_cast<md::Device*>(_device);
-						if(!device
-							|| device->getModel() != md::MachineModel::Machinedrum)
-							return false;
-						deviceIdentity = device;
-						epoch = device->hardwareEpoch();
-						generation = device->getHardware().plusDriveGeneration();
-						data = device->getHardware().copyPlusDriveData();
-						return true;
-					});
-				juce::String error;
-				const juce::File target(
-					juce::String::fromUTF8(targetPath.c_str()));
-				const bool written = captured
-					&& storageImage::writePlusDriveAtomically(target, data, error);
-				{
-					std::lock_guard lock(m_plusDrivePersistenceMutex);
-					m_plusDrivePersistenceStatus = written
-						? "Auto-save mirror is current: " + target.getFullPathName()
-						: "Final auto-save mirror failed: "
-							+ (captured ? error : "local Machinedrum unavailable");
-					if(written && m_plusDriveAutoSavePath == targetPath)
-						m_plusDriveFlushedRequest = flushRequest;
-				}
-				if(written)
-					getPlugin().withDeviceLocked([&](synthLib::Device* const _device)
-					{
-						auto* const device = dynamic_cast<md::Device*>(_device);
-						if(device == deviceIdentity && device
-							&& device->hardwareEpoch() == epoch)
-							device->getHardware().markPlusDrivePersisted(generation);
-					});
-				return;
-			}
-
-			md::Device* deviceIdentity = nullptr;
-			uint64_t epoch = 0;
-			uint64_t generation = 0;
-			bool dirty = false;
-			getPlugin().withDeviceLocked([&](synthLib::Device* const _device)
+		return getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
 			{
 				auto* const device = dynamic_cast<md::Device*>(_device);
 				if(!device || device->getModel() != md::MachineModel::Machinedrum)
-					return;
-				deviceIdentity = device;
-				epoch = device->hardwareEpoch();
-				generation = device->getHardware().plusDriveGeneration();
-				dirty = device->getHardware().plusDriveDirty();
+					return false;
+				auto& hardware = device->getHardware();
+				_epoch = device->hardwareEpoch();
+				_generation = hardware.plusDriveGeneration();
+				_dirty = hardware.plusDriveDirty();
+				if(_includeData)
+					_data = hardware.copyPlusDriveData();
+				return true;
 			});
-			if(!deviceIdentity || (!dirty && !forced))
-				continue;
+	}
 
-			const auto now = Clock::now();
-			if(deviceIdentity != observedDevice || epoch != observedEpoch
-				|| generation != observedGeneration)
-			{
-				observedDevice = deviceIdentity;
-				observedEpoch = epoch;
-				observedGeneration = generation;
-				flushAfter = now + std::chrono::seconds(1);
-				continue;
-			}
-			if(now < flushAfter)
-				continue;
-			std::unique_lock operationLock(m_storageLoadMutex, std::try_to_lock);
-			if(!operationLock.owns_lock())
-				continue;
-
-			std::vector<uint8_t> data;
-			const bool snapshotValid = getPlugin().withDeviceLocked(
-				[&](synthLib::Device* const _device)
-				{
-					auto* const device = dynamic_cast<md::Device*>(_device);
-					if(device != deviceIdentity || !device
-						|| device->hardwareEpoch() != epoch
-						|| device->getHardware().plusDriveGeneration() != generation)
-						return false;
-					data = device->getHardware().copyPlusDriveData();
-					return true;
-				});
-			if(!snapshotValid)
-				continue;
-
-			juce::String error;
-			const juce::File target(juce::String::fromUTF8(targetPath.c_str()));
-			const bool written = storageImage::writePlusDriveAtomically(target, data, error);
-			bool sameTarget = false;
-			{
-				std::lock_guard lock(m_plusDrivePersistenceMutex);
-				sameTarget = m_plusDriveAutoSavePath == targetPath;
-				m_plusDrivePersistenceStatus = written
-					? "Auto-save mirror is current: " + target.getFullPathName()
-					: "Auto-save mirror failed: " + error;
-				if(written && sameTarget
-					&& flushRequest > m_plusDriveFlushedRequest)
-					m_plusDriveFlushedRequest = flushRequest;
-			}
-			if(written && sameTarget)
-			{
-				getPlugin().withDeviceLocked([&](synthLib::Device* const _device)
-				{
-					auto* const device = dynamic_cast<md::Device*>(_device);
-					if(device == deviceIdentity && device
-						&& device->hardwareEpoch() == epoch)
-						device->getHardware().markPlusDrivePersisted(generation);
-				});
-			}
-			flushAfter = Clock::now() + (written
-				? std::chrono::seconds(1) : std::chrono::seconds(2));
-		}
+	void AudioPluginAudioProcessor::acknowledgePlusDrivePersistence(
+		const uint64_t _epoch, const uint64_t _generation)
+	{
+		getPlugin().withDeviceLocked([&](synthLib::Device* const _device)
+		{
+			auto* const device = dynamic_cast<md::Device*>(_device);
+			if(device && device->getModel() == md::MachineModel::Machinedrum
+				&& device->hardwareEpoch() == _epoch)
+				device->getHardware().markPlusDrivePersisted(_generation);
+		});
 	}
 
 	AudioPluginAudioProcessor::AudioPluginAudioProcessor(const md::MachineModel _model)
@@ -935,14 +693,15 @@ namespace mdJucePlugin
 		getController();
 		const auto latencyBlocks = getConfig().getIntValue("latencyBlocks", static_cast<int>(getPlugin().getLatencyBlocks()));
 		Processor::setLatencyBlocks(latencyBlocks);
+		initializeStandalonePlusDrivePersistence();
 	}
 
 	AudioPluginAudioProcessor::~AudioPluginAudioProcessor()
 	{
 		destroyEditorState();
-		stopPlusDrivePersistenceThread();
-		releasePlusDriveMirror(this);
-		m_plusDriveInterprocessLock.reset();
+		if(m_standalonePlusDrive)
+			m_standalonePlusDrive->stop();
+		m_standalonePlusDrive.reset();
 	}
 
 	jucePluginEditorLib::PluginEditorState* AudioPluginAudioProcessor::createEditorState()

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
@@ -575,10 +575,13 @@ namespace mdJucePlugin
 	void AudioPluginAudioProcessor::initializeStandalonePlusDrivePersistence()
 	{
 		if(m_model != md::MachineModel::Machinedrum
-			|| wrapperType != juce::AudioProcessor::wrapperType_Standalone)
+			|| (wrapperType != juce::AudioProcessor::wrapperType_Standalone
+				&& m_standalonePlusDriveFile == juce::File()))
 			return;
-		const auto file = juce::File(juce::String::fromUTF8(getDataFolder().c_str()))
-			.getChildFile("nvram").getChildFile("md-plusdrive-standalone-v1.mdpd");
+		const auto file = m_standalonePlusDriveFile != juce::File()
+			? m_standalonePlusDriveFile
+			: juce::File(juce::String::fromUTF8(getDataFolder().c_str()))
+				.getChildFile("nvram").getChildFile("md-plusdrive-standalone-v1.mdpd");
 		m_standalonePlusDrive = std::make_unique<StandalonePlusDrivePersistence>(
 			file, m_storageLoadMutex,
 			[this](const bool _includeData,
@@ -658,14 +661,15 @@ namespace mdJucePlugin
 	}
 
 	AudioPluginAudioProcessor::AudioPluginAudioProcessor(const md::MachineModel _model,
-		EphemeralConfig, const bool _allowMcpServer) :
-		AudioPluginAudioProcessor(_model, std::vector<uint8_t>{}, _allowMcpServer, true)
+		EphemeralConfig _config, const bool _allowMcpServer) :
+		AudioPluginAudioProcessor(_model, std::vector<uint8_t>{}, _allowMcpServer,
+			true, std::move(_config.standalonePlusDriveFile))
 	{
 	}
 
 	AudioPluginAudioProcessor::AudioPluginAudioProcessor(const md::MachineModel _model,
 		std::vector<uint8_t> _initialPatchRam, const bool _allowMcpServer,
-		const bool _ephemeralConfig) :
+		const bool _ephemeralConfig, juce::File _standalonePlusDriveFile) :
 		Processor(makeBuses(_model),
 			getOptions(_model, _ephemeralConfig), makeProcessorProperties(_model),
 			_allowMcpServer, _ephemeralConfig
@@ -673,6 +677,7 @@ namespace mdJucePlugin
 				: jucePluginEditorLib::Processor::ConfigMode::Persistent)
 		, m_model(_model)
 		, m_initialPatchRam(std::move(_initialPatchRam))
+		, m_standalonePlusDriveFile(std::move(_standalonePlusDriveFile))
 	{
 		// The hardware-width skins need more than the generic 100% default. Keep
 		// the migration within a laptop desktop; the editor window restores this

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
@@ -4,7 +4,10 @@
 #include "mdLib/mdtypes.h"
 
 #include <string_view>
+#include <condition_variable>
+#include <memory>
 #include <mutex>
+#include <thread>
 #include <vector>
 
 namespace mdJucePlugin
@@ -29,13 +32,24 @@ namespace mdJucePlugin
 		juce::File getInstalledFactoryStorageImage() const;
 		juce::File getStorageRecoveryImage() const;
 		bool loadStorageImage(const juce::File& _source, juce::String& _result);
+		bool importPlusDriveImage(const juce::File& _source, juce::String& _result);
+		bool exportPlusDriveImage(const juce::File& _target, juce::String& _result);
+		bool resetPlusDrive(juce::String& _result);
+		bool rebootMachinedrum(juce::String& _result);
+		bool rebootDevice() override;
+		bool enablePlusDriveAutoSave(const juce::File& _target, juce::String& _result);
+		void disablePlusDriveAutoSave();
+		bool plusDriveAutoSaveEnabled() const;
+		juce::File getPlusDriveAutoSaveFile() const;
+		juce::String getPlusDrivePersistenceStatus() const;
 
 	    jucePluginEditorLib::PluginEditorState* createEditorState() override;
 	    synthLib::Device* createDevice() override;
 		void getRemoteDeviceParams(synthLib::DeviceCreateParams& _params) const override;
 
-	    pluginLib::Controller* createController() override;
+		pluginLib::Controller* createController() override;
 		void saveChunkData(baseLib::BinaryStream& _stream) override;
+		bool loadCustomData(const std::vector<uint8_t>& _sourceBuffer) override;
 		void loadChunkData(baseLib::ChunkReader& _reader) override;
 
 	private:
@@ -43,10 +57,26 @@ namespace mdJucePlugin
 		AudioPluginAudioProcessor(md::MachineModel _model,
 			std::vector<uint8_t> _initialPatchRam, bool _allowMcpServer,
 			bool _ephemeralConfig);
+		bool replacePlusDrive(std::vector<uint8_t> _replacement,
+			const juce::String& _operation, juce::String& _result);
+		bool exportPlusDriveImageUnlocked(const juce::File& _target,
+			juce::String& _result);
+		void startPlusDrivePersistenceThread();
+		void stopPlusDrivePersistenceThread();
+		void plusDrivePersistenceLoop();
 
 		const md::MachineModel m_model;
 		const std::vector<uint8_t> m_initialPatchRam;
 		std::mutex m_storageLoadMutex;
+		mutable std::mutex m_plusDrivePersistenceMutex;
+		std::condition_variable m_plusDrivePersistenceCv;
+		std::thread m_plusDrivePersistenceThread;
+		std::unique_ptr<juce::InterProcessLock> m_plusDriveInterprocessLock;
+		std::string m_plusDriveAutoSavePath;
+		juce::String m_plusDrivePersistenceStatus{"Project-owned +Drive"};
+		bool m_plusDrivePersistenceStop = false;
+		uint64_t m_plusDriveFlushRequest = 0;
+		uint64_t m_plusDriveFlushedRequest = 0;
 		JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioPluginAudioProcessor)
 	};
 }

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
@@ -15,7 +15,12 @@ namespace mdJucePlugin
 	class AudioPluginAudioProcessor : public jucePluginEditorLib::Processor
 	{
 	public:
-		struct EphemeralConfig final {};
+		struct EphemeralConfig final
+		{
+			// Tests may route the standalone checkpoint into an isolated directory.
+			// Production callers leave this empty and use the fixed user-data path.
+			juce::File standalonePlusDriveFile;
+		};
 
 	    AudioPluginAudioProcessor();
 		explicit AudioPluginAudioProcessor(md::MachineModel _model);
@@ -52,7 +57,7 @@ namespace mdJucePlugin
 		static BusesProperties makeBuses(md::MachineModel _model);
 		AudioPluginAudioProcessor(md::MachineModel _model,
 			std::vector<uint8_t> _initialPatchRam, bool _allowMcpServer,
-			bool _ephemeralConfig);
+			bool _ephemeralConfig, juce::File _standalonePlusDriveFile = {});
 		bool replacePlusDrive(std::vector<uint8_t> _replacement,
 			const juce::String& _operation, juce::String& _result);
 		bool exportPlusDriveImageUnlocked(const juce::File& _target,
@@ -65,6 +70,7 @@ namespace mdJucePlugin
 
 		const md::MachineModel m_model;
 		const std::vector<uint8_t> m_initialPatchRam;
+		const juce::File m_standalonePlusDriveFile;
 		std::mutex m_storageLoadMutex;
 		std::unique_ptr<StandalonePlusDrivePersistence> m_standalonePlusDrive;
 		JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioPluginAudioProcessor)

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
@@ -4,14 +4,14 @@
 #include "mdLib/mdtypes.h"
 
 #include <string_view>
-#include <condition_variable>
 #include <memory>
 #include <mutex>
-#include <thread>
 #include <vector>
 
 namespace mdJucePlugin
 {
+	class StandalonePlusDrivePersistence;
+
 	class AudioPluginAudioProcessor : public jucePluginEditorLib::Processor
 	{
 	public:
@@ -37,10 +37,6 @@ namespace mdJucePlugin
 		bool resetPlusDrive(juce::String& _result);
 		bool rebootMachinedrum(juce::String& _result);
 		bool rebootDevice() override;
-		bool enablePlusDriveAutoSave(const juce::File& _target, juce::String& _result);
-		void disablePlusDriveAutoSave();
-		bool plusDriveAutoSaveEnabled() const;
-		juce::File getPlusDriveAutoSaveFile() const;
 		juce::String getPlusDrivePersistenceStatus() const;
 
 	    jucePluginEditorLib::PluginEditorState* createEditorState() override;
@@ -61,22 +57,16 @@ namespace mdJucePlugin
 			const juce::String& _operation, juce::String& _result);
 		bool exportPlusDriveImageUnlocked(const juce::File& _target,
 			juce::String& _result);
-		void startPlusDrivePersistenceThread();
-		void stopPlusDrivePersistenceThread();
-		void plusDrivePersistenceLoop();
+		void initializeStandalonePlusDrivePersistence();
+		bool capturePlusDrivePersistenceSnapshot(bool _includeData,
+			uint64_t& _epoch, uint64_t& _generation, bool& _dirty,
+			std::vector<uint8_t>& _data);
+		void acknowledgePlusDrivePersistence(uint64_t _epoch, uint64_t _generation);
 
 		const md::MachineModel m_model;
 		const std::vector<uint8_t> m_initialPatchRam;
 		std::mutex m_storageLoadMutex;
-		mutable std::mutex m_plusDrivePersistenceMutex;
-		std::condition_variable m_plusDrivePersistenceCv;
-		std::thread m_plusDrivePersistenceThread;
-		std::unique_ptr<juce::InterProcessLock> m_plusDriveInterprocessLock;
-		std::string m_plusDriveAutoSavePath;
-		juce::String m_plusDrivePersistenceStatus{"Project-owned +Drive"};
-		bool m_plusDrivePersistenceStop = false;
-		uint64_t m_plusDriveFlushRequest = 0;
-		uint64_t m_plusDriveFlushedRequest = 0;
+		std::unique_ptr<StandalonePlusDrivePersistence> m_standalonePlusDrive;
 		JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioPluginAudioProcessor)
 	};
 }

--- a/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.cpp
+++ b/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.cpp
@@ -1,6 +1,7 @@
 #include "mdSettingsPanelFeel.h"
 
 #include "mdEditor.h"
+#include "mdPluginProcessor.h"
 
 #include "jucePluginEditorLib/pluginProcessor.h"
 
@@ -10,6 +11,8 @@
 #include "juceRmlUi/rmlHelper.h"
 
 #include "RmlUi/Core/Element.h"
+
+#include <utility>
 
 namespace mdJucePlugin
 {
@@ -57,6 +60,25 @@ namespace mdJucePlugin
 			_root, "sysexDropTarget", false))
 			m_sysexDropTarget = std::make_unique<SysexDropTarget>(m_editor, drop);
 		m_sysexStatus = juceRmlUi::helper::findChild(_root, "sysexTransferStatus", false);
+		m_plusDriveStatus = juceRmlUi::helper::findChild(_root, "plusDriveStatus", false);
+		const auto bind = [_root, this](const char* const _id, auto&& _callback)
+		{
+			if(auto* const button = juceRmlUi::helper::findChild(_root, _id, false))
+				juceRmlUi::EventListener::AddClick(button,
+					[this, callback = std::forward<decltype(_callback)>(_callback)]
+					{ callback(m_editor); });
+		};
+		bind("btImportPlusDrive", [](Editor& _editor) { _editor.choosePlusDriveImport(); });
+		bind("btExportPlusDrive", [](Editor& _editor) { _editor.choosePlusDriveExport(); });
+		bind("btEnablePlusDriveAutoSave",
+			[](Editor& _editor) { _editor.choosePlusDriveAutoSave(); });
+		bind("btRebootMachinedrum", [](Editor& _editor) { _editor.rebootMachinedrum(); });
+		bind("btResetPlusDrive", [](Editor& _editor) { _editor.resetPlusDrive(); });
+		m_disablePlusDriveAutoSave = juceRmlUi::helper::findChild(
+			_root, "btDisablePlusDriveAutoSave", false);
+		if(m_disablePlusDriveAutoSave)
+			juceRmlUi::EventListener::AddClick(m_disablePlusDriveAutoSave, [this]
+			{ m_editor.disablePlusDriveAutoSave(); });
 
 		if(auto* const loadFactory = juceRmlUi::helper::findChild(
 			_root, "btLoadInstalledFactoryStorage", false))
@@ -86,7 +108,7 @@ namespace mdJucePlugin
 		}
 		if(m_sysexStatus)
 			startTimerHz(10);
-		else if(m_restoreStorage)
+		else if(m_restoreStorage || m_plusDriveStatus)
 			startTimerHz(2);
 	}
 
@@ -97,6 +119,15 @@ namespace mdJucePlugin
 		updateRestoreAvailability();
 		if(m_sysexStatus)
 			m_sysexStatus->SetInnerRML(m_editor.sysexTransferStatusText());
+		if(m_plusDriveStatus)
+			m_plusDriveStatus->SetInnerRML(m_editor.plusDriveStatusText());
+		if(m_disablePlusDriveAutoSave)
+		{
+			auto* const processor = dynamic_cast<AudioPluginAudioProcessor*>(
+				&m_editor.getProcessor());
+			juceRmlUi::helper::setEnabled(m_disablePlusDriveAutoSave,
+				processor && processor->plusDriveAutoSaveEnabled());
+		}
 	}
 
 	void SettingsPanelFeel::updateRestoreAvailability()

--- a/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.cpp
+++ b/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.cpp
@@ -1,7 +1,6 @@
 #include "mdSettingsPanelFeel.h"
 
 #include "mdEditor.h"
-#include "mdPluginProcessor.h"
 
 #include "jucePluginEditorLib/pluginProcessor.h"
 
@@ -70,15 +69,8 @@ namespace mdJucePlugin
 		};
 		bind("btImportPlusDrive", [](Editor& _editor) { _editor.choosePlusDriveImport(); });
 		bind("btExportPlusDrive", [](Editor& _editor) { _editor.choosePlusDriveExport(); });
-		bind("btEnablePlusDriveAutoSave",
-			[](Editor& _editor) { _editor.choosePlusDriveAutoSave(); });
 		bind("btRebootMachinedrum", [](Editor& _editor) { _editor.rebootMachinedrum(); });
 		bind("btResetPlusDrive", [](Editor& _editor) { _editor.resetPlusDrive(); });
-		m_disablePlusDriveAutoSave = juceRmlUi::helper::findChild(
-			_root, "btDisablePlusDriveAutoSave", false);
-		if(m_disablePlusDriveAutoSave)
-			juceRmlUi::EventListener::AddClick(m_disablePlusDriveAutoSave, [this]
-			{ m_editor.disablePlusDriveAutoSave(); });
 
 		if(auto* const loadFactory = juceRmlUi::helper::findChild(
 			_root, "btLoadInstalledFactoryStorage", false))
@@ -121,13 +113,6 @@ namespace mdJucePlugin
 			m_sysexStatus->SetInnerRML(m_editor.sysexTransferStatusText());
 		if(m_plusDriveStatus)
 			m_plusDriveStatus->SetInnerRML(m_editor.plusDriveStatusText());
-		if(m_disablePlusDriveAutoSave)
-		{
-			auto* const processor = dynamic_cast<AudioPluginAudioProcessor*>(
-				&m_editor.getProcessor());
-			juceRmlUi::helper::setEnabled(m_disablePlusDriveAutoSave,
-				processor && processor->plusDriveAutoSaveEnabled());
-		}
 	}
 
 	void SettingsPanelFeel::updateRestoreAvailability()

--- a/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.h
+++ b/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.h
@@ -32,6 +32,8 @@ namespace mdJucePlugin
 		Editor& m_editor;
 		Rml::Element* m_restoreStorage = nullptr;
 		Rml::Element* m_sysexStatus = nullptr;
+		Rml::Element* m_plusDriveStatus = nullptr;
+		Rml::Element* m_disablePlusDriveAutoSave = nullptr;
 		std::unique_ptr<SysexDropTarget> m_sysexDropTarget;
 	};
 }

--- a/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.h
+++ b/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.h
@@ -33,7 +33,6 @@ namespace mdJucePlugin
 		Rml::Element* m_restoreStorage = nullptr;
 		Rml::Element* m_sysexStatus = nullptr;
 		Rml::Element* m_plusDriveStatus = nullptr;
-		Rml::Element* m_disablePlusDriveAutoSave = nullptr;
 		std::unique_ptr<SysexDropTarget> m_sysexDropTarget;
 	};
 }

--- a/source/elektron/md/mdJucePlugin/mdStandalonePlusDrivePersistence.cpp
+++ b/source/elektron/md/mdJucePlugin/mdStandalonePlusDrivePersistence.cpp
@@ -100,7 +100,8 @@ namespace mdJucePlugin
 			if(result.hasInitialImage)
 				m_status = m_writer
 					? "Standalone +Drive checkpoint active: " + m_file.getFullPathName()
-					: "Standalone +Drive opened without persistence; another instance owns "
+					: "Standalone +Drive is read-only for this session; restart after closing "
+						"the other instance to persist changes. Checkpoint: "
 						+ m_file.getFullPathName();
 			else if(m_file.existsAsFile())
 				m_status = m_writer
@@ -112,7 +113,8 @@ namespace mdJucePlugin
 				m_status = m_writer
 					? "Standalone +Drive checkpoint will be created at "
 						+ m_file.getFullPathName()
-					: "Standalone +Drive is temporary; another instance owns "
+					: "Standalone +Drive is temporary for this session; restart after closing "
+						"the other instance to persist changes. Checkpoint: "
 						+ m_file.getFullPathName();
 		}
 

--- a/source/elektron/md/mdJucePlugin/mdStandalonePlusDrivePersistence.cpp
+++ b/source/elektron/md/mdJucePlugin/mdStandalonePlusDrivePersistence.cpp
@@ -1,0 +1,335 @@
+#include "mdStandalonePlusDrivePersistence.h"
+
+#include "mdStorageImage.h"
+
+#include <chrono>
+#include <utility>
+
+namespace
+{
+	std::mutex g_standalonePlusDriveOwnerMutex;
+	const mdJucePlugin::StandalonePlusDrivePersistence* g_standalonePlusDriveOwner = nullptr;
+
+	bool claimStandalonePlusDrive(
+		const mdJucePlugin::StandalonePlusDrivePersistence* const _owner)
+	{
+		std::lock_guard lock(g_standalonePlusDriveOwnerMutex);
+		if(g_standalonePlusDriveOwner && g_standalonePlusDriveOwner != _owner)
+			return false;
+		g_standalonePlusDriveOwner = _owner;
+		return true;
+	}
+
+	void releaseStandalonePlusDrive(
+		const mdJucePlugin::StandalonePlusDrivePersistence* const _owner)
+	{
+		std::lock_guard lock(g_standalonePlusDriveOwnerMutex);
+		if(g_standalonePlusDriveOwner == _owner)
+			g_standalonePlusDriveOwner = nullptr;
+	}
+
+	juce::String lockName(const juce::File& _file)
+	{
+		return "gearmulator-md-standalone-plusdrive-"
+			+ juce::String::toHexString(_file.getFullPathName().hashCode64());
+	}
+}
+
+namespace mdJucePlugin
+{
+	StandalonePlusDrivePersistence::StandalonePlusDrivePersistence(
+		juce::File _file, std::mutex& _operationMutex, Capture _capture,
+		Acknowledge _acknowledge)
+		: m_file(std::move(_file))
+		, m_operationMutex(_operationMutex)
+		, m_capture(std::move(_capture))
+		, m_acknowledge(std::move(_acknowledge))
+	{
+	}
+
+	StandalonePlusDrivePersistence::~StandalonePlusDrivePersistence()
+	{
+		stop();
+	}
+
+	StandalonePlusDrivePersistence::StartResult
+	StandalonePlusDrivePersistence::start()
+	{
+		StartResult result;
+		{
+			std::lock_guard lock(m_mutex);
+			if(m_started)
+			{
+				result.writable = m_writer && !m_writeBlocked;
+				return result;
+			}
+			m_started = true;
+		}
+		Snapshot initialMetadata;
+		if(m_capture(false, initialMetadata))
+		{
+			m_hasInitialGeneration = true;
+			m_initialHardwareEpoch = initialMetadata.hardwareEpoch;
+			m_initialGeneration = initialMetadata.generation;
+		}
+
+		const bool inProcessOwner = claimStandalonePlusDrive(this);
+		if(inProcessOwner)
+		{
+			m_interprocessLock = std::make_unique<juce::InterProcessLock>(lockName(m_file));
+			m_writer = m_interprocessLock->enter(0);
+			if(!m_writer)
+			{
+				m_interprocessLock.reset();
+				releaseStandalonePlusDrive(this);
+			}
+		}
+
+		juce::String readError;
+		if(m_file.existsAsFile())
+		{
+			result.hasInitialImage = storageImage::readPlusDrive(
+				m_file, result.initialImage, readError);
+			m_authoritative = result.hasInitialImage;
+			if(!result.hasInitialImage && m_writer)
+				m_writeBlocked = true;
+		}
+
+		{
+			std::lock_guard lock(m_mutex);
+			if(result.hasInitialImage)
+				m_status = m_writer
+					? "Standalone +Drive checkpoint active: " + m_file.getFullPathName()
+					: "Standalone +Drive opened without persistence; another instance owns "
+						+ m_file.getFullPathName();
+			else if(m_file.existsAsFile())
+				m_status = m_writer
+					? "Standalone +Drive checkpoint is invalid and was preserved. Import a valid image to replace it. "
+						+ readError
+					: "Standalone +Drive checkpoint is unavailable and another instance owns it. "
+						+ readError;
+			else
+				m_status = m_writer
+					? "Standalone +Drive checkpoint will be created at "
+						+ m_file.getFullPathName()
+					: "Standalone +Drive is temporary; another instance owns "
+						+ m_file.getFullPathName();
+		}
+
+		result.writable = m_writer && !m_writeBlocked;
+		startThreadIfAllowed();
+		return result;
+	}
+
+	void StandalonePlusDrivePersistence::stop()
+	{
+		{
+			std::lock_guard lock(m_mutex);
+			if(!m_started)
+				return;
+			m_stop = true;
+		}
+		m_cv.notify_all();
+		if(m_thread.joinable())
+			m_thread.join();
+		if(m_interprocessLock)
+		{
+			m_interprocessLock->exit();
+			m_interprocessLock.reset();
+		}
+		releaseStandalonePlusDrive(this);
+		std::lock_guard lock(m_mutex);
+		m_started = false;
+		m_writer = false;
+	}
+
+	void StandalonePlusDrivePersistence::requestFlush(const bool _adoptCurrent)
+	{
+		{
+			std::lock_guard lock(m_mutex);
+			if(_adoptCurrent)
+				m_authoritative = true;
+			++m_flushRequest;
+		}
+		m_cv.notify_all();
+	}
+
+	void StandalonePlusDrivePersistence::allowReplacementAndFlush()
+	{
+		{
+			std::lock_guard lock(m_mutex);
+			m_writeBlocked = false;
+			m_authoritative = true;
+			++m_flushRequest;
+		}
+		startThreadIfAllowed();
+		m_cv.notify_all();
+	}
+
+	void StandalonePlusDrivePersistence::blockWrites(const juce::String& _reason)
+	{
+		{
+			std::lock_guard lock(m_mutex);
+			m_writeBlocked = true;
+			m_stop = true;
+			m_status = _reason;
+		}
+		m_cv.notify_all();
+		if(m_thread.joinable())
+			m_thread.join();
+		std::lock_guard lock(m_mutex);
+		m_stop = false;
+	}
+
+	bool StandalonePlusDrivePersistence::ownsWriter() const
+	{
+		std::lock_guard lock(m_mutex);
+		return m_writer;
+	}
+
+	bool StandalonePlusDrivePersistence::writable() const
+	{
+		std::lock_guard lock(m_mutex);
+		return m_writer && !m_writeBlocked;
+	}
+
+	bool StandalonePlusDrivePersistence::authoritative() const
+	{
+		std::lock_guard lock(m_mutex);
+		return m_authoritative;
+	}
+
+	juce::String StandalonePlusDrivePersistence::status() const
+	{
+		std::lock_guard lock(m_mutex);
+		return m_status;
+	}
+
+	void StandalonePlusDrivePersistence::startThreadIfAllowed()
+	{
+		std::lock_guard lock(m_mutex);
+		if(m_writer && !m_writeBlocked && !m_thread.joinable())
+		{
+			m_stop = false;
+			m_thread = std::thread([this] { run(); });
+		}
+	}
+
+	bool StandalonePlusDrivePersistence::writeSnapshot(
+		const Snapshot& _snapshot, const char* const _failurePrefix)
+	{
+		juce::String error;
+		const bool written = storageImage::writePlusDriveAtomically(
+			m_file, _snapshot.data, error);
+		{
+			std::lock_guard lock(m_mutex);
+			m_status = written
+				? "Standalone +Drive checkpoint is current: " + m_file.getFullPathName()
+				: juce::String(_failurePrefix) + error;
+			if(written)
+				m_authoritative = true;
+		}
+		if(written)
+			m_acknowledge(_snapshot.hardwareEpoch, _snapshot.generation);
+		return written;
+	}
+
+	void StandalonePlusDrivePersistence::run()
+	{
+		using Clock = std::chrono::steady_clock;
+		uint64_t observedEpoch = 0;
+		uint64_t observedGeneration = 0;
+		auto flushAfter = Clock::now();
+		while(true)
+		{
+			uint64_t flushRequest = 0;
+			uint64_t flushedRequest = 0;
+			bool stopping = false;
+			bool writeBlocked = false;
+			bool authoritative = false;
+			{
+				std::unique_lock lock(m_mutex);
+				m_cv.wait_for(lock, std::chrono::milliseconds(250),
+					[this] { return m_stop; });
+				stopping = m_stop;
+				writeBlocked = m_writeBlocked;
+				authoritative = m_authoritative;
+				flushRequest = m_flushRequest;
+				flushedRequest = m_flushedRequest;
+			}
+			if(writeBlocked)
+				return;
+
+			std::unique_lock operationLock(m_operationMutex, std::defer_lock);
+			if(stopping)
+				operationLock.lock();
+			else if(!operationLock.try_lock())
+				continue;
+
+			Snapshot metadata;
+			if(!m_capture(false, metadata))
+			{
+				if(stopping)
+					return;
+				continue;
+			}
+
+			const bool forced = flushRequest != flushedRequest;
+			const bool changedSinceStart = m_hasInitialGeneration
+				&& (metadata.hardwareEpoch != m_initialHardwareEpoch
+					|| metadata.generation != m_initialGeneration);
+			if(!authoritative && !forced && !changedSinceStart)
+			{
+				if(stopping)
+					return;
+				continue;
+			}
+			if(!authoritative)
+			{
+				std::lock_guard lock(m_mutex);
+				m_authoritative = true;
+			}
+			if(stopping)
+			{
+				Snapshot snapshot;
+				if(m_capture(true, snapshot)
+					&& writeSnapshot(snapshot, "Final standalone +Drive checkpoint failed: "))
+				{
+					std::lock_guard lock(m_mutex);
+					m_flushedRequest = flushRequest;
+				}
+				return;
+			}
+			if(!metadata.dirty && !forced)
+				continue;
+
+			const auto now = Clock::now();
+			if(metadata.hardwareEpoch != observedEpoch
+				|| metadata.generation != observedGeneration)
+			{
+				observedEpoch = metadata.hardwareEpoch;
+				observedGeneration = metadata.generation;
+				flushAfter = now + std::chrono::seconds(1);
+				continue;
+			}
+			if(now < flushAfter)
+				continue;
+
+			Snapshot snapshot;
+			if(!m_capture(true, snapshot)
+				|| snapshot.hardwareEpoch != metadata.hardwareEpoch
+				|| snapshot.generation != metadata.generation)
+				continue;
+			const bool written = writeSnapshot(snapshot,
+				"Standalone +Drive checkpoint failed: ");
+			if(written)
+			{
+				std::lock_guard lock(m_mutex);
+				if(flushRequest > m_flushedRequest)
+					m_flushedRequest = flushRequest;
+			}
+			flushAfter = Clock::now() + (written
+				? std::chrono::seconds(1) : std::chrono::seconds(2));
+		}
+	}
+}

--- a/source/elektron/md/mdJucePlugin/mdStandalonePlusDrivePersistence.h
+++ b/source/elektron/md/mdJucePlugin/mdStandalonePlusDrivePersistence.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "juce_core/juce_core.h"
+
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace mdJucePlugin
+{
+	class StandalonePlusDrivePersistence final
+	{
+	public:
+		struct Snapshot
+		{
+			uint64_t hardwareEpoch = 0;
+			uint64_t generation = 0;
+			bool dirty = false;
+			std::vector<uint8_t> data;
+		};
+
+		using Capture = std::function<bool(bool, Snapshot&)>;
+		using Acknowledge = std::function<void(uint64_t, uint64_t)>;
+
+		struct StartResult
+		{
+			std::vector<uint8_t> initialImage;
+			bool hasInitialImage = false;
+			bool writable = false;
+		};
+
+		StandalonePlusDrivePersistence(juce::File _file, std::mutex& _operationMutex,
+			Capture _capture, Acknowledge _acknowledge);
+		~StandalonePlusDrivePersistence();
+
+		StartResult start();
+		void stop();
+		void requestFlush(bool _adoptCurrent = false);
+		void allowReplacementAndFlush();
+		void blockWrites(const juce::String& _reason);
+
+		bool ownsWriter() const;
+		bool writable() const;
+		bool authoritative() const;
+		juce::String status() const;
+		const juce::File& file() const { return m_file; }
+
+	private:
+		void startThreadIfAllowed();
+		void run();
+		bool writeSnapshot(const Snapshot& _snapshot, const char* _failurePrefix);
+
+		const juce::File m_file;
+		std::mutex& m_operationMutex;
+		const Capture m_capture;
+		const Acknowledge m_acknowledge;
+		mutable std::mutex m_mutex;
+		std::condition_variable m_cv;
+		std::thread m_thread;
+		std::unique_ptr<juce::InterProcessLock> m_interprocessLock;
+		juce::String m_status;
+		bool m_started = false;
+		bool m_writer = false;
+		bool m_writeBlocked = false;
+		bool m_stop = false;
+		bool m_authoritative = false;
+		bool m_hasInitialGeneration = false;
+		uint64_t m_initialHardwareEpoch = 0;
+		uint64_t m_initialGeneration = 0;
+		uint64_t m_flushRequest = 0;
+		uint64_t m_flushedRequest = 0;
+	};
+}

--- a/source/elektron/md/mdJucePlugin/mdStandalonePlusDrivePersistenceTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdStandalonePlusDrivePersistenceTest.cpp
@@ -1,0 +1,159 @@
+#include "mdStandalonePlusDrivePersistence.h"
+
+#include "mdLib/mdplusdrive.h"
+
+#include "baseLib/filesystem.h"
+
+#include <chrono>
+#include <cstdio>
+#include <mutex>
+#include <thread>
+
+namespace
+{
+	std::vector<uint8_t> makeImage(const uint32_t _sector, const uint8_t _value)
+	{
+		md::PlusDrive drive;
+		auto image = drive.copyStorage();
+		image[15] = 1;
+		image.push_back(static_cast<uint8_t>(_sector >> 24));
+		image.push_back(static_cast<uint8_t>(_sector >> 16));
+		image.push_back(static_cast<uint8_t>(_sector >> 8));
+		image.push_back(static_cast<uint8_t>(_sector));
+		image.insert(image.end(), 512, _value);
+		return image;
+	}
+
+	bool waitForImage(const juce::File& _file, const std::vector<uint8_t>& _expected)
+	{
+		for(int attempt = 0; attempt < 80; ++attempt)
+		{
+			std::vector<uint8_t> actual;
+			if(baseLib::filesystem::readFile(
+				actual, _file.getFullPathName().toStdString()) && actual == _expected)
+				return true;
+			std::this_thread::sleep_for(std::chrono::milliseconds(50));
+		}
+		return false;
+	}
+
+	int fail(const char* const _message)
+	{
+		std::fprintf(stderr, "mdStandalonePlusDrivePersistenceTest: %s\n", _message);
+		return 1;
+	}
+}
+
+int main()
+{
+	const auto directory = juce::File::getCurrentWorkingDirectory()
+		.getNonexistentChildFile("gearmulator-md-standalone-plusdrive-test", {}, false);
+	const auto createResult = directory.createDirectory();
+	if(createResult.failed())
+	{
+		std::fprintf(stderr,
+			"mdStandalonePlusDrivePersistenceTest: could not create %s: %s\n",
+			directory.getFullPathName().toRawUTF8(),
+			createResult.getErrorMessage().toRawUTF8());
+		return 1;
+	}
+	struct Cleanup final
+	{
+		juce::File directory;
+		~Cleanup() { directory.deleteRecursively(); }
+	} cleanup{directory};
+
+	const auto imageA = makeImage(7, 0x5a);
+	const auto imageB = makeImage(9, 0x27);
+	if(!md::PlusDrive::validateStorage(imageA)
+		|| !md::PlusDrive::validateStorage(imageB))
+		return fail("test image was invalid");
+
+	std::mutex operationMutex;
+	std::mutex stateMutex;
+	mdJucePlugin::StandalonePlusDrivePersistence::Snapshot live;
+	live.hardwareEpoch = 1;
+	live.generation = 1;
+	live.dirty = true;
+	live.data = imageA;
+	const auto capture = [&](const bool _includeData,
+		mdJucePlugin::StandalonePlusDrivePersistence::Snapshot& _snapshot)
+	{
+		std::lock_guard lock(stateMutex);
+		_snapshot.hardwareEpoch = live.hardwareEpoch;
+		_snapshot.generation = live.generation;
+		_snapshot.dirty = live.dirty;
+		if(_includeData)
+			_snapshot.data = live.data;
+		return true;
+	};
+	const auto acknowledge = [&](const uint64_t _epoch, const uint64_t _generation)
+	{
+		std::lock_guard lock(stateMutex);
+		if(live.hardwareEpoch == _epoch && live.generation == _generation)
+			live.dirty = false;
+	};
+
+	const auto file = directory.getChildFile("standalone.mdpd");
+	{
+		mdJucePlugin::StandalonePlusDrivePersistence owner(
+			file, operationMutex, capture, acknowledge);
+		const auto ownerStart = owner.start();
+		if(!ownerStart.writable || ownerStart.hasInitialImage)
+			return fail("new checkpoint did not acquire sole write ownership");
+
+		mdJucePlugin::StandalonePlusDrivePersistence competitor(
+			file, operationMutex, capture, acknowledge);
+		const auto competitorStart = competitor.start();
+		if(competitorStart.writable || competitor.ownsWriter())
+			return fail("two instances acquired the standalone checkpoint");
+
+		std::this_thread::sleep_for(std::chrono::milliseconds(1250));
+		if(file.existsAsFile() || owner.authoritative())
+			return fail("initial firmware dirtiness was mistaken for user-owned state");
+
+		owner.requestFlush(true);
+		if(!waitForImage(file, imageA) || !owner.authoritative())
+			return fail("first debounced checkpoint was not committed");
+		{
+			std::lock_guard lock(stateMutex);
+			live.generation = 2;
+			live.dirty = true;
+			live.data = imageB;
+		}
+		if(!waitForImage(file, imageB))
+			return fail("dirty generation was not checkpointed");
+		competitor.stop();
+		owner.stop();
+	}
+
+	{
+		mdJucePlugin::StandalonePlusDrivePersistence restored(
+			file, operationMutex, capture, acknowledge);
+		const auto start = restored.start();
+		if(!start.writable || !start.hasInitialImage || start.initialImage != imageB
+			|| !restored.authoritative())
+			return fail("checkpoint did not restore as the standalone authority");
+		restored.stop();
+	}
+
+	const auto corruptFile = directory.getChildFile("corrupt.mdpd");
+	const std::vector<uint8_t> corrupt{1, 2, 3, 4};
+	if(!baseLib::filesystem::writeFileAtomic(
+		corruptFile.getFullPathName().toStdString(), corrupt))
+		return fail("could not prepare corrupt checkpoint");
+	{
+		mdJucePlugin::StandalonePlusDrivePersistence recovery(
+			corruptFile, operationMutex, capture, acknowledge);
+		const auto start = recovery.start();
+		if(!recovery.ownsWriter() || start.writable || start.hasInitialImage)
+			return fail("invalid checkpoint was not preserved behind explicit recovery");
+		recovery.allowReplacementAndFlush();
+		if(!waitForImage(corruptFile, imageB))
+			return fail("explicit recovery did not replace the invalid checkpoint");
+		recovery.stop();
+	}
+
+	std::puts("mdStandalonePlusDrivePersistenceTest: PASS");
+	return 0;
+}

--- a/source/elektron/md/mdJucePlugin/mdStandalonePlusDrivePersistenceTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdStandalonePlusDrivePersistenceTest.cpp
@@ -6,7 +6,9 @@
 
 #include <chrono>
 #include <cstdio>
+#include <initializer_list>
 #include <mutex>
+#include <string>
 #include <thread>
 
 namespace
@@ -26,11 +28,22 @@ namespace
 
 	bool waitForImage(const juce::File& _file, const std::vector<uint8_t>& _expected)
 	{
-		for(int attempt = 0; attempt < 80; ++attempt)
+		for(int attempt = 0; attempt < 120; ++attempt)
 		{
 			std::vector<uint8_t> actual;
 			if(baseLib::filesystem::readFile(
 				actual, _file.getFullPathName().toStdString()) && actual == _expected)
+				return true;
+			std::this_thread::sleep_for(std::chrono::milliseconds(50));
+		}
+		return false;
+	}
+
+	bool waitForFile(const juce::File& _file)
+	{
+		for(int attempt = 0; attempt < 120; ++attempt)
+		{
+			if(_file.existsAsFile())
 				return true;
 			std::this_thread::sleep_for(std::chrono::milliseconds(50));
 		}
@@ -42,10 +55,137 @@ namespace
 		std::fprintf(stderr, "mdStandalonePlusDrivePersistenceTest: %s\n", _message);
 		return 1;
 	}
+
+	struct LiveState final
+	{
+		std::mutex operationMutex;
+		std::mutex stateMutex;
+		mdJucePlugin::StandalonePlusDrivePersistence::Snapshot live;
+
+		mdJucePlugin::StandalonePlusDrivePersistence makePersistence(
+			const juce::File& _file)
+		{
+			return {
+				_file, operationMutex,
+				[this](const bool _includeData,
+					mdJucePlugin::StandalonePlusDrivePersistence::Snapshot& _snapshot)
+				{
+					std::lock_guard lock(stateMutex);
+					_snapshot.hardwareEpoch = live.hardwareEpoch;
+					_snapshot.generation = live.generation;
+					_snapshot.dirty = live.dirty;
+					if(_includeData)
+						_snapshot.data = live.data;
+					return true;
+				},
+				[this](const uint64_t _epoch, const uint64_t _generation)
+				{
+					std::lock_guard lock(stateMutex);
+					if(live.hardwareEpoch == _epoch && live.generation == _generation)
+						live.dirty = false;
+				}
+			};
+		}
+	};
+
+	int runOwnerChild(const juce::File& _checkpoint, const juce::File& _ready,
+		const juce::File& _release)
+	{
+		LiveState state;
+		state.live = {1, 1, false, makeImage(7, 0x5a)};
+		auto persistence = state.makePersistence(_checkpoint);
+		const auto started = persistence.start();
+		if(!started.writable)
+			return fail("owner child could not acquire checkpoint");
+		persistence.requestFlush(true);
+		if(!waitForImage(_checkpoint, state.live.data)
+			|| !_ready.replaceWithText("ready"))
+			return fail("owner child did not become ready");
+		for(int attempt = 0; attempt < 400 && !_release.existsAsFile(); ++attempt)
+			std::this_thread::sleep_for(std::chrono::milliseconds(50));
+		if(!_release.existsAsFile())
+			return fail("owner child timed out waiting for release");
+		persistence.stop();
+		return 0;
+	}
+
+	int runProbeChild(const juce::File& _checkpoint, const bool _expectWriter)
+	{
+		LiveState state;
+		state.live = {1, 1, false, makeImage(7, 0x5a)};
+		auto persistence = state.makePersistence(_checkpoint);
+		const auto started = persistence.start();
+		const bool isWriter = started.writable && persistence.ownsWriter();
+		if(isWriter != _expectWriter)
+			return fail(_expectWriter
+				? "fresh process could not take over released checkpoint"
+				: "separate process acquired an already-owned checkpoint");
+		if(!_expectWriter && !persistence.status().containsIgnoreCase("restart"))
+			return fail("read-only ownership status did not explain recovery");
+		persistence.stop();
+		return 0;
+	}
+
+	int runChangeChild(const juce::File& _checkpoint, const juce::File& _ready)
+	{
+		LiveState state;
+		state.live = {1, 1, false, makeImage(7, 0x5a)};
+		auto persistence = state.makePersistence(_checkpoint);
+		const auto started = persistence.start();
+		if(!started.writable || !started.hasInitialImage
+			|| started.initialImage != state.live.data)
+			return fail("change child did not restore its initial checkpoint");
+		{
+			std::lock_guard lock(state.stateMutex);
+			state.live.generation = 2;
+			state.live.dirty = true;
+			state.live.data = makeImage(9, 0x27);
+		}
+		if(!_ready.replaceWithText("changed"))
+			return fail("change child could not signal readiness");
+		for(int attempt = 0; attempt < 400; ++attempt)
+			std::this_thread::sleep_for(std::chrono::milliseconds(50));
+		return fail("change child was not terminated by its parent");
+	}
+
+	bool startChild(juce::ChildProcess& _child, const juce::StringArray& _arguments)
+	{
+		return _child.start(_arguments,
+			juce::ChildProcess::wantStdOut | juce::ChildProcess::wantStdErr);
+	}
+
+	juce::StringArray childArguments(
+		const std::initializer_list<juce::String> _arguments)
+	{
+		juce::StringArray result;
+		for(const auto& argument : _arguments)
+			result.add(argument);
+		return result;
+	}
+
+	bool childSucceeded(juce::ChildProcess& _child)
+	{
+		return _child.waitForProcessToFinish(10000) && _child.getExitCode() == 0;
+	}
 }
 
-int main()
+int main(const int _argc, const char* const* _argv)
 {
+	if(_argc >= 3)
+	{
+		const std::string mode(_argv[1]);
+		if(mode == "--owner" && _argc == 5)
+			return runOwnerChild(juce::File(_argv[2]), juce::File(_argv[3]),
+				juce::File(_argv[4]));
+		if(mode == "--probe-reader" && _argc == 3)
+			return runProbeChild(juce::File(_argv[2]), false);
+		if(mode == "--probe-writer" && _argc == 3)
+			return runProbeChild(juce::File(_argv[2]), true);
+		if(mode == "--change" && _argc == 4)
+			return runChangeChild(juce::File(_argv[2]), juce::File(_argv[3]));
+		return fail("invalid child arguments");
+	}
+
 	const auto directory = juce::File::getCurrentWorkingDirectory()
 		.getNonexistentChildFile("gearmulator-md-standalone-plusdrive-test", {}, false);
 	const auto createResult = directory.createDirectory();
@@ -136,6 +276,73 @@ int main()
 			return fail("checkpoint did not restore as the standalone authority");
 		restored.stop();
 	}
+
+	// Exercise the named OS lock with genuinely separate processes. A running
+	// second instance stays read-only for its entire session; a newly launched
+	// process can take ownership after the original writer exits.
+	const auto executable = juce::File::getSpecialLocation(
+		juce::File::currentExecutableFile).getFullPathName();
+	const auto processFile = directory.getChildFile("process-owned.mdpd");
+	const auto ownerReady = directory.getChildFile("owner-ready");
+	const auto ownerRelease = directory.getChildFile("owner-release");
+	juce::ChildProcess ownerChild;
+	if(!startChild(ownerChild, childArguments({executable, "--owner",
+		processFile.getFullPathName(), ownerReady.getFullPathName(),
+		ownerRelease.getFullPathName()})))
+		return fail("could not launch checkpoint owner process");
+	if(!waitForFile(ownerReady) || !waitForImage(processFile, imageA))
+	{
+		ownerChild.kill();
+		return fail("checkpoint owner process did not become ready");
+	}
+	juce::ChildProcess readerChild;
+	if(!startChild(readerChild, childArguments({executable, "--probe-reader",
+		processFile.getFullPathName()})) || !childSucceeded(readerChild))
+	{
+		ownerChild.kill();
+		return fail("cross-process checkpoint exclusion failed");
+	}
+	if(!ownerRelease.replaceWithText("release") || !childSucceeded(ownerChild))
+		return fail("checkpoint owner process did not exit cleanly");
+	juce::ChildProcess writerChild;
+	if(!startChild(writerChild, childArguments({executable, "--probe-writer",
+		processFile.getFullPathName()})) || !childSucceeded(writerChild))
+		return fail("released checkpoint was not available to a fresh process");
+
+	// A forced termination inside the debounce interval may lose the newest
+	// change, but it must leave the previous checkpoint byte-for-byte valid.
+	const auto crashFile = directory.getChildFile("forced-termination.mdpd");
+	if(!baseLib::filesystem::writeFileAtomic(
+		crashFile.getFullPathName().toStdString(), imageA))
+		return fail("could not prepare forced-termination checkpoint");
+	const auto crashReady = directory.getChildFile("crash-ready");
+	juce::ChildProcess crashChild;
+	if(!startChild(crashChild, childArguments({executable, "--change",
+		crashFile.getFullPathName(), crashReady.getFullPathName()}))
+		|| !waitForFile(crashReady))
+	{
+		crashChild.kill();
+		return fail("forced-termination child did not become ready");
+	}
+	std::this_thread::sleep_for(std::chrono::milliseconds(200));
+	if(!crashChild.kill() || !crashChild.waitForProcessToFinish(5000)
+		|| !waitForImage(crashFile, imageA))
+		return fail("forced termination damaged the prior checkpoint");
+
+	// Once the same change remains stable past the debounce window, it must be
+	// visible to another process even if the writer is then forcibly terminated.
+	crashReady.deleteFile();
+	juce::ChildProcess settledChild;
+	if(!startChild(settledChild, childArguments({executable, "--change",
+		crashFile.getFullPathName(), crashReady.getFullPathName()}))
+		|| !waitForFile(crashReady) || !waitForImage(crashFile, imageB))
+	{
+		settledChild.kill();
+		return fail("stable change exceeded the standalone debounce bound");
+	}
+	if(!settledChild.kill() || !settledChild.waitForProcessToFinish(5000)
+		|| !waitForImage(crashFile, imageB))
+		return fail("settled checkpoint did not survive forced termination");
 
 	const auto corruptFile = directory.getChildFile("corrupt.mdpd");
 	const std::vector<uint8_t> corrupt{1, 2, 3, 4};

--- a/source/elektron/md/mdJucePlugin/mdStorageImage.cpp
+++ b/source/elektron/md/mdJucePlugin/mdStorageImage.cpp
@@ -1,6 +1,9 @@
 #include "mdStorageImage.h"
 
 #include "mdLib/mdstate.h"
+#include "mdLib/mdplusdrive.h"
+
+#include "baseLib/filesystem.h"
 
 namespace mdJucePlugin::storageImage
 {
@@ -153,5 +156,78 @@ namespace mdJucePlugin::storageImage
 		_error = "Commit failed and the newly created recovery image could not be removed: "
 			+ describe(_target);
 		return false;
+	}
+
+	bool readPlusDrive(const juce::File& _source, std::vector<uint8_t>& _bytes,
+		juce::String& _error)
+	{
+		_bytes.clear();
+		_error.clear();
+		if(!_source.existsAsFile())
+		{
+			_error = "+Drive image was not found: " + describe(_source);
+			return false;
+		}
+		const auto size = _source.getSize();
+		if(size < 16
+			|| size > static_cast<juce::int64>(md::g_plusDriveMaxSerializedBytes))
+		{
+			_error = "+Drive image must be between 16 bytes and 512 MiB";
+			return false;
+		}
+		std::vector<uint8_t> decoded;
+		if(!baseLib::filesystem::readFile(
+			decoded, _source.getFullPathName().toStdString())
+			|| decoded.size() != static_cast<size_t>(size))
+		{
+			_error = "Could not read the complete +Drive image: " + describe(_source);
+			return false;
+		}
+		if(!md::PlusDrive::validateStorage(decoded))
+		{
+			_error = "The selected file is not a valid sparse MDPD +Drive image";
+			return false;
+		}
+		_bytes.swap(decoded);
+		return true;
+	}
+
+	bool writePlusDriveAtomically(const juce::File& _target,
+		const std::vector<uint8_t>& _bytes, juce::String& _error)
+	{
+		_error.clear();
+		if(_target == juce::File() || _target.isDirectory())
+		{
+			_error = "Choose a +Drive image filename, not a folder";
+			return false;
+		}
+		if(_bytes.size() < 16 || _bytes.size() > md::g_plusDriveMaxSerializedBytes
+			|| !md::PlusDrive::validateStorage(_bytes))
+		{
+			_error = "The live +Drive data is not a valid bounded sparse image";
+			return false;
+		}
+		const auto directoryResult = _target.getParentDirectory().createDirectory();
+		if(directoryResult.failed())
+		{
+			_error = "Could not create the +Drive image folder: "
+				+ directoryResult.getErrorMessage();
+			return false;
+		}
+		if(!baseLib::filesystem::writeFileAtomic(
+			_target.getFullPathName().toStdString(), _bytes))
+		{
+			_error = "Could not flush and atomically replace the +Drive image: "
+				+ describe(_target);
+			return false;
+		}
+		if(!_target.existsAsFile()
+			|| _target.getSize() != static_cast<juce::int64>(_bytes.size()))
+		{
+			_error = "The atomically replaced +Drive image failed verification: "
+				+ describe(_target);
+			return false;
+		}
+		return true;
 	}
 }

--- a/source/elektron/md/mdJucePlugin/mdStorageImage.h
+++ b/source/elektron/md/mdJucePlugin/mdStorageImage.h
@@ -26,4 +26,12 @@ namespace mdJucePlugin::storageImage
 	bool installRecoveryThenCommit(const juce::File& _target,
 		const std::vector<uint8_t>& _currentBytes,
 		const std::function<bool()>& _commit, juce::String& _error);
+
+	// Reads/writes the self-describing sparse MDPD image used by project state and
+	// explicit +Drive import/export. The 512 MiB host cap covers all documented UW
+	// Snapshot/sample-bank content while bounding allocations from hostile files.
+	bool readPlusDrive(const juce::File& _source, std::vector<uint8_t>& _bytes,
+		juce::String& _error);
+	bool writePlusDriveAtomically(const juce::File& _target,
+		const std::vector<uint8_t>& _bytes, juce::String& _error);
 }

--- a/source/elektron/md/mdJucePlugin/tus_settings_gui_Machinedrum.rml
+++ b/source/elektron/md/mdJucePlugin/tus_settings_gui_Machinedrum.rml
@@ -56,19 +56,17 @@
 	<settingsspacer1/>
 	<h1>+Drive</h1>
 	<settingsspacer1/>
-	<label>The +Drive belongs to this plug-in project. Import and export use sparse .mdpd images; different instances do not silently share one live disk file.</label>
+	<label>In a DAW, the +Drive belongs to the project. The standalone application instead keeps one private crash-safe checkpoint. Import and export are explicit sparse .mdpd snapshots.</label>
 	<settingsspacer1/>
 	<button id="btImportPlusDrive" class="button">Import +Drive Image...</button>
 	<button id="btExportPlusDrive" class="button">Export +Drive Image...</button>
 	<settingsspacer1/>
-	<button id="btEnablePlusDriveAutoSave" class="button">Choose Auto-save Mirror...</button>
-	<button id="btDisablePlusDriveAutoSave" class="button">Disable Auto-save Mirror</button>
 	<label id="plusDriveStatus" class="settings-sysex-status">PROJECT-OWNED +DRIVE</label>
 	<settingsspacer1/>
 	<button id="btRebootMachinedrum" class="button">Reboot Machinedrum</button>
 	<button id="btResetPlusDrive" class="button">Create Blank +Drive...</button>
 	<settingsspacer1/>
-	<label>Import and blank-drive operations reboot the emulated machine. Auto-save mirrors are optional, session-local, debounced, and written atomically in the background.</label>
+	<label>Import and blank-drive operations reboot the emulated machine. Standalone checkpoints are debounced and atomically replaced; DAW instances never write a hidden external mirror.</label>
 	<settingsspacer1/>
 	<div class="settings-advanced">
 		<h1>Panel Feel</h1>

--- a/source/elektron/md/mdJucePlugin/tus_settings_gui_Machinedrum.rml
+++ b/source/elektron/md/mdJucePlugin/tus_settings_gui_Machinedrum.rml
@@ -56,7 +56,7 @@
 	<settingsspacer1/>
 	<h1>+Drive</h1>
 	<settingsspacer1/>
-	<label>In a DAW, the +Drive belongs to the project. The standalone application instead keeps one private crash-safe checkpoint. Import and export are explicit sparse .mdpd snapshots.</label>
+	<label>In a DAW, the +Drive belongs to the project. The standalone application instead keeps one private, atomically replaced checkpoint. Import and export are explicit sparse .mdpd snapshots.</label>
 	<settingsspacer1/>
 	<button id="btImportPlusDrive" class="button">Import +Drive Image...</button>
 	<button id="btExportPlusDrive" class="button">Export +Drive Image...</button>
@@ -66,7 +66,7 @@
 	<button id="btRebootMachinedrum" class="button">Reboot Machinedrum</button>
 	<button id="btResetPlusDrive" class="button">Create Blank +Drive...</button>
 	<settingsspacer1/>
-	<label>Import and blank-drive operations reboot the emulated machine. Standalone checkpoints are debounced and atomically replaced; DAW instances never write a hidden external mirror.</label>
+	<label>Import and blank-drive operations reboot the emulated machine. Standalone changes settle for about one second before checkpointing and are flushed on a clean quit; a forced termination can lose the newest unsettled changes but preserves the previous valid checkpoint. DAW instances never write a hidden external mirror.</label>
 	<settingsspacer1/>
 	<div class="settings-advanced">
 		<h1>Panel Feel</h1>

--- a/source/elektron/md/mdJucePlugin/tus_settings_gui_Machinedrum.rml
+++ b/source/elektron/md/mdJucePlugin/tus_settings_gui_Machinedrum.rml
@@ -54,6 +54,22 @@
 	<settingsspacer1/>
 	<label>OS updater .syx files belong in Machinedrum/roms and are loaded at startup; they are not sent from this panel.</label>
 	<settingsspacer1/>
+	<h1>+Drive</h1>
+	<settingsspacer1/>
+	<label>The +Drive belongs to this plug-in project. Import and export use sparse .mdpd images; different instances do not silently share one live disk file.</label>
+	<settingsspacer1/>
+	<button id="btImportPlusDrive" class="button">Import +Drive Image...</button>
+	<button id="btExportPlusDrive" class="button">Export +Drive Image...</button>
+	<settingsspacer1/>
+	<button id="btEnablePlusDriveAutoSave" class="button">Choose Auto-save Mirror...</button>
+	<button id="btDisablePlusDriveAutoSave" class="button">Disable Auto-save Mirror</button>
+	<label id="plusDriveStatus" class="settings-sysex-status">PROJECT-OWNED +DRIVE</label>
+	<settingsspacer1/>
+	<button id="btRebootMachinedrum" class="button">Reboot Machinedrum</button>
+	<button id="btResetPlusDrive" class="button">Create Blank +Drive...</button>
+	<settingsspacer1/>
+	<label>Import and blank-drive operations reboot the emulated machine. Auto-save mirrors are optional, session-local, debounced, and written atomically in the background.</label>
+	<settingsspacer1/>
 	<div class="settings-advanced">
 		<h1>Panel Feel</h1>
 		<settingsspacer1/>

--- a/source/elektron/md/mdLib/CMakeLists.txt
+++ b/source/elektron/md/mdLib/CMakeLists.txt
@@ -53,6 +53,14 @@ if(GEARMULATOR_MD_BUILD_PROFILE_WORKLOAD)
 			ENVIRONMENT "GEARMULATOR_MDMM_BOUNDED_JIT=1")
 	endif()
 endif()
+
+option(GEARMULATOR_MD_BUILD_PLUSDRIVE_STATE_WORKLOAD
+	"Build the manual worst-case +Drive project-state workload" OFF)
+if(GEARMULATOR_MD_BUILD_PLUSDRIVE_STATE_WORKLOAD)
+	add_executable(mdPlusDriveStateWorkload profile/mdplusdrivestateworkload.cpp)
+	target_link_libraries(mdPlusDriveStateWorkload PRIVATE mdLib)
+	set_property(TARGET mdPlusDriveStateWorkload PROPERTY FOLDER "Elektron/profile")
+endif()
 set_property(TARGET mdLib PROPERTY FOLDER "Elektron")
 
 target_include_directories(mdLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/source/elektron/md/mdLib/CMakeLists.txt
+++ b/source/elektron/md/mdLib/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
 	mdmmwaveforms.h
 	mdrealtimemidiqueue.h
 	mdpanel.cpp mdpanel.h
+	mdplusdrive.cpp mdplusdrive.h
 	mdsim.cpp mdsim.h
 	mdrom.cpp mdrom.h
 	mdromdata.cpp mdromdata.h

--- a/source/elektron/md/mdLib/mddevice.cpp
+++ b/source/elektron/md/mdLib/mddevice.cpp
@@ -51,6 +51,45 @@ namespace
 		return mdFlashCacheFilename(_params.homePath, _model);
 	}
 
+	std::string legacyPlusDriveFilename(const std::string& _homePath,
+		const md::MachineModel _model)
+	{
+		if(_model != md::MachineModel::Machinedrum || _homePath.empty())
+			return {};
+		return baseLib::filesystem::validatePath(_homePath)
+			+ "nvram/md-plusdrive-v1.bin";
+	}
+
+	std::vector<uint8_t> loadLegacyPlusDrive(const std::string& _homePath,
+		const md::MachineModel _model)
+	{
+		const auto filename = legacyPlusDriveFilename(_homePath, _model);
+		std::vector<uint8_t> data;
+		if(filename.empty() || !baseLib::filesystem::exists(filename))
+			return {};
+		const auto size = baseLib::filesystem::getFileSize(filename);
+		if(size < 16 || size > md::g_plusDriveMaxSerializedBytes)
+		{
+			std::fprintf(stderr,
+				"[MD] ignoring out-of-bounds legacy +Drive image: %s (%zu bytes)\n",
+				filename.c_str(), size);
+			return {};
+		}
+		if(!baseLib::filesystem::readFile(data, filename) || data.size() != size)
+			return {};
+		md::PlusDrive validation;
+		if(!validation.replaceStorage(data))
+		{
+			std::fprintf(stderr, "[MD] ignoring invalid +Drive image: %s\n",
+				filename.c_str());
+			return {};
+		}
+		std::fprintf(stderr,
+			"[MD] imported legacy shared +Drive image as private instance state: %s\n",
+			filename.c_str());
+		return data;
+	}
+
 	struct InitialMdFlash
 	{
 		std::vector<uint8_t> flash;
@@ -130,7 +169,8 @@ namespace md
 		auto initialFlash = loadInitialMdFlash(_params, m_model);
 		m_hardware = std::make_unique<Hardware>(_params.romData, _params.romName, m_model,
 			loadInitialPatchRam(_params, m_model, _initialPatchRam), m_frontPanelPublisher,
-			m_midiSysexProgressPublisher, initialFlash.flash, initialFlash.cache);
+			m_midiSysexProgressPublisher, initialFlash.flash, initialFlash.cache,
+			FlashSectorOverlay{}, loadLegacyPlusDrive(_params.homePath, m_model));
 	}
 
 	Device::~Device()
@@ -177,31 +217,37 @@ namespace md
 		if(m_model == MachineModel::Monomachine)
 			return encodeState(_state, patchRam, m_model, _type,
 				m_hardware->copyUserFlash());
+		const auto plusDrive = m_hardware->copyPlusDriveData();
 		std::vector<uint8_t> factoryBaseline;
 		if(m_hardware->copyFactoryFlashBaseline(factoryBaseline))
 			return encodeState(_state, patchRam, m_hardware->copyFlashData(),
-				factoryBaseline, m_hardware->flashBaseline(), m_model, _type);
+				factoryBaseline, m_hardware->flashBaseline(), m_model, _type,
+				plusDrive);
 		FlashSectorOverlay pending;
 		if(m_hardware->copyPendingFlashOverlay(pending))
 			return encodeState(_state, patchRam, pending,
-				m_hardware->flashBaseline(), m_model, _type);
+				m_hardware->flashBaseline(), m_model, _type, plusDrive);
 		// If interaction happened before the first machine-local baseline was
 		// captured, preserve a complete flash image. An absolute sector set records
 		// ROM-equal deletions and lets the replacement boot coherently without waiting
 		// for another factory-initialization pass.
 		return encodeState(_state, patchRam, m_hardware->copyFlashData(),
-			m_hardware->flashBaseline(), m_hardware->flashBaseline(), m_model, _type);
+			m_hardware->flashBaseline(), m_hardware->flashBaseline(), m_model, _type,
+			plusDrive);
 	}
 
 	bool Device::setState(const std::vector<uint8_t>& _state, synthLib::StateType _type)
 	{
-		auto prepared = prepareState(m_preparationContext, _state, _type);
+		auto prepared = prepareState(m_preparationContext, _state, _type,
+			m_model == MachineModel::Machinedrum
+				? m_hardware->copyFactoryFlashCache() : std::vector<uint8_t>{});
 		return prepared && commitPreparedState(*prepared);
 	}
 
 	std::unique_ptr<Device::PreparedState> Device::prepareState(
 		std::shared_ptr<const PreparationContext> _context,
-		const std::vector<uint8_t>& _state, const synthLib::StateType _type)
+		const std::vector<uint8_t>& _state, const synthLib::StateType _type,
+		const std::vector<uint8_t>& _factoryFlashCache)
 	{
 		if(!_context)
 			return {};
@@ -209,6 +255,7 @@ namespace md
 		std::vector<uint8_t> patchRam;
 		std::vector<uint8_t> initialFlash;
 		bool containsFlash = false;
+		bool containsPlusDrive = false;
 		if(_context->m_model == MachineModel::Monomachine)
 		{
 			if(!decodeState(patchRam, initialFlash, _state, _context->m_model, _type))
@@ -225,8 +272,16 @@ namespace md
 				return {};
 			patchRam = std::move(decoded.patchRam);
 			containsFlash = decoded.containsFlash;
+			containsPlusDrive = decoded.containsPlusDrive;
 			auto factory = loadInitialMdFlash(stateRom,
 				mdFlashCacheFilename(_context->m_homePath, _context->m_model));
+			if(factory.cache.empty() && !_factoryFlashCache.empty())
+			{
+				if(!decodeFactoryFlashCache(factory.flash, _factoryFlashCache,
+					stateRom.data()))
+					return {};
+				factory.cache = _factoryFlashCache;
+			}
 			FlashSectorOverlay pending;
 			if(containsFlash)
 			{
@@ -254,23 +309,26 @@ namespace md
 			auto replacement = std::make_unique<Hardware>(
 				_context->m_romData, _context->m_romName, _context->m_model, patchRam,
 				_context->m_frontPanelPublisher, _context->m_midiSysexProgressPublisher,
-				initialFlash, factory.cache, pending);
+				initialFlash, factory.cache, pending, containsPlusDrive
+					? decoded.plusDrive
+					: std::vector<uint8_t>{});
 			if(!replacement->isValid())
 				return {};
 			return std::unique_ptr<PreparedState>(
 				new PreparedState(std::move(_context), std::move(replacement),
-					containsFlash));
+					containsFlash, containsPlusDrive));
 		}
 
 		auto replacement = std::make_unique<Hardware>(
 			_context->m_romData, _context->m_romName, _context->m_model, patchRam,
 			_context->m_frontPanelPublisher, _context->m_midiSysexProgressPublisher,
-			initialFlash);
+			initialFlash, std::vector<uint8_t>{}, FlashSectorOverlay{},
+			std::vector<uint8_t>{});
 		if(!replacement->isValid())
 			return {};
 		return std::unique_ptr<PreparedState>(
 			new PreparedState(std::move(_context), std::move(replacement),
-				containsFlash));
+				containsFlash, false));
 	}
 
 	bool Device::commitPreparedState(PreparedState& _prepared)
@@ -281,6 +339,13 @@ namespace md
 			return false;
 
 		const auto clockPercent = getDspClockPercent();
+		if(!_prepared.m_containsPlusDrive)
+		{
+			const auto plusDrive = m_hardware->copyPlusDriveData();
+			if(!_prepared.m_hardware->replacePlusDriveData(
+				plusDrive, m_hardware->plusDriveDirty()))
+				return false;
+		}
 		_prepared.m_hardware->getDspMixer().getPeriph().getEssiClock()
 			.setSpeedPercent(clockPercent);
 		if(m_model == MachineModel::Machinedrum && !_prepared.m_containsFlash)
@@ -294,6 +359,7 @@ namespace md
 
 		m_frontPanelPublisher->reset();
 		m_hardware.swap(_prepared.m_hardware);
+		++m_hardwareEpoch;
 		_prepared.m_committed = true;
 		// Replacement aborts any transfer owned by the retired Hardware. Reset
 		// only after the replacement has validated and become authoritative, so a

--- a/source/elektron/md/mdLib/mddevice.h
+++ b/source/elektron/md/mdLib/mddevice.h
@@ -66,15 +66,18 @@ namespace md
 			friend struct DevicePreparedStateTestAccess;
 
 			PreparedState(std::shared_ptr<const PreparationContext> _context,
-				std::unique_ptr<Hardware> _hardware, const bool _containsFlash)
+				std::unique_ptr<Hardware> _hardware, const bool _containsFlash,
+				const bool _containsPlusDrive)
 				: m_context(std::move(_context)), m_hardware(std::move(_hardware))
 				, m_containsFlash(_containsFlash)
+				, m_containsPlusDrive(_containsPlusDrive)
 			{
 			}
 
 			std::shared_ptr<const PreparationContext> m_context;
 			std::unique_ptr<Hardware> m_hardware;
 			bool m_containsFlash = false;
+			bool m_containsPlusDrive = false;
 			bool m_committed = false;
 		};
 
@@ -92,7 +95,8 @@ namespace md
 		}
 		static std::unique_ptr<PreparedState> prepareState(
 			std::shared_ptr<const PreparationContext> _context,
-			const std::vector<uint8_t>& _state, synthLib::StateType _type);
+			const std::vector<uint8_t>& _state, synthLib::StateType _type,
+			const std::vector<uint8_t>& _factoryFlashCache = {});
 		// Requires exclusive access to this Device. A successful exchange leaves the
 		// retired Hardware in _prepared so its destruction can happen after the
 		// caller releases any process/control lock.
@@ -123,6 +127,7 @@ namespace md
 		{
 			return m_midiSysexProgressPublisher->read();
 		}
+		uint64_t hardwareEpoch() const { return m_hardwareEpoch; }
 
 		// Direct access for the in-process editor (option B): the front-panel LCD/LED state
 		// and panel-event injection. Only valid for a local (non-bridged) device instance.
@@ -145,5 +150,6 @@ namespace md
 		uint32_t m_numSamplesProcessed = 0;
 		bool m_nativeProgramChangesEnabled = false;
 		std::string m_mdFlashCacheFilename;
+		uint64_t m_hardwareEpoch = 1;
 	};
 }

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -100,10 +100,13 @@ namespace md
 		std::shared_ptr<MidiSysexTransferProgressPublisher> _midiSysexProgressPublisher,
 		const std::vector<uint8_t>& _initialUserFlash,
 		const std::vector<uint8_t>& _factoryFlashCache,
-		const FlashSectorOverlay& _pendingFlashOverlay)
+		const FlashSectorOverlay& _pendingFlashOverlay,
+		const std::vector<uint8_t>& _initialPlusDrive,
+		const bool _plusDriveEnabled)
 		: Hardware(false, _romData, _romName, _model, _initialPatchRam,
 			std::move(_frontPanelPublisher), std::move(_midiSysexProgressPublisher),
-			_initialUserFlash, _factoryFlashCache, _pendingFlashOverlay)
+			_initialUserFlash, _factoryFlashCache, _pendingFlashOverlay, _initialPlusDrive,
+			_plusDriveEnabled)
 	{
 	}
 
@@ -114,13 +117,15 @@ namespace md
 		std::shared_ptr<MidiSysexTransferProgressPublisher> _midiSysexProgressPublisher,
 		const std::vector<uint8_t>& _initialUserFlash,
 		const std::vector<uint8_t>& _factoryFlashCache,
-		const FlashSectorOverlay& _pendingFlashOverlay)
+		const FlashSectorOverlay& _pendingFlashOverlay,
+		const std::vector<uint8_t>& _initialPlusDrive,
+		const bool _plusDriveEnabled)
 		: m_model(_model)
 		, m_rom(initRom(_romData, _romName, _model, _syntheticProfile))
 		, m_firmwareFingerprint(_syntheticProfile ? 0 : fingerprintRom(m_rom.data()))
 		, m_uc(m_rom, m_model, initPatchRam(m_rom,
 			_pendingFlashOverlay.valid ? std::vector<uint8_t>{} : _initialPatchRam),
-			initMainRam(m_rom), _initialUserFlash)
+			initMainRam(m_rom), _initialUserFlash, _initialPlusDrive, _plusDriveEnabled)
 		// A complete project image can boot directly without a local factory cache,
 		// but it must never become the machine-local factory baseline itself.
 		, m_externalInteraction(_model == MachineModel::Machinedrum

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -65,7 +65,9 @@ namespace md
 			std::shared_ptr<MidiSysexTransferProgressPublisher> _midiSysexProgressPublisher = {},
 			const std::vector<uint8_t>& _initialUserFlash = {},
 			const std::vector<uint8_t>& _factoryFlashCache = {},
-			const FlashSectorOverlay& _pendingFlashOverlay = {});
+			const FlashSectorOverlay& _pendingFlashOverlay = {},
+			const std::vector<uint8_t>& _initialPlusDrive = {},
+			bool _plusDriveEnabled = true);
 		~Hardware();
 
 		bool isValid() const;
@@ -97,6 +99,17 @@ namespace md
 		std::vector<uint8_t> copyPatchRam() const;
 		std::vector<uint8_t> copyUserFlash() const { return m_uc.copyUserFlash(); }
 		std::vector<uint8_t> copyFlashData() const { return m_uc.copyFlashData(); }
+		std::vector<uint8_t> copyPlusDriveData() const { return m_uc.copyPlusDriveData(); }
+		bool replacePlusDriveData(const std::vector<uint8_t>& _data, bool _dirty = false)
+		{
+			return m_uc.replacePlusDriveData(_data, _dirty);
+		}
+		bool plusDriveDirty() const { return m_uc.plusDriveDirty(); }
+		uint64_t plusDriveGeneration() const { return m_uc.plusDriveGeneration(); }
+		void markPlusDrivePersisted(const uint64_t _generation)
+		{
+			m_uc.markPlusDrivePersisted(_generation);
+		}
 		const std::vector<uint8_t>& flashBaseline() const { return m_rom.data(); }
 		bool flashDirty() const { return m_uc.flashDirty(); }
 		bool factoryFlashCacheReady();
@@ -205,7 +218,9 @@ namespace md
 			std::shared_ptr<MidiSysexTransferProgressPublisher> _midiSysexProgressPublisher,
 			const std::vector<uint8_t>& _initialUserFlash,
 			const std::vector<uint8_t>& _factoryFlashCache,
-			const FlashSectorOverlay& _pendingFlashOverlay);
+			const FlashSectorOverlay& _pendingFlashOverlay,
+			const std::vector<uint8_t>& _initialPlusDrive,
+			bool _plusDriveEnabled);
 		void ensureBufferSize(uint32_t _frames);
 		void advanceFactoryFlashCapture();
 		void registerExternalInteraction();

--- a/source/elektron/md/mdLib/mdmc.cpp
+++ b/source/elektron/md/mdLib/mdmc.cpp
@@ -70,7 +70,9 @@ namespace md
 	Microcontroller::Microcontroller(const Rom& _rom, const MachineModel _model,
 		const std::vector<uint8_t>& _initialPatchRam,
 		const std::vector<uint8_t>& _initialMainRam,
-		const std::vector<uint8_t>& _initialUserFlash)
+		const std::vector<uint8_t>& _initialUserFlash,
+		const std::vector<uint8_t>& _initialPlusDrive,
+		const bool _plusDriveEnabled)
 		: Mc68k(M68K_CPU_TYPE_MCF5206E)
 		, m_model(_model)
 		, m_rom(_rom)
@@ -98,6 +100,10 @@ namespace md
 
 		// Report the MKII board profile used by both supported targets.
 		m_sim.setMk2PortAInvertedLoopback(true);
+		m_sim.setPlusDriveEnabled(
+			m_model == MachineModel::Machinedrum && _plusDriveEnabled);
+		if(m_model == MachineModel::Machinedrum)
+			m_sim.getPlusDrive().replaceStorage(_initialPlusDrive);
 
 		// The panel controller is not part of the emulator. Reproduce the public
 		// MAME driver's UART startup handshake here.

--- a/source/elektron/md/mdLib/mdmc.h
+++ b/source/elektron/md/mdLib/mdmc.h
@@ -52,7 +52,9 @@ namespace md
 		Microcontroller(const Rom& _rom, MachineModel _model = MachineModel::Machinedrum,
 			const std::vector<uint8_t>& _initialPatchRam = {},
 			const std::vector<uint8_t>& _initialMainRam = {},
-			const std::vector<uint8_t>& _initialUserFlash = {});
+			const std::vector<uint8_t>& _initialUserFlash = {},
+			const std::vector<uint8_t>& _initialPlusDrive = {},
+			bool _plusDriveEnabled = true);
 
 		// mc68k::Mc68k overrides
 		uint32_t exec() override;
@@ -178,6 +180,23 @@ namespace md
 		// vectors are exchanged without copying, allocating, freeing, or waiting.
 		StateImagePublishResult publishStateImagesRealtime(
 			std::vector<uint8_t>& _flash, std::vector<uint8_t>& _patchRam, bool _dirty);
+		std::vector<uint8_t> copyPlusDriveData() const
+		{
+			return m_sim.getPlusDrive().copyStorage();
+		}
+		bool replacePlusDriveData(const std::vector<uint8_t>& _data, bool _dirty = false)
+		{
+			return m_sim.getPlusDrive().replaceStorage(_data, _dirty);
+		}
+		bool plusDriveDirty() const { return m_sim.getPlusDrive().storageDirty(); }
+		uint64_t plusDriveGeneration() const
+		{
+			return m_sim.getPlusDrive().storageGeneration();
+		}
+		void markPlusDrivePersisted(const uint64_t _generation)
+		{
+			m_sim.getPlusDrive().markStoragePersisted(_generation);
+		}
 
 
 	private:

--- a/source/elektron/md/mdLib/mdplusdrive.cpp
+++ b/source/elektron/md/mdLib/mdplusdrive.cpp
@@ -1,0 +1,525 @@
+#include "mdplusdrive.h"
+
+#include <algorithm>
+
+namespace md
+{
+	namespace
+	{
+		constexpr uint8_t g_clock = 0x04;
+		constexpr uint8_t g_command = 0x08;
+		constexpr std::array<uint8_t, 4> g_storageMagic{{'M', 'D', 'P', 'D'}};
+		constexpr uint32_t g_storageVersion = 1;
+		constexpr size_t g_storageHeaderSize = 16;
+		constexpr size_t g_storageRecordSize = 4 + 512;
+		constexpr uint32_t g_sectorCount = 2u * 1024u * 1024u * 1024u / 512u;
+
+		uint32_t readBe32(const uint8_t* const _data)
+		{
+			return (static_cast<uint32_t>(_data[0]) << 24)
+				| (static_cast<uint32_t>(_data[1]) << 16)
+				| (static_cast<uint32_t>(_data[2]) << 8) | _data[3];
+		}
+
+		void appendBe32(std::vector<uint8_t>& _data, const uint32_t _value)
+		{
+			_data.push_back(static_cast<uint8_t>(_value >> 24));
+			_data.push_back(static_cast<uint8_t>(_value >> 16));
+			_data.push_back(static_cast<uint8_t>(_value >> 8));
+			_data.push_back(static_cast<uint8_t>(_value));
+		}
+
+		// Stable, standards-shaped identity values. The OS uses the CSD geometry and
+		// OCR capacity flags; product text and serial fields are informational.
+		constexpr std::array<uint8_t, 16> g_cid{{
+			0x15, 0x01, 0x00, 'G', 'M', 'D', '+', 'D', 'R', 0x01,
+			0x12, 0x34, 0x56, 0x78, 0x01, 0xff}};
+		constexpr std::array<uint8_t, 16> g_csd{{
+			0xd0, 0x0f, 0x00, 0x32, 0x0f, 0x59, 0x00, 0x00,
+			0xed, 0xc8, 0x7f, 0x80, 0x0a, 0x40, 0x00, 0xff}};
+	}
+
+	void PlusDrive::reset()
+	{
+		m_clock = false;
+		m_commandOutput = true;
+		m_command.fill(0);
+		m_commandBits = 0;
+		m_response.fill(0xff);
+		m_responseBits = 0;
+		m_responseCursor = 0;
+		m_responseDelay = 0;
+		m_initialized = false;
+		m_reading = false;
+		m_singleBlock = false;
+		m_dataDelay = 0;
+		m_dataCursor = 0;
+		m_dataOutput = 0xf0;
+		m_readSector = 0;
+		m_writeState = WriteState::Idle;
+		m_singleWrite = false;
+		m_writeSector = 0;
+		m_writeCursor = 0;
+		m_writeResponseCursor = 0;
+		m_writeBlock.fill(0xff);
+		m_writeSawIdleData = false;
+		m_commandCount = 0;
+		m_lastCommand = 0xff;
+	}
+
+	void PlusDrive::setEnabled(const bool _enabled)
+	{
+		if(m_enabled == _enabled)
+			return;
+		m_enabled = _enabled;
+		reset();
+	}
+
+	std::vector<uint8_t> PlusDrive::copyStorage() const
+	{
+		if(!m_serializedStorage.empty())
+			return m_serializedStorage;
+		std::vector<uint32_t> sectors;
+		sectors.reserve(m_sectors.size());
+		for(const auto& entry : m_sectors)
+			sectors.push_back(entry.first);
+		std::sort(sectors.begin(), sectors.end());
+
+		std::vector<uint8_t> result;
+		result.reserve(g_storageHeaderSize + sectors.size() * g_storageRecordSize);
+		result.insert(result.end(), g_storageMagic.begin(), g_storageMagic.end());
+		appendBe32(result, g_storageVersion);
+		appendBe32(result, 512);
+		appendBe32(result, static_cast<uint32_t>(sectors.size()));
+		for(const auto sector : sectors)
+		{
+			appendBe32(result, sector);
+			const auto& data = m_sectors.at(sector);
+			result.insert(result.end(), data.begin(), data.end());
+		}
+		m_serializedStorage = result;
+		return result;
+	}
+
+	bool PlusDrive::validateStorage(const uint8_t* const _data, const size_t _size)
+	{
+		if(_size == 0)
+			return true;
+		if(_size < g_storageHeaderSize || !_data
+			|| !std::equal(g_storageMagic.begin(), g_storageMagic.end(), _data)
+			|| readBe32(_data + 4) != g_storageVersion
+			|| readBe32(_data + 8) != 512)
+			return false;
+		const uint32_t count = readBe32(_data + 12);
+		if(count > g_sectorCount
+			|| _size != g_storageHeaderSize
+				+ static_cast<size_t>(count) * g_storageRecordSize)
+			return false;
+		if(count == 0)
+			return true;
+
+		std::vector<uint8_t> seen((g_sectorCount + 7u) / 8u);
+		size_t offset = g_storageHeaderSize;
+		for(uint32_t i = 0; i < count; ++i, offset += g_storageRecordSize)
+		{
+			const uint32_t sector = readBe32(_data + offset);
+			if(sector >= g_sectorCount)
+				return false;
+			const auto mask = static_cast<uint8_t>(1u << (sector & 7u));
+			auto& byte = seen[sector >> 3u];
+			if(byte & mask)
+				return false;
+			byte |= mask;
+		}
+		return true;
+	}
+
+	bool PlusDrive::replaceStorage(const std::vector<uint8_t>& _data, const bool _dirty)
+	{
+		if(_data.empty())
+		{
+			if(!m_sectors.empty())
+			{
+				m_sectors.clear();
+				storageChanged(_dirty);
+			}
+			else if(!_dirty)
+				m_persistedGeneration = m_storageGeneration;
+			return true;
+		}
+		if(!validateStorage(_data))
+			return false;
+		const uint32_t count = readBe32(_data.data() + 12);
+
+		std::unordered_map<uint32_t, std::array<uint8_t, 512>> sectors;
+		sectors.reserve(count);
+		size_t offset = g_storageHeaderSize;
+		for(uint32_t i = 0; i < count; ++i, offset += g_storageRecordSize)
+		{
+			const uint32_t sector = readBe32(_data.data() + offset);
+			std::array<uint8_t, 512> block{};
+			std::copy_n(_data.begin() + static_cast<std::ptrdiff_t>(offset + 4),
+				block.size(), block.begin());
+			sectors.emplace(sector, block);
+		}
+		if(m_sectors != sectors)
+		{
+			m_sectors = std::move(sectors);
+			storageChanged(_dirty);
+		}
+		else if(!_dirty)
+			m_persistedGeneration = m_storageGeneration;
+		return true;
+	}
+
+	void PlusDrive::storageChanged(const bool _dirty)
+	{
+		m_serializedStorage.clear();
+		if(++m_storageGeneration == 0)
+		{
+			m_storageGeneration = 1;
+			m_persistedGeneration = 0;
+		}
+		if(!_dirty)
+			m_persistedGeneration = m_storageGeneration;
+	}
+
+	void PlusDrive::markStoragePersisted(const uint64_t _generation)
+	{
+		if(_generation > m_persistedGeneration && _generation <= m_storageGeneration)
+			m_persistedGeneration = _generation;
+	}
+
+	void PlusDrive::portChanged(const uint8_t _direction, const uint8_t _output)
+	{
+		if(!m_enabled || !(_direction & g_clock))
+		{
+			m_clock = false;
+			return;
+		}
+		if(m_writeState == WriteState::AwaitStart && (_direction & 0xf0) == 0xf0)
+		{
+			if((_output & 0xf0) == 0xf0)
+				m_writeSawIdleData = true;
+			else if((_output & 0xf0) == 0 && m_writeSawIdleData)
+			{
+				m_writeState = WriteState::Data;
+				m_writeCursor = 0;
+				m_writeBlock.fill(0xff);
+				// This transition carries the four-bit start token. Data begins on
+				// the following edge, so consume the clock phase without sampling it.
+				m_clock = (_output & g_clock) != 0;
+				return;
+			}
+		}
+
+		const bool clock = (_output & g_clock) != 0;
+		if(clock != m_clock)
+			clockEdge(_direction, _output);
+		m_clock = clock;
+	}
+
+	uint8_t PlusDrive::inputLevel() const
+	{
+		if(!m_enabled)
+			return 0xff;
+		// Data lines are pulled high while the block-transfer engine is idle.
+		return static_cast<uint8_t>(0x07 | m_dataOutput
+			| (m_commandOutput ? g_command : 0));
+	}
+
+	void PlusDrive::clockEdge(const uint8_t _direction, const uint8_t _output)
+	{
+		if(_direction & g_command)
+		{
+			m_commandOutput = true;
+			receiveCommandBit((_output & g_command) != 0);
+			return;
+		}
+
+		if(m_responseDelay)
+		{
+			--m_responseDelay;
+			m_commandOutput = true;
+		}
+		else if(m_responseCursor < m_responseBits)
+		{
+			const size_t byte = m_responseCursor / 8;
+			const size_t bit = 7 - (m_responseCursor % 8);
+			m_commandOutput = ((m_response[byte] >> bit) & 1) != 0;
+			++m_responseCursor;
+		}
+		else
+			m_commandOutput = true;
+		advanceReadData(_direction);
+		advanceWriteData(_direction, _output);
+	}
+
+	void PlusDrive::receiveCommandBit(const bool _bit)
+	{
+		if(!m_commandBits)
+		{
+			// MMC commands begin with a zero start bit. Ignore idle clocks.
+			if(_bit)
+				return;
+			m_command.fill(0);
+		}
+
+		const size_t byte = m_commandBits / 8;
+		m_command[byte] = static_cast<uint8_t>((m_command[byte] << 1) | (_bit ? 1 : 0));
+		if(++m_commandBits == 48)
+		{
+			m_commandBits = 0;
+			executeCommand();
+		}
+	}
+
+	void PlusDrive::executeCommand()
+	{
+		// The top two bits are the MMC start/transmission framing; the command index
+		// occupies the lower six bits.
+		m_lastCommand = static_cast<uint8_t>(m_command[0] & 0x3f);
+		const uint32_t argument = (static_cast<uint32_t>(m_command[1]) << 24)
+			| (static_cast<uint32_t>(m_command[2]) << 16)
+			| (static_cast<uint32_t>(m_command[3]) << 8) | m_command[4];
+		++m_commandCount;
+		switch(m_lastCommand)
+		{
+		case 0: // GO_IDLE_STATE: no response
+			m_initialized = false;
+			m_responseBits = 0;
+			m_responseCursor = 0;
+			m_responseDelay = 0;
+			break;
+		case 1: // SEND_OP_COND: ready, sector-addressed, supported voltage window
+			queueShortResponse(0xc0ff8080u);
+			break;
+		case 2: // ALL_SEND_CID
+			queueLongResponse(g_cid);
+			break;
+		case 3: // SET_RELATIVE_ADDR
+			queueShortResponse(0x00000700u); // ready, STANDBY state
+			break;
+		case 6: // SWITCH
+		case 7: // SELECT_CARD
+		case 16: // SET_BLOCKLEN
+			queueShortResponse(0x00000900u); // ready, TRANSFER state
+			if(m_lastCommand == 16)
+				m_initialized = true;
+			break;
+		case 9: // SEND_CSD
+			queueLongResponse(g_csd);
+			break;
+		case 12: // STOP_TRANSMISSION
+			m_reading = false;
+			m_writeState = WriteState::Idle;
+			m_dataOutput = 0xf0;
+			queueShortResponse(0x00000900u);
+			break;
+		case 17: // READ_SINGLE_BLOCK
+		case 18: // READ_MULTIPLE_BLOCK
+			if(argument >= g_sectorCount)
+			{
+				queueShortResponse(0x80000900u); // OUT_OF_RANGE, TRANSFER state
+				m_reading = false;
+				m_writeState = WriteState::Idle;
+				break;
+			}
+			queueShortResponse(0x00000900u);
+			m_writeState = WriteState::Idle;
+			m_reading = true;
+			m_singleBlock = m_lastCommand == 17;
+			m_readSector = argument;
+			// R1 turnaround + 40 response bits + the host's trailing clocks.
+			m_dataDelay = 52;
+			m_dataCursor = 0;
+			m_dataOutput = 0xf0;
+			break;
+		case 24: // WRITE_BLOCK
+		case 25: // WRITE_MULTIPLE_BLOCK
+			if(argument >= g_sectorCount)
+			{
+				queueShortResponse(0x80000900u); // OUT_OF_RANGE, TRANSFER state
+				m_reading = false;
+				m_writeState = WriteState::Idle;
+				break;
+			}
+			queueShortResponse(0x00000900u);
+			m_reading = false;
+			m_writeState = WriteState::AwaitStart;
+			m_singleWrite = m_lastCommand == 24;
+			m_writeSector = argument;
+			m_writeCursor = 0;
+			m_writeResponseCursor = 0;
+			m_writeSawIdleData = false;
+			m_writeBlock.fill(0xff);
+			break;
+		default:
+			// R1 with ILLEGAL_COMMAND. This keeps unsupported operations bounded and
+			// visible to the guest instead of leaving the command line floating.
+			queueShortResponse(1u << 22);
+			break;
+		}
+	}
+
+	void PlusDrive::advanceReadData(const uint8_t _direction)
+	{
+		if(!m_reading || (_direction & 0xf0) != 0)
+			return;
+		if(m_dataDelay)
+		{
+			--m_dataDelay;
+			m_dataOutput = 0xf0;
+			return;
+		}
+
+		constexpr size_t dataNibbles = 512 * 2;
+		constexpr size_t crcNibbles = 16;
+		if(m_dataCursor == 0)
+			m_dataOutput = 0x00; // four-bit start token
+		else if(m_dataCursor <= dataNibbles)
+		{
+			const size_t nibble = m_dataCursor - 1;
+			const auto sector = m_sectors.find(m_readSector);
+			const uint8_t byte = sector == m_sectors.end()
+				? 0xff : sector->second[nibble / 2];
+			m_dataOutput = static_cast<uint8_t>((nibble & 1)
+				? (byte << 4) : (byte & 0xf0));
+		}
+		else if(m_dataCursor <= dataNibbles + crcNibbles)
+			m_dataOutput = 0x00; // one CRC16 per data line
+		else
+		{
+			m_dataOutput = 0xf0;
+			if(m_singleBlock)
+				m_reading = false;
+			else
+			{
+				if(m_readSector + 1 >= g_sectorCount)
+				{
+					m_reading = false;
+					return;
+				}
+				++m_readSector;
+				m_dataDelay = 2;
+				m_dataCursor = 0;
+				return;
+			}
+		}
+		++m_dataCursor;
+	}
+
+	void PlusDrive::advanceWriteData(const uint8_t _direction, const uint8_t _output)
+	{
+		if(m_writeState == WriteState::Idle)
+			return;
+
+		const bool hostDrivesData = (_direction & 0xf0) == 0xf0;
+		if(hostDrivesData)
+		{
+			const uint8_t nibble = static_cast<uint8_t>(_output >> 4);
+			switch(m_writeState)
+			{
+			case WriteState::AwaitStart:
+				break;
+			case WriteState::Data:
+			{
+				const size_t byte = m_writeCursor / 2;
+				if((m_writeCursor & 1) == 0)
+					m_writeBlock[byte] = static_cast<uint8_t>(nibble << 4);
+				else
+					m_writeBlock[byte] |= nibble;
+				if(++m_writeCursor == 512 * 2)
+				{
+					m_writeState = WriteState::Crc;
+					m_writeCursor = 0;
+				}
+				break;
+			}
+			case WriteState::Crc:
+				if(++m_writeCursor == 16)
+				{
+					const auto existing = m_sectors.find(m_writeSector);
+					const bool erased = std::all_of(m_writeBlock.begin(), m_writeBlock.end(),
+						[](const uint8_t _byte) { return _byte == 0xff; });
+					if(erased)
+					{
+						if(existing != m_sectors.end())
+						{
+							m_sectors.erase(existing);
+							storageChanged(true);
+						}
+					}
+					else if(existing == m_sectors.end() || existing->second != m_writeBlock)
+					{
+						m_sectors[m_writeSector] = m_writeBlock;
+						storageChanged(true);
+					}
+					if(m_writeSector + 1 >= g_sectorCount)
+						m_singleWrite = true;
+					++m_writeSector;
+					m_writeState = WriteState::Response;
+					m_writeResponseCursor = 0;
+					m_dataOutput = 0xf0;
+				}
+				break;
+			case WriteState::Response:
+			case WriteState::Idle:
+				break;
+			}
+			return;
+		}
+
+		if(m_writeState != WriteState::Response)
+			return;
+
+		// Four idle edges, then the five-bit accepted token (00101), a short busy
+		// interval, and finally DAT0 high/ready.
+		constexpr std::array<bool, 5> accepted{{false, false, true, false, true}};
+		if(m_writeResponseCursor < 4)
+			m_dataOutput = 0xf0;
+		else if(m_writeResponseCursor < 4 + accepted.size())
+			m_dataOutput = accepted[m_writeResponseCursor - 4] ? 0xf0 : 0x70;
+		else if(m_writeResponseCursor < 4 + accepted.size() + 8)
+			m_dataOutput = 0x70;
+		else
+		{
+			m_dataOutput = 0xf0;
+			m_writeState = m_singleWrite ? WriteState::Idle : WriteState::AwaitStart;
+			m_writeCursor = 0;
+			m_writeSawIdleData = false;
+			return;
+		}
+		++m_writeResponseCursor;
+	}
+
+	void PlusDrive::queueShortResponse(const uint32_t _value)
+	{
+		const std::array<uint8_t, 5> response{{
+			0x3f,
+			static_cast<uint8_t>(_value >> 24),
+			static_cast<uint8_t>(_value >> 16),
+			static_cast<uint8_t>(_value >> 8),
+			static_cast<uint8_t>(_value)}};
+		queueResponse(response.data(), response.size());
+	}
+
+	void PlusDrive::queueLongResponse(const std::array<uint8_t, 16>& _value)
+	{
+		std::array<uint8_t, 17> response{};
+		response[0] = 0x3f;
+		std::copy(_value.begin(), _value.end(), response.begin() + 1);
+		queueResponse(response.data(), response.size());
+	}
+
+	void PlusDrive::queueResponse(const uint8_t* const _bytes, const size_t _size)
+	{
+		m_response.fill(0xff);
+		std::copy_n(_bytes, std::min(_size, m_response.size()), m_response.begin());
+		m_responseBits = std::min(_size, m_response.size()) * 8;
+		m_responseCursor = 0;
+		// The host supplies two turnaround edges before it starts polling CMD.
+		m_responseDelay = 2;
+		m_commandOutput = true;
+	}
+}

--- a/source/elektron/md/mdLib/mdplusdrive.h
+++ b/source/elektron/md/mdLib/mdplusdrive.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace md
+{
+	constexpr size_t g_plusDriveMaxSerializedBytes = 512u * 1024u * 1024u;
+
+	// Serial MMC device connected to the Machinedrum MKII Port A pins. The
+	// ColdFire drives clock on bit 2 and uses bit 3 as the bidirectional command
+	// line; bits 7..4 are the four data lines. Storage commands are implemented
+	// separately from the wire protocol so a sparse backing store can be used.
+	class PlusDrive
+	{
+	public:
+		void reset();
+		void setEnabled(bool _enabled);
+		void portChanged(uint8_t _direction, uint8_t _output);
+		uint8_t inputLevel() const;
+
+		bool enabled() const { return m_enabled; }
+		bool initialized() const { return m_initialized; }
+		uint64_t commandCount() const { return m_commandCount; }
+		uint8_t lastCommand() const { return m_lastCommand; }
+		size_t storedSectorCount() const { return m_sectors.size(); }
+		std::vector<uint8_t> copyStorage() const;
+		static bool validateStorage(const uint8_t* _data, size_t _size);
+		static bool validateStorage(const std::vector<uint8_t>& _data)
+		{
+			return validateStorage(_data.data(), _data.size());
+		}
+		bool replaceStorage(const std::vector<uint8_t>& _data, bool _dirty = false);
+		bool storageDirty() const { return m_storageGeneration != m_persistedGeneration; }
+		uint64_t storageGeneration() const { return m_storageGeneration; }
+		uint64_t persistedGeneration() const { return m_persistedGeneration; }
+		void markStoragePersisted(uint64_t _generation);
+
+	private:
+		void clockEdge(uint8_t _direction, uint8_t _output);
+		void receiveCommandBit(bool _bit);
+		void executeCommand();
+		void advanceReadData(uint8_t _direction);
+		void advanceWriteData(uint8_t _direction, uint8_t _output);
+		void queueShortResponse(uint32_t _value);
+		void queueLongResponse(const std::array<uint8_t, 16>& _value);
+		void queueResponse(const uint8_t* _bytes, size_t _size);
+		void storageChanged(bool _dirty);
+
+		bool m_enabled = false;
+		bool m_clock = false;
+		bool m_commandOutput = true;
+		std::array<uint8_t, 6> m_command{};
+		size_t m_commandBits = 0;
+		std::array<uint8_t, 17> m_response{};
+		size_t m_responseBits = 0;
+		size_t m_responseCursor = 0;
+		size_t m_responseDelay = 0;
+		bool m_initialized = false;
+		bool m_reading = false;
+		bool m_singleBlock = false;
+		size_t m_dataDelay = 0;
+		size_t m_dataCursor = 0;
+		uint8_t m_dataOutput = 0xf0;
+		uint32_t m_readSector = 0;
+		enum class WriteState { Idle, AwaitStart, Data, Crc, Response };
+		WriteState m_writeState = WriteState::Idle;
+		bool m_singleWrite = false;
+		uint32_t m_writeSector = 0;
+		size_t m_writeCursor = 0;
+		size_t m_writeResponseCursor = 0;
+		std::array<uint8_t, 512> m_writeBlock{};
+		std::unordered_map<uint32_t, std::array<uint8_t, 512>> m_sectors;
+		bool m_writeSawIdleData = false;
+		uint64_t m_storageGeneration = 0;
+		uint64_t m_persistedGeneration = 0;
+		mutable std::vector<uint8_t> m_serializedStorage;
+		uint64_t m_commandCount = 0;
+		uint8_t m_lastCommand = 0xff;
+	};
+}

--- a/source/elektron/md/mdLib/mdsim.cpp
+++ b/source/elektron/md/mdLib/mdsim.cpp
@@ -25,6 +25,7 @@ namespace md
 		m_mem[g_imr + 1] = 0xfe;		//            stored big-endian
 
 		m_ppInputLevel = 0xff;			// MD parallel-port inputs idle HIGH
+		m_plusDrive.reset();
 
 		for(auto& t : m_timer)
 			t = Timer{};
@@ -184,6 +185,8 @@ namespace md
 		// UART mode/clock/command config, interrupt controller, ...) is stored so a
 		// subsequent read returns what was written.
 		m_mem[_offset] = _value;
+		if(_offset == g_ppddr || _offset == g_ppdat)
+			m_plusDrive.portChanged(m_mem[g_ppddr], m_mem[g_ppdat]);
 
 		const auto refreshIfTimerConfig = [this, _offset](const unsigned _index,
 			const uint32_t _base)
@@ -228,6 +231,12 @@ namespace md
 		const uint8_t ddr    = m_mem[g_ppddr];
 		const uint8_t outLat = m_mem[g_ppdat];
 		uint8_t inputLevel = m_ppInputLevel;
+		if(m_plusDrive.enabled())
+		{
+			constexpr uint8_t drivePins = 0xf8;
+			inputLevel = static_cast<uint8_t>((inputLevel & ~drivePins)
+				| (m_plusDrive.inputLevel() & drivePins));
+		}
 		if(m_mk2PortAInvertedLoopback)
 		{
 			// MKII board identification uses an inverted Port A loopback: input

--- a/source/elektron/md/mdLib/mdsim.h
+++ b/source/elektron/md/mdLib/mdsim.h
@@ -5,6 +5,8 @@
 #include <cstdint>
 #include <functional>
 
+#include "mdplusdrive.h"
+
 namespace md
 {
 	// -------------------------------------------------------------------------
@@ -163,6 +165,9 @@ namespace md
 		{
 			m_mk2PortAInvertedLoopback = _enabled;
 		}
+		void setPlusDriveEnabled(bool _enabled) { m_plusDrive.setEnabled(_enabled); }
+		PlusDrive& getPlusDrive() { return m_plusDrive; }
+		const PlusDrive& getPlusDrive() const { return m_plusDrive; }
 
 		uint8_t getParallelDirection() const { return m_mem[g_ppddr]; }	// PPDDR
 		uint8_t getParallelData()      const { return computeParallelData(); }	// value a PPDAT read returns
@@ -312,6 +317,7 @@ namespace md
 		uint8_t m_ppInputLevel = 0xff;
 		// MKII motherboard strap: input bit 0 inverts driven output bit 2.
 		bool m_mk2PortAInvertedLoopback = false;
+		PlusDrive m_plusDrive;
 
 		std::array<Uart, g_uartCount> m_uart{};
 

--- a/source/elektron/md/mdLib/mdstate.cpp
+++ b/source/elektron/md/mdLib/mdstate.cpp
@@ -1,5 +1,7 @@
 #include "mdstate.h"
 
+#include "mdplusdrive.h"
+
 #include <algorithm>
 #include <array>
 #include <cstddef>
@@ -17,6 +19,9 @@ namespace md
 		constexpr uint16_t g_version3 = 3;
 		constexpr uint16_t g_version3HeaderSize = 52;
 		constexpr uint16_t g_version3FlashFlag = 1;
+		constexpr uint16_t g_version4 = 4;
+		constexpr uint16_t g_version4HeaderSize = 60;
+		constexpr uint16_t g_version4Flags = g_version3FlashFlag | 2;
 		constexpr uint32_t g_sectorEntryHeaderSize = 8;
 		constexpr std::array<uint8_t, 4> g_cacheMagic = {'M', 'D', 'F', 'C'};
 		constexpr uint16_t g_cacheVersion = 2;
@@ -62,6 +67,15 @@ namespace md
 		{
 			return (static_cast<uint64_t>(readU32(_src, _offset)) << 32)
 				| readU32(_src, _offset + 4);
+		}
+
+		void writeU32(std::vector<uint8_t>& _dst, const size_t _offset,
+			const uint32_t _value)
+		{
+			_dst[_offset] = static_cast<uint8_t>(_value >> 24);
+			_dst[_offset + 1] = static_cast<uint8_t>(_value >> 16);
+			_dst[_offset + 2] = static_cast<uint8_t>(_value >> 8);
+			_dst[_offset + 3] = static_cast<uint8_t>(_value);
 		}
 
 		uint32_t crc32(const uint8_t* const _data, const size_t _size)
@@ -258,7 +272,8 @@ namespace md
 		const std::vector<uint8_t>& _flashData,
 		const std::vector<uint8_t>& _factoryFlashBaseline,
 		const std::vector<uint8_t>& _romBaseline,
-		const MachineModel _model, const synthLib::StateType _type)
+		const MachineModel _model, const synthLib::StateType _type,
+		const std::vector<uint8_t>& _plusDrive)
 	{
 		FlashSectorOverlay overlay;
 		// A ROM-relative fallback must describe every sector, including a sector the
@@ -268,32 +283,39 @@ namespace md
 		if(!makeFlashOverlay(overlay, _flashData, _factoryFlashBaseline,
 			_romBaseline, completeImage))
 			return false;
-		return encodeState(_state, _patchRam, overlay, _romBaseline, _model, _type);
+		return encodeState(_state, _patchRam, overlay, _romBaseline, _model, _type,
+			_plusDrive);
 	}
 
 	bool encodeState(std::vector<uint8_t>& _state,
 		const std::vector<uint8_t>& _patchRam,
 		const FlashSectorOverlay& _flashOverlay,
 		const std::vector<uint8_t>& _romBaseline,
-		const MachineModel _model, const synthLib::StateType _type)
+		const MachineModel _model, const synthLib::StateType _type,
+		const std::vector<uint8_t>& _plusDrive)
 	{
+		const bool hasPlusDrive = !_plusDrive.empty();
 		if(_model != MachineModel::Machinedrum
 			|| _patchRam.size() != g_patchRamStateSize || !validStateType(_type)
 			|| !validFlashOverlay(_flashOverlay, _romBaseline)
-			|| _flashOverlay.sectors.size() > std::numeric_limits<uint16_t>::max())
+			|| _flashOverlay.sectors.size() > std::numeric_limits<uint16_t>::max()
+			|| _plusDrive.size() > g_plusDriveMaxSerializedBytes
+			|| (hasPlusDrive && !PlusDrive::validateStorage(_plusDrive)))
 			return false;
 
 		const auto originalSize = _state.size();
 		const auto entrySize = static_cast<size_t>(g_sectorEntryHeaderSize)
 			+ g_uwFlashSectorSize;
-		_state.reserve(originalSize + g_version3HeaderSize + _patchRam.size()
-			+ _flashOverlay.sectors.size() * entrySize);
+		const auto headerSize = hasPlusDrive
+			? g_version4HeaderSize : g_version3HeaderSize;
+		_state.reserve(originalSize + headerSize + _patchRam.size()
+			+ _flashOverlay.sectors.size() * entrySize + _plusDrive.size());
 		_state.insert(_state.end(), g_magic.begin(), g_magic.end());
-		appendU16(_state, g_version3);
-		appendU16(_state, g_version3HeaderSize);
+		appendU16(_state, hasPlusDrive ? g_version4 : g_version3);
+		appendU16(_state, static_cast<uint16_t>(headerSize));
 		_state.push_back(modelTag(_model));
 		_state.push_back(static_cast<uint8_t>(_type));
-		appendU16(_state, g_version3FlashFlag);
+		appendU16(_state, hasPlusDrive ? g_version4Flags : g_version3FlashFlag);
 		appendU32(_state, static_cast<uint32_t>(_patchRam.size()));
 		appendU32(_state, crc32(_patchRam.data(), _patchRam.size()));
 		appendU64(_state, _flashOverlay.romFingerprint);
@@ -304,15 +326,22 @@ namespace md
 		appendU16(_state, 0);
 		const auto overlayCrcOffset = _state.size();
 		appendU32(_state, 0);
+		if(hasPlusDrive)
+		{
+			appendU32(_state, static_cast<uint32_t>(_plusDrive.size()));
+			appendU32(_state, crc32(_plusDrive.data(), _plusDrive.size()));
+		}
 		_state.insert(_state.end(), _patchRam.begin(), _patchRam.end());
 		const auto overlayOffset = _state.size();
 		appendFlashEntries(_state, _flashOverlay);
-		const auto overlayCrc = crc32(_state.data() + overlayOffset,
-			_state.size() - overlayOffset);
+		const auto overlaySize = _flashOverlay.sectors.size() * entrySize;
+		const auto overlayCrc = crc32(_state.data() + overlayOffset, overlaySize);
 		_state[overlayCrcOffset] = static_cast<uint8_t>(overlayCrc >> 24);
 		_state[overlayCrcOffset + 1] = static_cast<uint8_t>(overlayCrc >> 16);
 		_state[overlayCrcOffset + 2] = static_cast<uint8_t>(overlayCrc >> 8);
 		_state[overlayCrcOffset + 3] = static_cast<uint8_t>(overlayCrc);
+		if(hasPlusDrive)
+			_state.insert(_state.end(), _plusDrive.begin(), _plusDrive.end());
 		return true;
 	}
 
@@ -386,12 +415,19 @@ namespace md
 			_decoded = std::move(decoded);
 			return true;
 		}
-		if(readU16(_state, 4) != g_version3 || _state.size() < g_version3HeaderSize
-			|| readU16(_state, 6) != g_version3HeaderSize
+		const auto version = readU16(_state, 4);
+		const bool hasPlusDrive = version == g_version4;
+		const auto headerSize = hasPlusDrive
+			? g_version4HeaderSize : g_version3HeaderSize;
+		const auto expectedFlags = hasPlusDrive
+			? g_version4Flags : g_version3FlashFlag;
+		if((version != g_version3 && version != g_version4)
+			|| _state.size() < headerSize
+			|| readU16(_state, 6) != headerSize
 			|| _expectedModel != MachineModel::Machinedrum
 			|| _state[8] != modelTag(_expectedModel)
 			|| _state[9] != static_cast<uint8_t>(_expectedType)
-			|| readU16(_state, 10) != g_version3FlashFlag)
+			|| readU16(_state, 10) != expectedFlags)
 			return false;
 
 		const auto patchSize = readU32(_state, 12);
@@ -407,17 +443,30 @@ namespace md
 			return false;
 
 		const auto entrySize = static_cast<size_t>(g_sectorEntryHeaderSize) + sectorSize;
-		const auto expectedSize = static_cast<size_t>(g_version3HeaderSize) + patchSize
-			+ static_cast<size_t>(sectorCount) * entrySize;
+		const auto plusDriveSize = hasPlusDrive ? readU32(_state, 52) : 0;
+		if(hasPlusDrive && (plusDriveSize < 16
+			|| plusDriveSize > g_plusDriveMaxSerializedBytes))
+			return false;
+		const auto flashEntriesSize = static_cast<size_t>(sectorCount) * entrySize;
+		const auto expectedSize = static_cast<size_t>(headerSize) + patchSize
+			+ flashEntriesSize + plusDriveSize;
 		if(_state.size() != expectedSize)
 			return false;
-		const auto* const patch = _state.data() + g_version3HeaderSize;
+		const auto* const patch = _state.data() + headerSize;
 		if(readU32(_state, 16) != crc32(patch, patchSize))
 			return false;
-		const auto overlayOffset = static_cast<size_t>(g_version3HeaderSize) + patchSize;
+		const auto overlayOffset = static_cast<size_t>(headerSize) + patchSize;
 		if(readU32(_state, 48) != crc32(_state.data() + overlayOffset,
-			_state.size() - overlayOffset))
+			flashEntriesSize))
 			return false;
+		const auto plusDriveOffset = overlayOffset + flashEntriesSize;
+		if(hasPlusDrive)
+		{
+			const auto* const plusDrive = _state.data() + plusDriveOffset;
+			if(readU32(_state, 56) != crc32(plusDrive, plusDriveSize)
+				|| !PlusDrive::validateStorage(plusDrive, plusDriveSize))
+				return false;
+		}
 
 		DecodedState decoded;
 		decoded.patchRam.assign(patch, patch + patchSize);
@@ -427,6 +476,13 @@ namespace md
 		decoded.containsFlash = true;
 		if(!decodeFlashEntries(decoded.flashOverlay, _state, overlayOffset, sectorCount))
 			return false;
+		if(hasPlusDrive)
+		{
+			decoded.plusDrive.assign(
+				_state.begin() + static_cast<std::ptrdiff_t>(plusDriveOffset),
+				_state.end());
+			decoded.containsPlusDrive = true;
+		}
 		_decoded = std::move(decoded);
 		return true;
 	}
@@ -465,6 +521,54 @@ namespace md
 				flash.begin() + destination);
 		}
 		_flashData.swap(flash);
+		return true;
+	}
+
+	bool replacePlusDriveState(std::vector<uint8_t>& _state,
+		const std::vector<uint8_t>& _plusDrive)
+	{
+		if(_state.size() < g_version4HeaderSize || !hasMagic(_state)
+			|| readU16(_state, 4) != g_version4
+			|| readU16(_state, 6) != g_version4HeaderSize
+			|| _state[8] != modelTag(MachineModel::Machinedrum)
+			|| !validStateType(static_cast<synthLib::StateType>(_state[9]))
+			|| readU16(_state, 10) != g_version4Flags
+			|| _plusDrive.size() < 16
+			|| _plusDrive.size() > g_plusDriveMaxSerializedBytes
+			|| !PlusDrive::validateStorage(_plusDrive))
+			return false;
+
+		const auto patchSize = readU32(_state, 12);
+		const auto flashSize = readU32(_state, 36);
+		const auto sectorSize = readU32(_state, 40);
+		const auto sectorCount = readU16(_state, 44);
+		const auto oldPlusDriveSize = readU32(_state, 52);
+		if(patchSize != g_patchRamStateSize || flashSize != g_romSize
+			|| sectorSize != g_uwFlashSectorSize || readU16(_state, 46) != 0
+			|| sectorCount > flashSize / sectorSize || oldPlusDriveSize < 16
+			|| oldPlusDriveSize > g_plusDriveMaxSerializedBytes)
+			return false;
+		const auto entrySize = static_cast<size_t>(g_sectorEntryHeaderSize) + sectorSize;
+		const auto overlaySize = static_cast<size_t>(sectorCount) * entrySize;
+		const auto patchOffset = static_cast<size_t>(g_version4HeaderSize);
+		const auto overlayOffset = patchOffset + patchSize;
+		const auto plusDriveOffset = overlayOffset + overlaySize;
+		if(_state.size() != plusDriveOffset + oldPlusDriveSize
+			|| readU32(_state, 16) != crc32(_state.data() + patchOffset, patchSize)
+			|| readU32(_state, 48) != crc32(_state.data() + overlayOffset, overlaySize)
+			|| readU32(_state, 56)
+				!= crc32(_state.data() + plusDriveOffset, oldPlusDriveSize))
+			return false;
+		if(!PlusDrive::validateStorage(
+			_state.data() + plusDriveOffset, oldPlusDriveSize))
+			return false;
+
+		std::vector<uint8_t> updated(_state.begin(),
+			_state.begin() + static_cast<std::ptrdiff_t>(plusDriveOffset));
+		writeU32(updated, 52, static_cast<uint32_t>(_plusDrive.size()));
+		writeU32(updated, 56, crc32(_plusDrive.data(), _plusDrive.size()));
+		updated.insert(updated.end(), _plusDrive.begin(), _plusDrive.end());
+		_state.swap(updated);
 		return true;
 	}
 

--- a/source/elektron/md/mdLib/mdstate.h
+++ b/source/elektron/md/mdLib/mdstate.h
@@ -27,7 +27,9 @@ namespace md
 	{
 		std::vector<uint8_t> patchRam;
 		FlashSectorOverlay flashOverlay;
+		std::vector<uint8_t> plusDrive;
 		bool containsFlash = false;
+		bool containsPlusDrive = false;
 	};
 
 	// Append a self-describing patch-RAM image to _state. The synthLib plugin wrapper may
@@ -49,11 +51,13 @@ namespace md
 		const std::vector<uint8_t>& _flashData,
 		const std::vector<uint8_t>& _factoryFlashBaseline,
 		const std::vector<uint8_t>& _romBaseline,
-		MachineModel _model, synthLib::StateType _type);
+		MachineModel _model, synthLib::StateType _type,
+		const std::vector<uint8_t>& _plusDrive = {});
 	bool encodeState(std::vector<uint8_t>& _state, const std::vector<uint8_t>& _patchRam,
 		const FlashSectorOverlay& _flashOverlay,
 		const std::vector<uint8_t>& _romBaseline,
-		MachineModel _model, synthLib::StateType _type);
+		MachineModel _model, synthLib::StateType _type,
+		const std::vector<uint8_t>& _plusDrive = {});
 
 	// Validate and decode a device payload. No output is changed on failure.
 	bool decodeState(std::vector<uint8_t>& _patchRam, const std::vector<uint8_t>& _state,
@@ -68,6 +72,10 @@ namespace md
 	bool decodeState(DecodedState& _decoded, const std::vector<uint8_t>& _state,
 		const std::vector<uint8_t>& _romBaseline,
 		MachineModel _expectedModel, synthLib::StateType _expectedType);
+	// Replace only the project-owned +Drive payload in a validated version-4 MD
+	// state. All kit/pattern/song/global and UW flash bytes remain unchanged.
+	bool replacePlusDriveState(std::vector<uint8_t>& _state,
+		const std::vector<uint8_t>& _plusDrive);
 	bool applyFlashOverlay(std::vector<uint8_t>& _flashData,
 		const FlashSectorOverlay& _overlay,
 		const std::vector<uint8_t>& _factoryFlashBaseline,

--- a/source/elektron/md/mdLib/profile/mdplusdrivestateworkload.cpp
+++ b/source/elektron/md/mdLib/profile/mdplusdrivestateworkload.cpp
@@ -1,0 +1,141 @@
+#include "mdLib/mdplusdrive.h"
+#include "mdLib/mdstate.h"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <vector>
+
+#if defined(__APPLE__) || defined(__linux__)
+#include <sys/resource.h>
+#endif
+
+namespace
+{
+	constexpr size_t HeaderSize = 16;
+	constexpr size_t RecordSize = 4 + 512;
+
+	void writeBe32(std::vector<uint8_t>& _data, const size_t _offset,
+		const uint32_t _value)
+	{
+		_data[_offset] = static_cast<uint8_t>(_value >> 24);
+		_data[_offset + 1] = static_cast<uint8_t>(_value >> 16);
+		_data[_offset + 2] = static_cast<uint8_t>(_value >> 8);
+		_data[_offset + 3] = static_cast<uint8_t>(_value);
+	}
+
+	std::vector<uint8_t> makeImage(const uint32_t _sectorCount)
+	{
+		std::vector<uint8_t> image(HeaderSize
+			+ static_cast<size_t>(_sectorCount) * RecordSize);
+		image[0] = 'M';
+		image[1] = 'D';
+		image[2] = 'P';
+		image[3] = 'D';
+		writeBe32(image, 4, 1);
+		writeBe32(image, 8, 512);
+		writeBe32(image, 12, _sectorCount);
+		for(uint32_t sector = 0; sector < _sectorCount; ++sector)
+		{
+			const auto offset = HeaderSize + static_cast<size_t>(sector) * RecordSize;
+			writeBe32(image, offset, sector);
+			image[offset + 4] = static_cast<uint8_t>(sector);
+			image[offset + RecordSize - 1] = static_cast<uint8_t>(sector >> 8);
+		}
+		return image;
+	}
+
+	long long millisecondsSince(const std::chrono::steady_clock::time_point _start)
+	{
+		return std::chrono::duration_cast<std::chrono::milliseconds>(
+			std::chrono::steady_clock::now() - _start).count();
+	}
+
+	uint64_t peakResidentBytes()
+	{
+#if defined(__APPLE__) || defined(__linux__)
+		rusage usage{};
+		if(getrusage(RUSAGE_SELF, &usage) != 0)
+			return 0;
+#if defined(__APPLE__)
+		return static_cast<uint64_t>(usage.ru_maxrss);
+#else
+		return static_cast<uint64_t>(usage.ru_maxrss) * 1024u;
+#endif
+#else
+		return 0;
+#endif
+	}
+}
+
+int main(const int _argc, const char* const* _argv)
+{
+	try
+	{
+		const auto maximumRecords = static_cast<uint32_t>(
+			(md::g_plusDriveMaxSerializedBytes - HeaderSize) / RecordSize);
+		const auto records = _argc > 1
+			? static_cast<uint64_t>(std::stoull(_argv[1]))
+			: static_cast<uint64_t>(maximumRecords);
+		if(records > maximumRecords
+			|| records > std::numeric_limits<uint32_t>::max())
+		{
+			std::cerr << "sector count exceeds the bounded MDPD state maximum\n";
+			return 2;
+		}
+
+		const auto buildStart = std::chrono::steady_clock::now();
+		auto plusDrive = makeImage(static_cast<uint32_t>(records));
+		const auto buildMs = millisecondsSince(buildStart);
+		if(!md::PlusDrive::validateStorage(plusDrive))
+		{
+			std::cerr << "generated MDPD image was invalid\n";
+			return 1;
+		}
+
+		std::vector<uint8_t> patchRam(md::g_patchRamStateSize);
+		std::vector<uint8_t> rom(md::g_romSize);
+		auto factoryFlash = rom;
+		factoryFlash[0] = 1;
+		const auto flash = factoryFlash;
+
+		const auto encodeStart = std::chrono::steady_clock::now();
+		std::vector<uint8_t> projectState;
+		if(!md::encodeState(projectState, patchRam, flash, factoryFlash, rom,
+			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal, plusDrive))
+		{
+			std::cerr << "project-state encode failed\n";
+			return 1;
+		}
+		const auto encodeMs = millisecondsSince(encodeStart);
+
+		const auto decodeStart = std::chrono::steady_clock::now();
+		md::DecodedState decoded;
+		if(!md::decodeState(decoded, projectState, rom,
+			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal)
+			|| !decoded.containsPlusDrive || decoded.plusDrive != plusDrive)
+		{
+			std::cerr << "project-state round trip failed\n";
+			return 1;
+		}
+		const auto decodeMs = millisecondsSince(decodeStart);
+
+		std::cout << "records=" << records
+			<< " image_bytes=" << plusDrive.size()
+			<< " project_state_bytes=" << projectState.size()
+			<< " build_ms=" << buildMs
+			<< " encode_ms=" << encodeMs
+			<< " decode_ms=" << decodeMs
+			<< " peak_resident_bytes=" << peakResidentBytes() << '\n';
+		return 0;
+	}
+	catch(const std::exception& error)
+	{
+		std::cerr << "mdPlusDriveStateWorkload: " << error.what() << '\n';
+		return 2;
+	}
+}

--- a/source/elektron/md/mdLib/profile/mdprofileaccess.h
+++ b/source/elektron/md/mdLib/profile/mdprofileaccess.h
@@ -17,7 +17,7 @@ namespace md
 		{
 			return std::unique_ptr<Hardware>(
 				new Hardware(true, _image, "generated-profile-input", _model,
-					{}, {}, {}, {}, {}, {}));
+					{}, {}, {}, {}, {}, {}, {}, false));
 		}
 	};
 }

--- a/source/elektron/md/mdLib/test/mdplusdrive_test.cpp
+++ b/source/elektron/md/mdLib/test/mdplusdrive_test.cpp
@@ -1,0 +1,269 @@
+#include "mdLib/mdsim.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace
+{
+	void sendCommand(md::Sim& _sim, const uint8_t _command, const uint32_t _argument,
+		const uint8_t _crc)
+	{
+		const std::array<uint8_t, 6> bytes{{
+			static_cast<uint8_t>(0x40 | _command),
+			static_cast<uint8_t>(_argument >> 24),
+			static_cast<uint8_t>(_argument >> 16),
+			static_cast<uint8_t>(_argument >> 8),
+			static_cast<uint8_t>(_argument), _crc}};
+		_sim.write8(md::Sim::g_ppddr, 0x0c);
+		bool clock = (_sim.getParallelData() & 0x04) != 0;
+		for(const auto byte : bytes)
+			for(int bit = 7; bit >= 0; --bit)
+			{
+				clock = !clock;
+				const uint8_t data = (byte & (1u << bit)) ? 0x08 : 0;
+				_sim.write8(md::Sim::g_ppdat,
+					static_cast<uint8_t>(data | (clock ? 0x04 : 0)));
+			}
+	}
+
+	std::vector<uint8_t> readResponse(md::Sim& _sim, const size_t _size)
+	{
+		_sim.write8(md::Sim::g_ppddr, 0x04);
+		std::vector<uint8_t> response(_size);
+		bool clock = (_sim.getParallelData() & 0x04) != 0;
+		for(size_t i = 0; i < 2; ++i)
+		{
+			clock = !clock;
+			_sim.write8(md::Sim::g_ppdat, clock ? 0x04 : 0x00);
+		}
+		for(auto& byte : response)
+			for(int bit = 7; bit >= 0; --bit)
+			{
+				clock = !clock;
+				_sim.write8(md::Sim::g_ppdat, clock ? 0x04 : 0x00);
+				if(_sim.read8(md::Sim::g_ppdat) & 0x08)
+					byte |= static_cast<uint8_t>(1u << bit);
+			}
+		return response;
+	}
+
+	bool shortResponse(md::Sim& _sim, const uint8_t _command,
+		const uint32_t _argument, const uint32_t _expected)
+	{
+		sendCommand(_sim, _command, _argument, 0xff);
+		const auto response = readResponse(_sim, 5);
+		return response.size() == 5 && response[0] == 0x3f
+			&& (static_cast<uint32_t>(response[1]) << 24
+				| static_cast<uint32_t>(response[2]) << 16
+				| static_cast<uint32_t>(response[3]) << 8
+				| response[4]) == _expected;
+	}
+}
+
+int main()
+{
+	md::Sim sim;
+	sim.setPlusDriveEnabled(true);
+	if((sim.read8(md::Sim::g_ppdat) & 0xf8) != 0xf8)
+	{
+		std::fputs("mdplusdrive_test: idle bus is not pulled high\n", stderr);
+		return 1;
+	}
+
+	sendCommand(sim, 0, 0, 0x95);
+	if(sim.getPlusDrive().commandCount() != 1
+		|| sim.getPlusDrive().lastCommand() != 0)
+	{
+		std::fputs("mdplusdrive_test: GO_IDLE_STATE was not decoded\n", stderr);
+		return 1;
+	}
+	if(!shortResponse(sim, 1, 0x40ff8000u, 0xc0ff8080u))
+	{
+		std::fputs("mdplusdrive_test: SEND_OP_COND response is invalid\n", stderr);
+		return 1;
+	}
+
+	sendCommand(sim, 2, 0, 0xff);
+	const auto cid = readResponse(sim, 17);
+	if(cid[0] != 0x3f || cid[4] != 'G' || cid[5] != 'M' || cid[6] != 'D')
+	{
+		std::fputs("mdplusdrive_test: CID response is invalid\n", stderr);
+		return 1;
+	}
+	if(!shortResponse(sim, 3, 0x00020000u, 0x00000700u)
+		|| !shortResponse(sim, 7, 0x00020000u, 0x00000900u))
+	{
+		std::fputs("mdplusdrive_test: card selection failed\n", stderr);
+		return 1;
+	}
+
+	sendCommand(sim, 9, 0x00020000u, 0xff);
+	const auto csd = readResponse(sim, 17);
+	if(csd[0] != 0x3f || (csd[1] & 0xc0) != 0xc0)
+	{
+		std::fputs("mdplusdrive_test: CSD response is invalid\n", stderr);
+		return 1;
+	}
+	if(!shortResponse(sim, 6, 0x03b70100u, 0x00000900u)
+		|| !shortResponse(sim, 16, 512, 0x00000900u)
+		|| !sim.getPlusDrive().initialized())
+	{
+		std::fputs("mdplusdrive_test: initialization sequence did not complete\n", stderr);
+		return 1;
+	}
+	if(!shortResponse(sim, 17, 4u * 1024u * 1024u, 0x80000900u)
+		|| !shortResponse(sim, 24, 4u * 1024u * 1024u, 0x80000900u))
+	{
+		std::fputs("mdplusdrive_test: out-of-range block was accepted\n", stderr);
+		return 1;
+	}
+
+	sendCommand(sim, 17, 0, 0xff);
+	if(readResponse(sim, 5)[0] != 0x3f)
+		return 1;
+	// Consume the command routine's trailing clocks, then wait for the four-bit
+	// data start token and verify one erased 512-byte block.
+	bool clock = false;
+	for(size_t i = 0; i < 64; ++i)
+	{
+		clock = !clock;
+		sim.write8(md::Sim::g_ppdat, clock ? 0x04 : 0x00);
+		if((sim.read8(md::Sim::g_ppdat) & 0xf0) == 0)
+			break;
+		if(i == 63)
+		{
+			std::fputs("mdplusdrive_test: data token did not arrive\n", stderr);
+			return 1;
+		}
+	}
+	for(size_t nibble = 0; nibble < 1024; ++nibble)
+	{
+		clock = !clock;
+		sim.write8(md::Sim::g_ppdat, clock ? 0x04 : 0x00);
+		if((sim.read8(md::Sim::g_ppdat) & 0xf0) != 0xf0)
+		{
+			std::fputs("mdplusdrive_test: erased block data is invalid\n", stderr);
+			return 1;
+		}
+	}
+
+	sendCommand(sim, 24, 7, 0xff);
+	if(readResponse(sim, 5)[0] != 0x3f)
+		return 1;
+	clock = (sim.getParallelData() & 0x04) != 0;
+	for(size_t i = 0; i < 8; ++i)
+	{
+		clock = !clock;
+		sim.write8(md::Sim::g_ppdat, clock ? 0x04 : 0x00);
+	}
+	sim.write8(md::Sim::g_ppddr, 0xf4);
+	sim.write8(md::Sim::g_ppdat, 0xf0);
+	sim.write8(md::Sim::g_ppdat, 0xf4);
+	sim.write8(md::Sim::g_ppdat, 0x00);
+	clock = (sim.getParallelData() & 0x04) != 0;
+	for(size_t nibble = 0; nibble < 1024; ++nibble)
+	{
+		clock = !clock;
+		const uint8_t data = static_cast<uint8_t>((nibble & 1 ? 0x0a : 0x05) << 4);
+		sim.write8(md::Sim::g_ppdat,
+			static_cast<uint8_t>(data | (clock ? 0x04 : 0)));
+	}
+	for(size_t nibble = 0; nibble < 16; ++nibble)
+	{
+		clock = !clock;
+		sim.write8(md::Sim::g_ppdat, clock ? 0x04 : 0x00);
+	}
+	if(sim.getPlusDrive().storedSectorCount() != 1)
+	{
+		std::fputs("mdplusdrive_test: written block was not stored\n", stderr);
+		return 1;
+	}
+	const auto image = sim.getPlusDrive().copyStorage();
+	if(image.size() < 21 || image[19] != 7 || image[20] != 0x5a)
+	{
+		std::fprintf(stderr, "mdplusdrive_test: stored record is %02x/%02x\n",
+			image.size() > 19 ? image[19] : 0xff,
+			image.size() > 20 ? image[20] : 0xff);
+		return 1;
+	}
+	md::Sim restored;
+	restored.setPlusDriveEnabled(true);
+	if(!restored.getPlusDrive().replaceStorage(image))
+		return 1;
+	auto malformed = image;
+	malformed[16] = 0xff;
+	if(restored.getPlusDrive().replaceStorage(malformed))
+	{
+		std::fputs("mdplusdrive_test: malformed storage was accepted\n", stderr);
+		return 1;
+	}
+
+	md::PlusDrive generations;
+	if(!generations.replaceStorage(image)
+		|| generations.storageDirty())
+	{
+		std::fputs("mdplusdrive_test: clean image started dirty\n", stderr);
+		return 1;
+	}
+	auto secondImage = image;
+	secondImage[20] ^= 0x01;
+	if(!generations.replaceStorage(secondImage, true)
+		|| !generations.storageDirty())
+	{
+		std::fputs("mdplusdrive_test: changed image was not dirty\n", stderr);
+		return 1;
+	}
+	const auto firstGeneration = generations.storageGeneration();
+	auto thirdImage = secondImage;
+	thirdImage[20] ^= 0x02;
+	if(!generations.replaceStorage(thirdImage, true)
+		|| generations.storageGeneration() <= firstGeneration)
+	{
+		std::fputs("mdplusdrive_test: generation did not advance\n", stderr);
+		return 1;
+	}
+	const auto secondGeneration = generations.storageGeneration();
+	generations.markStoragePersisted(firstGeneration);
+	if(!generations.storageDirty())
+	{
+		std::fputs("mdplusdrive_test: stale flush cleared a newer write\n", stderr);
+		return 1;
+	}
+	generations.markStoragePersisted(secondGeneration);
+	if(generations.storageDirty())
+	{
+		std::fputs("mdplusdrive_test: current flush remained dirty\n", stderr);
+		return 1;
+	}
+	sendCommand(restored, 17, 7, 0xff);
+	if(readResponse(restored, 5)[0] != 0x3f)
+		return 1;
+	clock = (restored.getParallelData() & 0x04) != 0;
+	for(size_t i = 0; i < 64; ++i)
+	{
+		clock = !clock;
+		restored.write8(md::Sim::g_ppdat, clock ? 0x04 : 0x00);
+		if((restored.read8(md::Sim::g_ppdat) & 0xf0) == 0)
+			break;
+		if(i == 63)
+			return 1;
+	}
+	for(size_t nibble = 0; nibble < 1024; ++nibble)
+	{
+		clock = !clock;
+		restored.write8(md::Sim::g_ppdat, clock ? 0x04 : 0x00);
+		const uint8_t expected = (nibble & 1) ? 0xa0 : 0x50;
+		if((restored.read8(md::Sim::g_ppdat) & 0xf0) != expected)
+		{
+			std::fprintf(stderr,
+				"mdplusdrive_test: persisted block mismatch at nibble %zu: %02x != %02x\n",
+				nibble, restored.read8(md::Sim::g_ppdat) & 0xf0, expected);
+			return 1;
+		}
+	}
+
+	std::puts("mdplusdrive_test: PASS");
+	return 0;
+}

--- a/source/elektron/md/mdLibTest/CMakeLists.txt
+++ b/source/elektron/md/mdLibTest/CMakeLists.txt
@@ -20,6 +20,12 @@ add_test(NAME mdFlashTest COMMAND mdFlashTest)
 set_tests_properties(mdFlashTest PROPERTIES LABELS "UnitTest")
 set_property(TARGET mdFlashTest PROPERTY FOLDER "Elektron")
 
+add_executable(mdPlusDriveTest ../mdLib/test/mdplusdrive_test.cpp)
+target_link_libraries(mdPlusDriveTest PRIVATE mdLib)
+add_test(NAME mdPlusDriveTest COMMAND mdPlusDriveTest)
+set_tests_properties(mdPlusDriveTest PROPERTIES LABELS "UnitTest")
+set_property(TARGET mdPlusDriveTest PROPERTY FOLDER "Elektron")
+
 add_executable(mdStateTest ../mdLib/test/mdstate_test.cpp)
 target_link_libraries(mdStateTest PRIVATE mdLib)
 add_test(NAME mdStateTest COMMAND mdStateTest)

--- a/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
+++ b/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
@@ -1,9 +1,11 @@
 #include "mdLib/mdhardware.h"
 #include "mdLib/mdpanel.h"
+#include "mdLib/mdstate.h"
 
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <chrono>
 #include <cstdint>
 #include <fstream>
 #include <functional>
@@ -29,6 +31,27 @@ namespace
 		advance(_hardware, 2048);
 		_hardware.sendPanelEvent(packet->row, 0);
 		advance(_hardware, 4096);
+		return true;
+	}
+
+	bool longPressChord(md::Hardware& _hardware, const md::PanelControl _first,
+		const md::PanelControl _second)
+	{
+		const auto first = md::panelPacket(md::MachineModel::Machinedrum, _first);
+		const auto second = md::panelPacket(md::MachineModel::Machinedrum, _second);
+		if(!first || !second)
+			return false;
+		md::PanelRowState rows;
+		const auto firstPress = rows.press(*first);
+		_hardware.sendPanelEvent(firstPress.row, firstPress.mask);
+		const auto secondPress = rows.press(*second);
+		_hardware.sendPanelEvent(secondPress.row, secondPress.mask);
+		advance(_hardware, md::g_samplerate * 2);
+		const auto secondRelease = rows.release(*second);
+		_hardware.sendPanelEvent(secondRelease.row, secondRelease.mask);
+		const auto firstRelease = rows.release(*first);
+		_hardware.sendPanelEvent(firstRelease.row, firstRelease.mask);
+		advance(_hardware, 8192);
 		return true;
 	}
 
@@ -122,8 +145,24 @@ int main(const int argc, const char* const* argv)
 	// Boot once to let the firmware prepare UW flash, then verify the resulting
 	// factory baseline on a normal, freshly booted machine.
 	const auto initialized = initializeUwFlash(initializer);
+	if(!initializer.getUC().getSim().getPlusDrive().initialized())
+	{
+		std::cerr << "+Drive commands: "
+			<< initializer.getUC().getSim().getPlusDrive().commandCount()
+			<< ", last command: "
+			<< static_cast<uint32_t>(initializer.getUC().getSim().getPlusDrive().lastCommand())
+			<< '\n';
+		return fail("firmware did not initialize the +Drive interface");
+	}
 	if(!initializer.flashDirty())
+	{
+		std::cerr << "+Drive commands before UW init: "
+			<< initializer.getUC().getSim().getPlusDrive().commandCount()
+			<< ", last command: "
+			<< static_cast<uint32_t>(initializer.getUC().getSim().getPlusDrive().lastCommand())
+			<< '\n';
 		return fail("firmware did not initialize UW flash");
+	}
 	if(!initialized)
 		return fail("completed UW initializer was not eligible for the factory cache");
 
@@ -206,36 +245,84 @@ int main(const int argc, const char* const* argv)
 		|| deferredFactory != initializedFlash)
 		return fail("deferred project data contaminated the UW factory cache");
 
-	md::Hardware hardware(rom, argv[1], md::MachineModel::Machinedrum,
+	md::Hardware formatter(rom, argv[1], md::MachineModel::Machinedrum,
 		{}, {}, {}, initializedFlash, factoryCache);
-	advance(hardware, md::g_samplerate * 20);
+	advance(formatter, md::g_samplerate * 20);
+	const auto plusDrive = formatter.copyPlusDriveData();
+	if(formatter.getUC().getSim().getPlusDrive().storedSectorCount() == 0
+		|| plusDrive.empty())
+		return fail("firmware did not format the blank +Drive");
+	const auto stateStart = std::chrono::steady_clock::now();
+	std::vector<uint8_t> formattedProjectState;
+	if(!md::encodeState(formattedProjectState, formatter.copyPatchRam(),
+		formatter.copyFlashData(), initializedFlash, rom,
+		md::MachineModel::Machinedrum, synthLib::StateTypeGlobal, plusDrive))
+		return fail("formatted +Drive could not be embedded in project state");
+	const auto stateMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
+		std::chrono::steady_clock::now() - stateStart).count();
+	md::DecodedState formattedDecoded;
+	if(!md::decodeState(formattedDecoded, formattedProjectState, rom,
+		md::MachineModel::Machinedrum, synthLib::StateTypeGlobal)
+		|| formattedDecoded.plusDrive != plusDrive)
+		return fail("formatted +Drive did not round-trip through project state");
+	constexpr size_t formattedStateBudget = 4u * 1024u * 1024u;
+	if(formattedProjectState.size() > formattedStateBudget)
+		return fail("freshly formatted +Drive exceeded the 4 MiB project-state budget");
+	if(stateMilliseconds > 2000)
+		return fail("freshly formatted +Drive state encoding exceeded two seconds");
+	std::cout << "formatted +Drive: "
+		<< formatter.getUC().getSim().getPlusDrive().storedSectorCount()
+		<< " sectors, " << plusDrive.size() << " image bytes, "
+		<< formattedProjectState.size() << " project bytes, "
+		<< stateMilliseconds << " ms encode\n";
+	md::Hardware plusDriveHardware(rom, argv[1], md::MachineModel::Machinedrum,
+		formatter.copyPatchRam(), {}, {}, formatter.copyFlashData(), factoryCache,
+		{}, plusDrive);
+	advance(plusDriveHardware, md::g_samplerate * 20);
+	const auto mainScreen = plusDriveHardware.getFrontPanelSnapshot();
+	if(!longPressChord(plusDriveHardware, md::PanelControl::Function,
+		md::PanelControl::PatternSong))
+		return fail("failed to open +Drive Snapshot selection");
+	const auto snapshotScreen = plusDriveHardware.getFrontPanelSnapshot();
+	if(!tap(plusDriveHardware, md::PanelControl::Exit)
+		|| !longPressChord(plusDriveHardware, md::PanelControl::Function,
+			md::PanelControl::Kit))
+		return fail("failed to open +Drive sample-bank selection");
+	const auto sampleBankScreen = plusDriveHardware.getFrontPanelSnapshot();
+	if(sameLcd(mainScreen, snapshotScreen)
+		|| sameLcd(mainScreen, sampleBankScreen)
+		|| sameLcd(snapshotScreen, sampleBankScreen))
+		return fail("Snapshot and sample-bank selectors were not exposed by firmware");
+	if(!tap(plusDriveHardware, md::PanelControl::Exit))
+		return fail("failed to leave +Drive sample-bank selection");
 
-	if(!tap(hardware, md::PanelControl::Kit)
-		|| !tap(hardware, md::PanelControl::Down)
-		|| !tap(hardware, md::PanelControl::Enter))
+	if(!tap(plusDriveHardware, md::PanelControl::Kit)
+		|| !tap(plusDriveHardware, md::PanelControl::Down)
+		|| !tap(plusDriveHardware, md::PanelControl::Enter))
 		return fail("failed to enter the machine picker");
 
 	for(uint32_t family = 0; family < 6; ++family)
-		if(!tap(hardware, md::PanelControl::Down))
+		if(!tap(plusDriveHardware, md::PanelControl::Down))
 			return fail("failed to navigate to CTR");
-	const auto ctr = hardware.getFrontPanelSnapshot();
+	const auto ctr = plusDriveHardware.getFrontPanelSnapshot();
 
-	tap(hardware, md::PanelControl::Down);
-	const auto romFamily = hardware.getFrontPanelSnapshot();
-	tap(hardware, md::PanelControl::Down);
-	const auto ramFamily = hardware.getFrontPanelSnapshot();
-	tap(hardware, md::PanelControl::Down);
-	const auto afterRam = hardware.getFrontPanelSnapshot();
+	tap(plusDriveHardware, md::PanelControl::Down);
+	const auto romFamily = plusDriveHardware.getFrontPanelSnapshot();
+	tap(plusDriveHardware, md::PanelControl::Down);
+	const auto ramFamily = plusDriveHardware.getFrontPanelSnapshot();
+	tap(plusDriveHardware, md::PanelControl::Down);
+	const auto afterRam = plusDriveHardware.getFrontPanelSnapshot();
 	if(sameLcd(ctr, romFamily) || sameLcd(romFamily, ramFamily)
 		|| !sameLcd(ramFamily, afterRam))
 		return fail("ROM/RAM machine families were not exposed in the expected order");
 
-	// Return to ROM, select its current factory sample, assign it to track 1,
-	// and prove that the resulting machine reaches the audio output.
-	tap(hardware, md::PanelControl::Up);
-	tap(hardware, md::PanelControl::Right);
-	tap(hardware, md::PanelControl::Enter);
-	tap(hardware, md::PanelControl::Exit);
+	// The +Drive format deliberately clears its active sample bank. Use the
+	// no-+Drive board profile to retain the existing factory-ROM audio and RAM
+	// recording coverage after the format/reboot acceptance path above.
+	md::Hardware hardware(rom, argv[1], md::MachineModel::Machinedrum,
+		{}, {}, {}, initializedFlash, factoryCache, {}, {}, false);
+	advance(hardware, md::g_samplerate * 20);
+	assignUwMachine(hardware, 0, 0);
 	const auto trigger = md::panelPacket(md::MachineModel::Machinedrum,
 		md::PanelControl::Trigger1);
 	if(!trigger)

--- a/source/elektron/md/mdLibTest/turboMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/turboMidiTest.cpp
@@ -1,6 +1,7 @@
 #include "mdLib/mdfrontpanel.h"
 #include "mdLib/mdrealtimemidiqueue.h"
 #include "mdLib/mdhardware.h"
+#include "mdLib/mdplusdrive.h"
 #include "mdLib/mdsim.h"
 #include "mdLib/mdturbomidi.h"
 #include "mdLib/mdstate.h"
@@ -352,20 +353,71 @@ namespace
 		auto flashA = factoryBaseline;
 		flashA[3 * md::g_uwFlashSectorSize + 19] = 0x18;
 		flashA.back() = 0x00;
+		md::PlusDrive plusDriveA;
+		auto plusDriveImageA = plusDriveA.copyStorage();
+		// Add one sparse sector to the canonical MDPD image.
+		plusDriveImageA[15] = 1;
+		plusDriveImageA.insert(plusDriveImageA.end(), {0, 0, 0, 7});
+		plusDriveImageA.insert(plusDriveImageA.end(), 512, 0x5a);
+		if(!check(plusDriveA.replaceStorage(plusDriveImageA),
+			"test +Drive image is invalid"))
+			return false;
+
 		std::vector<uint8_t> encodedA;
 		if(!check(md::encodeState(encodedA, patchRam, flashA, factoryBaseline, rom,
-			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal,
+			plusDriveImageA),
 			"UW sparse state could not be encoded"))
 			return false;
 
 		constexpr size_t expectedChangedSectors = 2;
-		constexpr size_t stateHeaderSize = 52;
+		constexpr size_t stateHeaderSize = 60;
 		constexpr size_t sectorEntryHeaderSize = 8;
 		const auto expectedSize = stateHeaderSize + patchRam.size()
 			+ expectedChangedSectors
-				* (sectorEntryHeaderSize + md::g_uwFlashSectorSize);
+				* (sectorEntryHeaderSize + md::g_uwFlashSectorSize)
+			+ plusDriveImageA.size();
 		if(!check(encodedA.size() == expectedSize,
 			"UW sparse state did not contain exactly the changed sectors"))
+			return false;
+
+		// Exercise a meaningfully populated sparse drive without allocating the
+		// documented worst-case 128 sample banks in every CI run. Serialization is
+		// exactly 516 bytes per occupied 512-byte sector, so this 16K-sector fixture
+		// also verifies the size calculation used for larger project files.
+		constexpr uint32_t populatedSectorCount = 16u * 1024u;
+		std::vector<uint8_t> populatedDrive{
+			'M', 'D', 'P', 'D', 0, 0, 0, 1, 0, 0, 2, 0,
+			0, 0, static_cast<uint8_t>(populatedSectorCount >> 8), 0};
+		populatedDrive.reserve(16u + static_cast<size_t>(populatedSectorCount) * 516u);
+		for(uint32_t sector = 0; sector < populatedSectorCount; ++sector)
+		{
+			populatedDrive.push_back(static_cast<uint8_t>(sector >> 24));
+			populatedDrive.push_back(static_cast<uint8_t>(sector >> 16));
+			populatedDrive.push_back(static_cast<uint8_t>(sector >> 8));
+			populatedDrive.push_back(static_cast<uint8_t>(sector));
+			populatedDrive.insert(populatedDrive.end(), 512,
+				static_cast<uint8_t>(sector));
+		}
+		std::vector<uint8_t> populatedState;
+		md::DecodedState decodedPopulated;
+		const auto populatedExpectedSize = stateHeaderSize + patchRam.size()
+			+ expectedChangedSectors
+				* (sectorEntryHeaderSize + md::g_uwFlashSectorSize)
+			+ populatedDrive.size();
+		if(!check(md::PlusDrive::validateStorage(populatedDrive),
+			"populated +Drive fixture was invalid")
+			|| !check(md::encodeState(populatedState, patchRam, flashA,
+				factoryBaseline, rom, md::MachineModel::Machinedrum,
+				synthLib::StateTypeGlobal, populatedDrive),
+				"populated +Drive state could not be encoded")
+			|| !check(populatedState.size() == populatedExpectedSize,
+				"populated +Drive state size was not linear and exact")
+			|| !check(md::decodeState(decodedPopulated, populatedState, rom,
+				md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+				"populated +Drive state could not be decoded")
+			|| !check(decodedPopulated.plusDrive == populatedDrive,
+				"populated +Drive state changed its storage bytes"))
 			return false;
 
 		md::DecodedState decodedA;
@@ -374,7 +426,11 @@ namespace
 			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
 			"UW sparse state could not be decoded")
 			|| !check(decodedA.containsFlash, "UW state lost its flash marker")
+			|| !check(decodedA.containsPlusDrive,
+				"UW state lost its +Drive marker")
 			|| !check(decodedA.patchRam == patchRam, "UW state changed patch RAM")
+			|| !check(decodedA.plusDrive == plusDriveImageA,
+				"UW state changed +Drive data")
 			|| !check(md::applyFlashOverlay(restoredA, decodedA.flashOverlay,
 				factoryBaseline), "UW sparse state could not be applied")
 			|| !check(restoredA == flashA, "UW state changed flash data"))
@@ -383,11 +439,15 @@ namespace
 		// A second instance must reconstruct its own flash, not inherit A's sectors.
 		auto flashB = factoryBaseline;
 		flashB[7 * md::g_uwFlashSectorSize + 11] = 0x77;
+		auto plusDriveImageB = plusDriveImageA;
+		plusDriveImageB[19] = 9;
+		plusDriveImageB[20] = 0x27;
 		std::vector<uint8_t> encodedB;
 		md::DecodedState decodedB;
 		std::vector<uint8_t> restoredB;
 		if(!check(md::encodeState(encodedB, patchRam, flashB, factoryBaseline, rom,
-			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal,
+			plusDriveImageB),
 			"second UW state could not be encoded")
 			|| !check(md::decodeState(decodedB, encodedB, rom,
 				md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
@@ -395,7 +455,31 @@ namespace
 			|| !check(md::applyFlashOverlay(restoredB, decodedB.flashOverlay,
 				factoryBaseline), "second UW state could not be applied")
 			|| !check(restoredB == flashB && restoredB != restoredA,
-				"UW instances did not retain isolated flash images"))
+				"UW instances did not retain isolated flash images")
+			|| !check(decodedB.plusDrive == plusDriveImageB
+				&& decodedB.plusDrive != decodedA.plusDrive,
+				"UW instances did not retain isolated +Drive images"))
+			return false;
+
+		auto replacedDriveState = encodedA;
+		md::DecodedState decodedReplacement;
+		if(!check(md::replacePlusDriveState(replacedDriveState, plusDriveImageB),
+			"project +Drive payload could not be replaced")
+			|| !check(md::decodeState(decodedReplacement, replacedDriveState, rom,
+				md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+				"state with replaced +Drive could not be decoded")
+			|| !check(decodedReplacement.plusDrive == plusDriveImageB,
+				"state replacement did not install the requested +Drive")
+			|| !check(decodedReplacement.flashOverlay.data == decodedA.flashOverlay.data
+				&& decodedReplacement.patchRam == decodedA.patchRam,
+				"+Drive replacement changed machine or UW flash state"))
+			return false;
+		auto rejectedReplacement = replacedDriveState;
+		const std::vector<uint8_t> invalidDrive{1, 2, 3};
+		if(!check(!md::replacePlusDriveState(rejectedReplacement, invalidDrive),
+			"invalid +Drive replacement was accepted")
+			|| !check(rejectedReplacement == replacedDriveState,
+				"failed +Drive replacement modified project state"))
 			return false;
 
 		auto wrongRom = rom;
@@ -448,6 +532,31 @@ namespace
 			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
 			"UW state accepted corrupt flash data"))
 			return false;
+		auto truncated = encodedA;
+		truncated.pop_back();
+		if(!check(!md::decodeState(unchanged, truncated, rom,
+			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+			"UW state accepted truncated +Drive data"))
+			return false;
+
+		// Version 3 remains valid and intentionally has no project-owned +Drive.
+		std::vector<uint8_t> version3;
+		md::DecodedState decodedVersion3;
+		if(!check(md::encodeState(version3, patchRam, flashA, factoryBaseline, rom,
+			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+			"version-3 MD state could not be encoded")
+			|| !check(md::decodeState(decodedVersion3, version3, rom,
+				md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+				"version-3 MD state could not be decoded")
+			|| !check(!decodedVersion3.containsPlusDrive,
+				"version-3 MD state unexpectedly replaced +Drive"))
+			return false;
+		const auto originalVersion3 = version3;
+		if(!check(!md::replacePlusDriveState(version3, plusDriveImageA),
+			"version-3 MD state was ambiguously upgraded in place")
+			|| !check(version3 == originalVersion3,
+				"failed version-3 replacement modified the legacy state"))
+			return false;
 
 		// Version-1 states remain valid and intentionally inherit the live flash.
 		std::vector<uint8_t> legacy;
@@ -458,7 +567,8 @@ namespace
 			&& check(md::decodeState(decodedLegacy, legacy, rom,
 				md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
 				"legacy MD state could not be decoded")
-			&& check(!decodedLegacy.containsFlash && decodedLegacy.patchRam == patchRam,
+			&& check(!decodedLegacy.containsFlash && !decodedLegacy.containsPlusDrive
+				&& decodedLegacy.patchRam == patchRam,
 				"legacy MD state unexpectedly replaced flash");
 	}
 

--- a/source/elektron/md/mdLibTest/turboMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/turboMidiTest.cpp
@@ -372,6 +372,7 @@ namespace
 
 		constexpr size_t expectedChangedSectors = 2;
 		constexpr size_t stateHeaderSize = 60;
+		constexpr size_t stateHeaderSizeWithoutPlusDrive = 52;
 		constexpr size_t sectorEntryHeaderSize = 8;
 		const auto expectedSize = stateHeaderSize + patchRam.size()
 			+ expectedChangedSectors
@@ -512,7 +513,7 @@ namespace
 		if(!check(md::encodeState(firstRunState, patchRam, firstRunFlash, rom, rom,
 			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
 			"first-run UW fallback state could not be encoded")
-			|| !check(firstRunState.size() == stateHeaderSize + patchRam.size()
+			|| !check(firstRunState.size() == stateHeaderSizeWithoutPlusDrive + patchRam.size()
 				+ (md::g_romSize / md::g_uwFlashSectorSize)
 					* (sectorEntryHeaderSize + md::g_uwFlashSectorSize),
 				"first-run UW fallback did not contain a complete flash image")

--- a/source/framework/baseLib/filesystem.h
+++ b/source/framework/baseLib/filesystem.h
@@ -32,13 +32,12 @@ namespace baseLib
 		bool isDirectory(const std::string& _path);
 
 		bool writeFile(const std::string& _filename, const uint8_t* _data, size_t _size);
+		// Replace a file only after a complete sibling file has been flushed.
+		bool writeFileAtomic(const std::string& _filename, const uint8_t* _data,
+			size_t _size);
 		// Create without replacing an existing file. Intended for immutable caches
 		// where concurrent writers must never clobber the first complete result.
 		bool writeFileExclusive(const std::string& _filename, const uint8_t* _data,
-			size_t _size);
-		// Atomically replace the destination after a complete sibling file has been
-		// flushed. Readers see either the old complete file or the new one.
-		bool writeFileAtomic(const std::string& _filename, const uint8_t* _data,
 			size_t _size);
 
 		template<typename Alloc>

--- a/source/framework/juce/jucePluginLib/processor.h
+++ b/source/framework/juce/jucePluginLib/processor.h
@@ -145,7 +145,7 @@ namespace pluginLib
 
 		virtual void processBpm(float _bpm) {}
 
-		bool rebootDevice();
+		virtual bool rebootDevice();
 
 		auto& getMidiPorts() { return m_midiPorts; }
 


### PR DESCRIPTION
## Summary

- Emulate the Machinedrum +Drive as sparse, firmware-driven MMC storage.
- Keep DAW +Drive contents embedded in and isolated to each host project.
- Give the standalone application one fixed, private, atomically checkpointed +Drive with deterministic legacy filterState migration and single-writer ownership.
- Keep import/export as explicit boundaries; add blank-drive and storage-preserving reboot controls.
- Expose the +Drive controls and persistence status in the Machinedrum settings overlay.

## Validation

- Core DSP, MD state, +Drive, MIDI, flash, audio-layout, robustness, and automation soak tests pass.
- A real cross-process persistence test covers sole-writer exclusion, read-only ownership guidance, ownership after restart, debounce, forced termination before and after settlement, corrupt-file preservation, and explicit recovery.
- A real OS 1.63 JUCE processor test covers first-launch filterState migration, clean-quit flush, relaunch restore, and rejection of stale filterState rollback.
- Real OS 1.63 firmware formats a blank drive and exposes Snapshot and sample-bank selectors.
- Real ROM/RAM playback and recording coverage passes.
- MD and MM JUCE automation firmware integration passes.
- The current release branch was integrated locally; its multi-output audio layout and the +Drive lifecycle compile and pass together.
- The macOS standalone bundle builds and signs locally; macOS and Windows packaging scripts build and run the persistence regression test.
- The exact 512 MiB defensive MDPD boundary round-trips: 536,870,668 image bytes become 537,919,304 project-state bytes. The arm64 Release diagnostic encoded in 4.245 s, decoded/verified in 4.298 s, and peaked at about 1.53 GiB resident memory.

## Notes

This targets `release/md-mm-public-alpha-20260826` and builds on its merged UW ROM/RAM, flash, LCD, and multi-output audio work. No firmware or ROM images are included.

The 512 MiB limit is a defensive ceiling, not a recommended DAW working size. Normal sparse drives are much smaller, and host-specific state limits may be lower.
