### PR TITLE
Hotfix MD/MM settings, panel LEDs, and MD first-run reboot

### DIFF
--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -75,6 +75,15 @@ endif()
 target_compile_definitions(mmJucePlugin PRIVATE MD_JUCEPLUGIN_MONOMACHINE=1)
 
 if(BUILD_TESTING)
+	add_executable(mdSettingsTemplateTest mdSettingsTemplateTest.cpp)
+	target_include_directories(mdSettingsTemplateTest PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/../../../framework/juce)
+	target_compile_definitions(mdSettingsTemplateTest PRIVATE
+		MD_SETTINGS_TEMPLATE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+	set_property(TARGET mdSettingsTemplateTest PROPERTY FOLDER "Elektron/test")
+	add_test(NAME mdSettingsTemplateTest COMMAND mdSettingsTemplateTest)
+	set_tests_properties(mdSettingsTemplateTest PROPERTIES LABELS "UnitTest")
+
 	add_executable(mdAudioIoLayoutTest mdAudioIoLayoutTest.cpp)
 	target_link_libraries(mdAudioIoLayoutTest PRIVATE
 		mdJucePlugin jucePluginEditorLib mdLib juce_plugin_modules

--- a/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
@@ -5,6 +5,7 @@
 #include "baseLib/filesystem.h"
 
 #include <chrono>
+#include <cstdlib>
 #include <iostream>
 #include <string>
 #include <thread>
@@ -177,6 +178,8 @@ namespace
 	{
 		bool audioReady = false;
 		bool factoryFlashReady = false;
+		bool factoryFlashReadyForReboot = false;
+		bool factoryFlashCaptureDisqualified = false;
 		bool initializationExpected = false;
 		bool automaticRebootReady = false;
 		size_t plusDriveSectors = 0;
@@ -195,6 +198,10 @@ namespace
 					auto& hardware = device->getHardware();
 					status.audioReady = hardware.isAudioReady();
 					status.factoryFlashReady = hardware.factoryFlashCacheReady();
+					status.factoryFlashReadyForReboot =
+						hardware.isFactoryFlashReadyForReboot();
+					status.factoryFlashCaptureDisqualified =
+						hardware.isFactoryFlashCaptureDisqualified();
 					status.initializationExpected =
 						hardware.isFactoryFlashInitializationExpected();
 					status.automaticRebootReady =
@@ -295,12 +302,29 @@ namespace
 		if(_model == md::MachineModel::Machinedrum)
 		{
 			const auto initialBoot = mdBootStatus(harness);
+			const bool testFirstRunInteraction =
+				std::getenv("GEARMULATOR_MD_TEST_FIRST_RUN_INTERACTION") != nullptr;
 			if(initialBoot.initializationExpected)
 			{
 				juce::String earlyRebootResult;
 				require(!harness.processor.rebootMachinedrum(earlyRebootResult)
 					&& earlyRebootResult.containsIgnoreCase("still being prepared"),
 					"manual reboot bypassed first-run cache preparation");
+				if(testFirstRunInteraction)
+				{
+					require(harness.processor.getPlugin().withDeviceLocked(
+						[](synthLib::Device* const _device)
+						{
+							auto* const device = dynamic_cast<md::Device*>(_device);
+							if(!device)
+								return false;
+							auto& hardware = device->getHardware();
+							return hardware.trySendPanelEvent(0x20, 0x01)
+								&& hardware.sendMidi(synthLib::SMidiEvent(
+									synthLib::MidiEventSource::Host,
+									0x90, 60, 100));
+						}), "could not inject first-run panel and host MIDI interaction");
+				}
 			}
 			// A blank +Drive is formatted during the first 1.63 boot. The original
 			// automation request predates that work, and the firmware asks for a
@@ -320,16 +344,18 @@ namespace
 				else
 					stableIntervals = 0;
 				previousBoot = firstBoot;
-				if(firstBoot.audioReady && firstBoot.factoryFlashReady
+				if(firstBoot.audioReady && firstBoot.factoryFlashReadyForReboot
 					&& firstBoot.automaticRebootReady
 					&& stableIntervals >= 2)
 					break;
 			}
 			std::cerr << "MD first boot: audio " << firstBoot.audioReady
 				<< ", factory flash " << firstBoot.factoryFlashReady
+				<< ", reboot-ready " << firstBoot.factoryFlashReadyForReboot
+				<< ", disqualified " << firstBoot.factoryFlashCaptureDisqualified
 				<< ", +Drive sectors " << firstBoot.plusDriveSectors
 				<< ", commands " << firstBoot.plusDriveCommands << '\n';
-			require(firstBoot.audioReady && firstBoot.factoryFlashReady
+			require(firstBoot.audioReady && firstBoot.factoryFlashReadyForReboot
 				&& firstBoot.automaticRebootReady
 				&& stableIntervals >= 2,
 				"Machinedrum did not finish formatting its blank +Drive");
@@ -348,8 +374,18 @@ namespace
 				require(harness.processor.rebootDevice(),
 					"post-format Machinedrum reboot failed");
 			}
-			require(mdBootStatus(harness).factoryFlashReady,
-				"Machinedrum reboot discarded its validated in-memory UW factory cache");
+			const auto rebooted = mdBootStatus(harness);
+			if(testFirstRunInteraction && initialBoot.initializationExpected)
+			{
+				require(firstBoot.factoryFlashCaptureDisqualified
+					&& !firstBoot.factoryFlashReady,
+					"first-run interaction unexpectedly published a global factory cache");
+				require(!rebooted.initializationExpected,
+					"project-preserving recovery reboot requested another initialization");
+			}
+			else
+				require(rebooted.factoryFlashReady,
+					"Machinedrum reboot discarded its validated in-memory UW factory cache");
 			// Audio-ready goes true before the main CPU has finished the +Drive boot
 			// path. Match the 20-second firmware acceptance test before sending SysEx.
 			harness.process(9000);

--- a/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
@@ -177,8 +177,11 @@ namespace
 	{
 		bool audioReady = false;
 		bool factoryFlashReady = false;
+		bool initializationExpected = false;
+		bool automaticRebootReady = false;
 		size_t plusDriveSectors = 0;
 		uint64_t plusDriveCommands = 0;
+		uint64_t hardwareEpoch = 0;
 	};
 
 	MdBootStatus mdBootStatus(Harness& _harness)
@@ -192,10 +195,15 @@ namespace
 					auto& hardware = device->getHardware();
 					status.audioReady = hardware.isAudioReady();
 					status.factoryFlashReady = hardware.factoryFlashCacheReady();
+					status.initializationExpected =
+						hardware.isFactoryFlashInitializationExpected();
+					status.automaticRebootReady =
+						hardware.isPlusDriveReadyForFactoryReboot();
 					status.plusDriveSectors = hardware.getUC().getSim()
 						.getPlusDrive().storedSectorCount();
 					status.plusDriveCommands = hardware.getUC().getSim()
 						.getPlusDrive().commandCount();
+					status.hardwareEpoch = device->hardwareEpoch();
 				}
 			});
 		return status;
@@ -286,6 +294,14 @@ namespace
 		auto& controller = harness.controller;
 		if(_model == md::MachineModel::Machinedrum)
 		{
+			const auto initialBoot = mdBootStatus(harness);
+			if(initialBoot.initializationExpected)
+			{
+				juce::String earlyRebootResult;
+				require(!harness.processor.rebootMachinedrum(earlyRebootResult)
+					&& earlyRebootResult.containsIgnoreCase("still being prepared"),
+					"manual reboot bypassed first-run cache preparation");
+			}
 			// A blank +Drive is formatted during the first 1.63 boot. The original
 			// automation request predates that work, and the firmware asks for a
 			// reboot afterward. Preserve the newly formatted project drive across that
@@ -305,6 +321,7 @@ namespace
 					stableIntervals = 0;
 				previousBoot = firstBoot;
 				if(firstBoot.audioReady && firstBoot.factoryFlashReady
+					&& firstBoot.automaticRebootReady
 					&& stableIntervals >= 2)
 					break;
 			}
@@ -313,10 +330,24 @@ namespace
 				<< ", +Drive sectors " << firstBoot.plusDriveSectors
 				<< ", commands " << firstBoot.plusDriveCommands << '\n';
 			require(firstBoot.audioReady && firstBoot.factoryFlashReady
+				&& firstBoot.automaticRebootReady
 				&& stableIntervals >= 2,
 				"Machinedrum did not finish formatting its blank +Drive");
-			require(harness.processor.rebootDevice(),
-				"post-format Machinedrum reboot failed");
+			if(initialBoot.initializationExpected)
+			{
+				require(harness.processor.serviceFactoryInitialization(),
+					"automatic post-format Machinedrum reboot failed");
+				require(!harness.processor.serviceFactoryInitialization(),
+					"automatic post-format reboot was not one-shot");
+				require(mdBootStatus(harness).hardwareEpoch
+					== initialBoot.hardwareEpoch + 1,
+					"automatic post-format reboot did not replace the Hardware once");
+			}
+			else
+			{
+				require(harness.processor.rebootDevice(),
+					"post-format Machinedrum reboot failed");
+			}
 			require(mdBootStatus(harness).factoryFlashReady,
 				"Machinedrum reboot discarded its validated in-memory UW factory cache");
 			// Audio-ready goes true before the main CPU has finished the +Drive boot

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -93,7 +93,6 @@ namespace mdJucePlugin
 		constexpr int g_presentationTimerId = 1;
 		constexpr int g_panelTimerId = 2;
 		constexpr double g_sysexStatusIntervalMilliseconds = 100.0;
-		constexpr size_t g_ledTransitionBatchSize = 256;
 
 		constexpr PanelButton g_panelButtons[] =
 		{
@@ -172,23 +171,27 @@ namespace mdJucePlugin
 		const auto ledPresentationBeforeDrain = m_ledPresentation;
 		const bool ledsChangedBeforeDrain = m_ledsChanged;
 
-		std::array<md::FrontPanelLedTransition, g_ledTransitionBatchSize> transitions;
-		const auto drainTransitions = [&](const uint64_t _afterSequence = 0)
+		const auto drainTransitions = [&](const uint64_t _snapshotEmulationCycles,
+			const uint64_t _afterSequence = 0)
 		{
-			// The queue is bounded, so a full pre-existing backlog takes at most
-			// eight batches. Newly arriving writes can wait for the next frame.
-			constexpr size_t maxBatches =
-				(md::FrontPanelPublisher::g_ledTransitionCapacity
-					+ g_ledTransitionBatchSize - 1) / g_ledTransitionBatchSize;
-			for(size_t batch = 0; batch < maxBatches; ++batch)
+			// Take one bounded queue snapshot. A racing transition can be newer than
+			// the last published panel, so use the newest retained edge as the clock
+			// anchor for the whole batch instead of collapsing that tail onto now.
+			const auto count = device->drainFrontPanelLedTransitions(
+				m_ledTransitionBuffer.data(), m_ledTransitionBuffer.size());
+			auto anchorCycles = _snapshotEmulationCycles;
+			for(size_t i = 0; i < count; ++i)
+				if(m_ledTransitionBuffer[i].sequence > _afterSequence)
+					anchorCycles = std::max(anchorCycles,
+						m_ledTransitionBuffer[i].emulationCycles);
+			for(size_t i = 0; i < count; ++i)
 			{
-				const auto count = device->drainFrontPanelLedTransitions(
-					transitions.data(), transitions.size());
-				for(size_t i = 0; i < count; ++i)
-					if(transitions[i].sequence > _afterSequence)
-						m_ledPresentation.apply(transitions[i], _nowMilliseconds);
-				if(count < transitions.size())
-					break;
+				const auto& transition = m_ledTransitionBuffer[i];
+				if(transition.sequence <= _afterSequence)
+					continue;
+				const auto eventTime = FrontPanelLedPresentation::eventMilliseconds(
+					_nowMilliseconds, anchorCycles, transition.emulationCycles);
+				m_ledPresentation.apply(transition, eventTime);
 			}
 		};
 
@@ -219,7 +222,7 @@ namespace mdJucePlugin
 			m_ledResyncPending = false;
 			// Discard transitions already represented by the coherent snapshot and
 			// retain only writes that raced publication.
-			drainTransitions(published.ledSequence);
+			drainTransitions(published.emulationCycles, published.ledSequence);
 		}
 		else if(m_ledResyncPending)
 		{
@@ -231,7 +234,7 @@ namespace mdJucePlugin
 		}
 		else
 		{
-			drainTransitions();
+			drainTransitions(published.emulationCycles);
 		}
 
 		auto finalStatus = device->getFrontPanelLedTransitionStatus();

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -1554,7 +1554,6 @@ namespace mdJucePlugin
 			{ "stSynth",   md::FrontPanel::StatusLed::Synthesis },
 			{ "stFx",      md::FrontPanel::StatusLed::Effects   },
 			{ "stRoute",   md::FrontPanel::StatusLed::Routing   },
-			{ "ledTempo",  md::FrontPanel::StatusLed::Tempo     },
 		};
 		static_assert(std::size(status) == std::tuple_size_v<decltype(m_statusLeds)>);
 
@@ -1568,11 +1567,22 @@ namespace mdJucePlugin
 			{ "ledBankAD",   md::FrontPanel::ModeLed::BankGroupAD },
 			{ "ledBankEH",   md::FrontPanel::ModeLed::BankGroupEH },
 			{ "ledRecord",   md::FrontPanel::ModeLed::Record      },
+			{ "ledTempo",    md::FrontPanel::ModeLed::Tempo       },
 		};
 		static_assert(std::size(mode) == std::tuple_size_v<decltype(m_mdModeLeds)>);
 
 		for(size_t i=0; i<m_mdModeLeds.size(); ++i)
 			m_mdModeLeds[i] = { findChild(mode[i].first, false), static_cast<uint8_t>(mode[i].second) };
+
+		const RawLedElem pages[] =
+		{
+			{ findChild("mdPatternPage0", false), 0x22, 0 },
+			{ findChild("mdPatternPage1", false), 0x22, 1 },
+			{ findChild("mdPatternPage2", false), 0x22, 2 },
+			{ findChild("mdPatternPage3", false), 0x23, 6 },
+		};
+		static_assert(std::size(pages) == std::tuple_size_v<decltype(m_mdPageLeds)>);
+		std::copy(std::begin(pages), std::end(pages), m_mdPageLeds.begin());
 	}
 
 	void Editor::updateLeds()
@@ -1646,6 +1656,12 @@ namespace mdJucePlugin
 		{
 			if(m.elem)
 				m.elem->SetClass("lit", lit(0x23, m.bit));
+		}
+
+		for(const auto& page : m_mdPageLeds)
+		{
+			if(page.elem)
+				page.elem->SetClass("lit", lit(page.bank, page.bit));
 		}
 		m_ledsChanged = false;
 	}

--- a/source/elektron/md/mdJucePlugin/mdEditor.h
+++ b/source/elektron/md/mdJucePlugin/mdEditor.h
@@ -159,6 +159,8 @@ namespace mdJucePlugin
 		bool m_lcdChanged = true;
 		bool m_lcdColorsInverted = false;
 		FrontPanelLedPresentation m_ledPresentation;
+		std::array<md::FrontPanelLedTransition,
+			md::FrontPanelPublisher::g_ledTransitionCapacity> m_ledTransitionBuffer{};
 		bool m_ledsChanged = true;
 		md::FrontPanelLedTransitionStatus m_ledTransitionStatus;
 		bool m_ledTransitionStatusValid = false;

--- a/source/elektron/md/mdJucePlugin/mdEditor.h
+++ b/source/elektron/md/mdJucePlugin/mdEditor.h
@@ -217,8 +217,8 @@ namespace mdJucePlugin
 			Rml::Element* elem;
 			uint8_t bit;	// md::FrontPanel::StatusLed
 		};
-		std::array<StatusLedElem, 6> m_statusLeds{};
-		std::array<StatusLedElem, 5> m_mdModeLeds{};
+		std::array<StatusLedElem, 5> m_statusLeds{};
+		std::array<StatusLedElem, 6> m_mdModeLeds{};
 
 		struct RawLedElem
 		{
@@ -226,6 +226,7 @@ namespace mdJucePlugin
 			uint8_t bank = 0;
 			uint8_t bit = 0;
 		};
+		std::array<RawLedElem, 4> m_mdPageLeds{};
 		std::array<RawLedElem, 20> m_mmPanelLeds{};
 		std::unique_ptr<juce::FileChooser> m_storageFileChooser;
 		StorageImageFlow m_storageImageFlow = StorageImageFlow::None;

--- a/source/elektron/md/mdJucePlugin/mdFrontPanelPresentation.h
+++ b/source/elektron/md/mdJucePlugin/mdFrontPanelPresentation.h
@@ -17,6 +17,18 @@ namespace mdJucePlugin
 	public:
 		static constexpr double g_minimumVisibleMilliseconds = 1000.0 / 30.0;
 
+		static double eventMilliseconds(const double _nowMilliseconds,
+			const uint64_t _snapshotEmulationCycles,
+			const uint64_t _eventEmulationCycles)
+		{
+			if(_eventEmulationCycles >= _snapshotEmulationCycles)
+				return _nowMilliseconds;
+			const auto ageCycles = _snapshotEmulationCycles - _eventEmulationCycles;
+			return _nowMilliseconds
+				- static_cast<double>(ageCycles) * 1000.0
+					/ static_cast<double>(md::g_frontPanelEmulationClockHz);
+		}
+
 		void reset(const md::FrontPanel& _panel)
 		{
 			for(uint8_t command = md::FrontPanel::g_firstLedBank;

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
@@ -357,7 +357,7 @@ namespace mdJucePlugin
 					return false;
 				const auto& hardware = device->getHardware();
 				if(hardware.isFactoryFlashInitializationExpected()
-					&& (!hardware.isFactoryFlashCacheReady()
+					&& (!hardware.isFactoryFlashReadyForReboot()
 						|| !hardware.isPlusDriveReadyForFactoryReboot()))
 				{
 					initializationPending = true;
@@ -511,7 +511,7 @@ namespace mdJucePlugin
 					return false;
 				const auto& hardware = device->getHardware();
 				if(hardware.isFactoryFlashInitializationExpected()
-					&& (!hardware.isFactoryFlashCacheReady()
+					&& (!hardware.isFactoryFlashReadyForReboot()
 						|| !hardware.isPlusDriveReadyForFactoryReboot()))
 				{
 					initializationPending = true;
@@ -579,12 +579,13 @@ namespace mdJucePlugin
 
 	bool AudioPluginAudioProcessor::serviceFactoryInitialization()
 	{
-		if(m_model != md::MachineModel::Machinedrum
-			|| m_factoryInitializationMonitorDone)
+		if(m_model != md::MachineModel::Machinedrum)
 			return false;
 
 		enum class State { Waiting, Ready, NotNeeded };
 		auto state = State::NotNeeded;
+		bool factoryCacheReady = false;
+		bool factoryCacheDisqualified = false;
 		getPlugin().withDeviceLocked([&](synthLib::Device* const _device)
 		{
 			auto* const device = dynamic_cast<md::Device*>(_device);
@@ -594,28 +595,47 @@ namespace mdJucePlugin
 			const auto& hardware = device->getHardware();
 			if(!hardware.isFactoryFlashInitializationExpected())
 				return;
-			state = hardware.isFactoryFlashCacheReady()
+			factoryCacheReady = hardware.isFactoryFlashCacheReady();
+			factoryCacheDisqualified =
+				hardware.isFactoryFlashCaptureDisqualified();
+			state = hardware.isFactoryFlashReadyForReboot()
 				&& hardware.isPlusDriveReadyForFactoryReboot()
 				? State::Ready : State::Waiting;
 		});
 
 		if(state == State::NotNeeded)
 		{
-			m_factoryInitializationMonitorDone = true;
-			stopTimer();
+			// Host state restore can replace the Hardware after construction. Keep a
+			// cheap monitor armed so a later cold image still receives its one-time
+			// in-process reboot.
+			startTimer(1000);
 			return false;
 		}
 		if(state != State::Ready)
+		{
+			startTimer(250);
 			return false;
+		}
 
 		std::string cacheError;
-		const bool cachePersisted = getPlugin().withDeviceLocked(
-			[&](synthLib::Device* const _device)
-			{
-				auto* const device = dynamic_cast<md::Device*>(_device);
-				return device && device->getModel() == md::MachineModel::Machinedrum
-					&& device->persistFactoryFlashCache(cacheError);
-			});
+		bool cachePersisted = false;
+		if(factoryCacheReady)
+		{
+			std::string cacheFilename;
+			std::vector<uint8_t> cache;
+			const bool cacheCaptured = getPlugin().withDeviceLocked(
+				[&](synthLib::Device* const _device)
+				{
+					auto* const device = dynamic_cast<md::Device*>(_device);
+					return device
+						&& device->getModel() == md::MachineModel::Machinedrum
+						&& device->captureFactoryFlashCachePersistence(
+							cacheFilename, cache, cacheError);
+				});
+			cachePersisted = cacheCaptured
+				&& md::Device::writeFactoryFlashCachePersistence(
+					cacheFilename, cache, cacheError);
+		}
 
 		juce::String result;
 		if(!rebootMachinedrum(result))
@@ -628,12 +648,16 @@ namespace mdJucePlugin
 			return false;
 		}
 
-		m_factoryInitializationMonitorDone = true;
-		m_factoryInitializationStatus = cachePersisted
-			? "Factory samples initialized; Machinedrum rebooted automatically"
-			: "Machinedrum rebooted automatically, but "
-				+ juce::String(cacheError);
-		stopTimer();
+		if(cachePersisted)
+			m_factoryInitializationStatus =
+				"Factory samples initialized; Machinedrum rebooted automatically";
+		else if(factoryCacheDisqualified)
+			m_factoryInitializationStatus =
+				"Machinedrum rebooted automatically; the project state was preserved";
+		else
+			m_factoryInitializationStatus =
+				"Machinedrum rebooted automatically, but " + juce::String(cacheError);
+		startTimer(1000);
 		updateHostDisplay(juce::AudioProcessorListener::ChangeDetails()
 			.withNonParameterStateChanged(true));
 		std::fprintf(stderr, "[MD] factory initialization complete; rebooted in process\n");

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
@@ -18,6 +18,7 @@
 
 #include "baseLib/binarystream.h"
 
+#include <cstdio>
 #include <utility>
 
 namespace
@@ -347,12 +348,21 @@ namespace mdJucePlugin
 		std::vector<uint8_t> originalState;
 		std::vector<uint8_t> factoryFlashCache;
 		std::shared_ptr<const md::Device::PreparationContext> preparationContext;
+		bool initializationPending = false;
 		const bool captured = getPlugin().withDeviceLocked(
 			[&](synthLib::Device* const _device)
 			{
 				auto* const device = dynamic_cast<md::Device*>(_device);
 				if(!device || device->getModel() != md::MachineModel::Machinedrum)
 					return false;
+				const auto& hardware = device->getHardware();
+				if(hardware.isFactoryFlashInitializationExpected()
+					&& (!hardware.isFactoryFlashCacheReady()
+						|| !hardware.isPlusDriveReadyForFactoryReboot()))
+				{
+					initializationPending = true;
+					return false;
+				}
 				liveDevice = device;
 				liveEpoch = device->hardwareEpoch();
 				preparationContext = device->getPreparationContext();
@@ -361,7 +371,9 @@ namespace mdJucePlugin
 			});
 		if(!captured || !preparationContext)
 		{
-			_result = "The local Machinedrum state could not be captured";
+			_result = initializationPending
+				? "Wait for first-run preparation and automatic reboot before replacing the +Drive"
+				: "The local Machinedrum state could not be captured";
 			return false;
 		}
 
@@ -490,12 +502,21 @@ namespace mdJucePlugin
 		std::vector<uint8_t> originalState;
 		std::vector<uint8_t> factoryFlashCache;
 		std::shared_ptr<const md::Device::PreparationContext> preparationContext;
+		bool initializationPending = false;
 		const bool captured = getPlugin().withDeviceLocked(
 			[&](synthLib::Device* const _device)
 			{
 				auto* const device = dynamic_cast<md::Device*>(_device);
 				if(!device || device->getModel() != md::MachineModel::Machinedrum)
 					return false;
+				const auto& hardware = device->getHardware();
+				if(hardware.isFactoryFlashInitializationExpected()
+					&& (!hardware.isFactoryFlashCacheReady()
+						|| !hardware.isPlusDriveReadyForFactoryReboot()))
+				{
+					initializationPending = true;
+					return false;
+				}
 				liveDevice = device;
 				liveEpoch = device->hardwareEpoch();
 				preparationContext = device->getPreparationContext();
@@ -504,7 +525,9 @@ namespace mdJucePlugin
 			});
 		if(!captured || !preparationContext)
 		{
-			_result = "The project-owned Machinedrum state could not be captured";
+			_result = initializationPending
+				? "Factory samples or +Drive are still being prepared. Keep host audio processing active and wait for the automatic reboot"
+				: "The project-owned Machinedrum state could not be captured";
 			return false;
 		}
 		auto prepared = md::Device::prepareState(preparationContext, originalState,
@@ -554,8 +577,78 @@ namespace mdJucePlugin
 		return rebootMachinedrum(result);
 	}
 
+	bool AudioPluginAudioProcessor::serviceFactoryInitialization()
+	{
+		if(m_model != md::MachineModel::Machinedrum
+			|| m_factoryInitializationMonitorDone)
+			return false;
+
+		enum class State { Waiting, Ready, NotNeeded };
+		auto state = State::NotNeeded;
+		getPlugin().withDeviceLocked([&](synthLib::Device* const _device)
+		{
+			auto* const device = dynamic_cast<md::Device*>(_device);
+			if(!device || device->getModel() != md::MachineModel::Machinedrum
+				|| !device->isValid())
+				return;
+			const auto& hardware = device->getHardware();
+			if(!hardware.isFactoryFlashInitializationExpected())
+				return;
+			state = hardware.isFactoryFlashCacheReady()
+				&& hardware.isPlusDriveReadyForFactoryReboot()
+				? State::Ready : State::Waiting;
+		});
+
+		if(state == State::NotNeeded)
+		{
+			m_factoryInitializationMonitorDone = true;
+			stopTimer();
+			return false;
+		}
+		if(state != State::Ready)
+			return false;
+
+		std::string cacheError;
+		const bool cachePersisted = getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				return device && device->getModel() == md::MachineModel::Machinedrum
+					&& device->persistFactoryFlashCache(cacheError);
+			});
+
+		juce::String result;
+		if(!rebootMachinedrum(result))
+		{
+			m_factoryInitializationStatus =
+				"Factory samples are ready, but automatic reboot is waiting: " + result;
+			// A state-save or storage operation can briefly win the transaction.
+			// Avoid rebuilding a replacement four times per second while it does.
+			startTimer(2000);
+			return false;
+		}
+
+		m_factoryInitializationMonitorDone = true;
+		m_factoryInitializationStatus = cachePersisted
+			? "Factory samples initialized; Machinedrum rebooted automatically"
+			: "Machinedrum rebooted automatically, but "
+				+ juce::String(cacheError);
+		stopTimer();
+		updateHostDisplay(juce::AudioProcessorListener::ChangeDetails()
+			.withNonParameterStateChanged(true));
+		std::fprintf(stderr, "[MD] factory initialization complete; rebooted in process\n");
+		return true;
+	}
+
+	void AudioPluginAudioProcessor::timerCallback()
+	{
+		(void)serviceFactoryInitialization();
+	}
+
 	juce::String AudioPluginAudioProcessor::getPlusDrivePersistenceStatus() const
 	{
+		if(m_factoryInitializationStatus.isNotEmpty())
+			return m_factoryInitializationStatus;
 		return m_standalonePlusDrive
 			? m_standalonePlusDrive->status()
 			: "Project-owned +Drive; saved with the host project";
@@ -688,6 +781,8 @@ namespace mdJucePlugin
 		const auto latencyBlocks = getConfig().getIntValue("latencyBlocks", static_cast<int>(getPlugin().getLatencyBlocks()));
 		Processor::setLatencyBlocks(latencyBlocks);
 		initializeStandalonePlusDrivePersistence();
+		if(m_model == md::MachineModel::Machinedrum)
+			startTimer(250);
 	}
 
 	juce::AudioProcessor::BusesProperties AudioPluginAudioProcessor::createBusesProperties()
@@ -711,6 +806,7 @@ namespace mdJucePlugin
 
 	AudioPluginAudioProcessor::~AudioPluginAudioProcessor()
 	{
+		stopTimer();
 		destroyEditorState();
 		if(m_standalonePlusDrive)
 			m_standalonePlusDrive->stop();

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
@@ -12,7 +12,8 @@ namespace mdJucePlugin
 {
 	class StandalonePlusDrivePersistence;
 
-	class AudioPluginAudioProcessor : public jucePluginEditorLib::Processor
+	class AudioPluginAudioProcessor : public jucePluginEditorLib::Processor,
+		private juce::Timer
 	{
 	public:
 		struct EphemeralConfig final
@@ -42,6 +43,7 @@ namespace mdJucePlugin
 		bool resetPlusDrive(juce::String& _result);
 		bool rebootMachinedrum(juce::String& _result);
 		bool rebootDevice() override;
+		bool serviceFactoryInitialization();
 		juce::String getPlusDrivePersistenceStatus() const;
 
 	    jucePluginEditorLib::PluginEditorState* createEditorState() override;
@@ -68,11 +70,14 @@ namespace mdJucePlugin
 			uint64_t& _epoch, uint64_t& _generation, bool& _dirty,
 			std::vector<uint8_t>& _data);
 		void acknowledgePlusDrivePersistence(uint64_t _epoch, uint64_t _generation);
+		void timerCallback() override;
 
 		const md::MachineModel m_model;
 		const std::vector<uint8_t> m_initialPatchRam;
 		const juce::File m_standalonePlusDriveFile;
 		std::mutex m_storageLoadMutex;
+		bool m_factoryInitializationMonitorDone = false;
+		juce::String m_factoryInitializationStatus;
 		std::unique_ptr<StandalonePlusDrivePersistence> m_standalonePlusDrive;
 		JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioPluginAudioProcessor)
 	};

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
@@ -76,7 +76,6 @@ namespace mdJucePlugin
 		const std::vector<uint8_t> m_initialPatchRam;
 		const juce::File m_standalonePlusDriveFile;
 		std::mutex m_storageLoadMutex;
-		bool m_factoryInitializationMonitorDone = false;
 		juce::String m_factoryInitializationStatus;
 		std::unique_ptr<StandalonePlusDrivePersistence> m_standalonePlusDrive;
 		JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioPluginAudioProcessor)

--- a/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
@@ -79,6 +79,16 @@ int main()
 			"sysexTransferStatus", "btLoadInstalledFactoryStorage",
 			"btEncoderSpeed100"});
 
+	const auto mdSkin = readFile(std::string(MD_SETTINGS_TEMPLATE_DIR)
+		+ "/skins/mdDefault/mdDefault.rml");
+	ok &= require(!mdSkin.empty(), "could not read the Machinedrum skin");
+	for(const auto* const id : {"mdPatternPage0", "mdPatternPage1",
+		"mdPatternPage2", "mdPatternPage3", "ledTempo"})
+	{
+		ok &= require(mdSkin.find("id=\"" + std::string(id) + "\"")
+			!= std::string::npos, "Machinedrum skin is missing LED " + std::string(id));
+	}
+
 	if(!ok)
 		return 1;
 	std::cout << "MD/MM device-specific settings templates: PASS\n";

--- a/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
@@ -1,0 +1,85 @@
+#include "jucePluginEditorLib/settingsDeviceSpecific.h"
+
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+namespace
+{
+	bool require(const bool _condition, const std::string& _message)
+	{
+		if(_condition)
+			return true;
+		std::cerr << "FAIL: " << _message << '\n';
+		return false;
+	}
+
+	std::string readFile(const std::string& _path)
+	{
+		std::ifstream stream(_path, std::ios::binary);
+		return {std::istreambuf_iterator<char>(stream),
+			std::istreambuf_iterator<char>()};
+	}
+
+	bool testProduct(const std::string& _productName,
+		const std::string& _deviceIdentity,
+		const std::string& _filename,
+		const std::vector<std::string>& _requiredIds)
+	{
+		const auto templateNames =
+			jucePluginEditorLib::makeDeviceSpecificSettingsTemplateNames(
+				"tus_settings_gui", _productName, _deviceIdentity);
+		const auto source = readFile(
+			std::string(MD_SETTINGS_TEMPLATE_DIR) + '/' + _filename);
+		std::string selectedTemplate;
+		for(const auto& candidate : templateNames)
+		{
+			if(!candidate.empty()
+				&& source.find("<template name=\"" + candidate + "\">")
+					!= std::string::npos)
+			{
+				selectedTemplate = candidate;
+				break;
+			}
+		}
+
+		bool ok = true;
+		ok &= require(!source.empty(), "could not read " + _filename);
+		ok &= require(selectedTemplate == "tus_settings_gui_" + _deviceIdentity,
+			_productName + " did not resolve its device-specific settings template");
+		for(const auto& id : _requiredIds)
+		{
+			ok &= require(source.find("id=\"" + id + "\"") != std::string::npos,
+				_filename + " is missing control " + id);
+		}
+		return ok;
+	}
+}
+
+int main()
+{
+	bool ok = true;
+	const auto fallbackNames =
+		jucePluginEditorLib::makeDeviceSpecificSettingsTemplateNames(
+			"tus_settings_gui", "Example Product", {});
+	ok &= require(fallbackNames[0] == "tus_settings_gui_Example Product"
+			&& fallbackNames[1].empty(),
+		"products without a data identity must retain display-name lookup");
+
+	ok &= testProduct("Gearmulator MD", "Machinedrum",
+		"tus_settings_gui_Machinedrum.rml",
+		{"btInvertLcdColors", "btSendSysexFile", "sysexDropTarget",
+			"sysexTransferStatus", "btImportPlusDrive", "btEncoderSpeed100"});
+	ok &= testProduct("Gearmulator MM", "Monomachine",
+		"tus_settings_gui_Monomachine.rml",
+		{"btInvertLcdColors", "btSendSysexFile", "sysexDropTarget",
+			"sysexTransferStatus", "btLoadInstalledFactoryStorage",
+			"btEncoderSpeed100"});
+
+	if(!ok)
+		return 1;
+	std::cout << "MD/MM device-specific settings templates: PASS\n";
+	return 0;
+}

--- a/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
@@ -71,7 +71,8 @@ int main()
 	ok &= testProduct("Gearmulator MD", "Machinedrum",
 		"tus_settings_gui_Machinedrum.rml",
 		{"btInvertLcdColors", "btSendSysexFile", "sysexDropTarget",
-			"sysexTransferStatus", "btImportPlusDrive", "btEncoderSpeed100"});
+			"sysexTransferStatus", "btImportPlusDrive", "btExportPlusDrive",
+			"btRebootMachinedrum", "btResetPlusDrive", "btEncoderSpeed100"});
 	ok &= testProduct("Gearmulator MM", "Monomachine",
 		"tus_settings_gui_Monomachine.rml",
 		{"btInvertLcdColors", "btSendSysexFile", "sysexDropTarget",

--- a/source/elektron/md/mdJucePlugin/mdShiftTriggerLatchTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdShiftTriggerLatchTest.cpp
@@ -8,6 +8,12 @@
 
 namespace
 {
+	static_assert(static_cast<uint8_t>(md::FrontPanel::StatusLed::Page1) == 0);
+	static_assert(static_cast<uint8_t>(md::FrontPanel::StatusLed::Page2) == 1);
+	static_assert(static_cast<uint8_t>(md::FrontPanel::StatusLed::Page3) == 2);
+	static_assert(static_cast<uint8_t>(md::FrontPanel::ModeLed::Tempo) == 5);
+	static_assert(static_cast<uint8_t>(md::FrontPanel::ModeLed::Page4) == 6);
+
 	using mdJucePlugin::panelAffordances::ShiftPanelLatch;
 	using PressAction = ShiftPanelLatch::PressAction;
 
@@ -162,22 +168,22 @@ namespace
 		md::FrontPanel panel;
 		mdJucePlugin::FrontPanelLedPresentation presentation;
 		presentation.reset(panel);
-		expect(!presentation.isLit(0x22, 1), "tempo LED baseline is not off");
+		expect(!presentation.isLit(0x23, 5), "tempo LED baseline is not off");
 
 		constexpr double now = 1000.0;
-		presentation.apply({1, 100, 0x22, 0xfd}, now);
-		presentation.apply({2, 120, 0x22, 0xff}, now);
+		presentation.apply({1, 100, 0x23, 0xdf}, now);
+		presentation.apply({2, 120, 0x23, 0xff}, now);
 		presentation.advance(now);
-		expect(presentation.isLit(0x22, 1),
+		expect(presentation.isLit(0x23, 5),
 			"pulse collapsed inside one UI frame");
 		presentation.advance(now
 			+ mdJucePlugin::FrontPanelLedPresentation::g_minimumVisibleMilliseconds
 			- 0.01);
-		expect(presentation.isLit(0x22, 1),
+		expect(presentation.isLit(0x23, 5),
 			"short pulse expired before one slow-renderer frame");
 		presentation.advance(now
 			+ mdJucePlugin::FrontPanelLedPresentation::g_minimumVisibleMilliseconds);
-		expect(!presentation.isLit(0x22, 1),
+		expect(!presentation.isLit(0x23, 5),
 			"short pulse did not return to firmware state");
 
 		presentation.apply({3, 200, 0x26, 0x7f}, now + 100.0);
@@ -198,12 +204,12 @@ namespace
 			mdJucePlugin::FrontPanelLedPresentation::eventMilliseconds(
 				now + 2000.0, 2000 * cyclesPerMillisecond,
 				110 * cyclesPerMillisecond);
-		presentation.apply({4, 100 * cyclesPerMillisecond, 0x22, 0xfd},
+		presentation.apply({4, 100 * cyclesPerMillisecond, 0x23, 0xdf},
 			oldPulseStart);
-		presentation.apply({5, 110 * cyclesPerMillisecond, 0x22, 0xff},
+		presentation.apply({5, 110 * cyclesPerMillisecond, 0x23, 0xff},
 			oldPulseEnd);
 		presentation.advance(now + 2000.0);
-		expect(!presentation.isLit(0x22, 1),
+		expect(!presentation.isLit(0x23, 5),
 			"stale pulse was restamped as a new UI-frame flash");
 
 		const auto recentPulseStart =
@@ -214,15 +220,15 @@ namespace
 			mdJucePlugin::FrontPanelLedPresentation::eventMilliseconds(
 				now + 3000.0, 3000 * cyclesPerMillisecond,
 				2995 * cyclesPerMillisecond);
-		presentation.apply({6, 2990 * cyclesPerMillisecond, 0x22, 0xfd},
+		presentation.apply({6, 2990 * cyclesPerMillisecond, 0x23, 0xdf},
 			recentPulseStart);
-		presentation.apply({7, 2995 * cyclesPerMillisecond, 0x22, 0xff},
+		presentation.apply({7, 2995 * cyclesPerMillisecond, 0x23, 0xff},
 			recentPulseEnd);
 		presentation.advance(now + 3000.0);
-		expect(presentation.isLit(0x22, 1),
+		expect(presentation.isLit(0x23, 5),
 			"recent sub-frame pulse was not held for its remaining visibility time");
 		presentation.advance(now + 3024.0);
-		expect(!presentation.isLit(0x22, 1),
+		expect(!presentation.isLit(0x23, 5),
 			"recent sub-frame pulse outlived its timestamped visibility window");
 
 		const auto futureEvent =

--- a/source/elektron/md/mdJucePlugin/mdShiftTriggerLatchTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdShiftTriggerLatchTest.cpp
@@ -187,6 +187,50 @@ namespace
 		presentation.advance(now + 1000.0);
 		expect(presentation.isLit(0x26, 7),
 			"steady LED was treated as a finite pulse");
+
+		constexpr uint64_t cyclesPerMillisecond =
+			md::g_frontPanelEmulationClockHz / 1000;
+		const auto oldPulseStart =
+			mdJucePlugin::FrontPanelLedPresentation::eventMilliseconds(
+				now + 2000.0, 2000 * cyclesPerMillisecond,
+				100 * cyclesPerMillisecond);
+		const auto oldPulseEnd =
+			mdJucePlugin::FrontPanelLedPresentation::eventMilliseconds(
+				now + 2000.0, 2000 * cyclesPerMillisecond,
+				110 * cyclesPerMillisecond);
+		presentation.apply({4, 100 * cyclesPerMillisecond, 0x22, 0xfd},
+			oldPulseStart);
+		presentation.apply({5, 110 * cyclesPerMillisecond, 0x22, 0xff},
+			oldPulseEnd);
+		presentation.advance(now + 2000.0);
+		expect(!presentation.isLit(0x22, 1),
+			"stale pulse was restamped as a new UI-frame flash");
+
+		const auto recentPulseStart =
+			mdJucePlugin::FrontPanelLedPresentation::eventMilliseconds(
+				now + 3000.0, 3000 * cyclesPerMillisecond,
+				2990 * cyclesPerMillisecond);
+		const auto recentPulseEnd =
+			mdJucePlugin::FrontPanelLedPresentation::eventMilliseconds(
+				now + 3000.0, 3000 * cyclesPerMillisecond,
+				2995 * cyclesPerMillisecond);
+		presentation.apply({6, 2990 * cyclesPerMillisecond, 0x22, 0xfd},
+			recentPulseStart);
+		presentation.apply({7, 2995 * cyclesPerMillisecond, 0x22, 0xff},
+			recentPulseEnd);
+		presentation.advance(now + 3000.0);
+		expect(presentation.isLit(0x22, 1),
+			"recent sub-frame pulse was not held for its remaining visibility time");
+		presentation.advance(now + 3024.0);
+		expect(!presentation.isLit(0x22, 1),
+			"recent sub-frame pulse outlived its timestamped visibility window");
+
+		const auto futureEvent =
+			mdJucePlugin::FrontPanelLedPresentation::eventMilliseconds(
+				now + 3000.0, 2000 * cyclesPerMillisecond,
+				2001 * cyclesPerMillisecond);
+		expect(futureEvent == now + 3000.0,
+			"transition newer than the snapshot was not clamped to the UI frame");
 	}
 
 	void checkIndependentTimerCadence()

--- a/source/elektron/md/mdJucePlugin/skins/mdDefault/mdDefault.rml
+++ b/source/elektron/md/mdJucePlugin/skins/mdDefault/mdDefault.rml
@@ -434,19 +434,19 @@
 			</div>
 			<div class="elektronScalePages">
 				<div class="elektronScaleCell">
-					<div class="elektronLed elektronScaleDot mdScaleDot"/>
+					<div id="mdPatternPage0" class="elektronLed elektronScaleDot mdScaleDot"/>
 					<div class="juceLabel elektronScalePageLabel">1:4</div>
 				</div>
 				<div class="elektronScaleCell">
-					<div class="elektronLed elektronScaleDot mdScaleDot"/>
+					<div id="mdPatternPage1" class="elektronLed elektronScaleDot mdScaleDot"/>
 					<div class="juceLabel elektronScalePageLabel">2:4</div>
 				</div>
 				<div class="elektronScaleCell">
-					<div class="elektronLed elektronScaleDot mdScaleDot"/>
+					<div id="mdPatternPage2" class="elektronLed elektronScaleDot mdScaleDot"/>
 					<div class="juceLabel elektronScalePageLabel">3:4</div>
 				</div>
 				<div class="elektronScaleCell">
-					<div class="elektronLed elektronScaleDot mdScaleDot"/>
+					<div id="mdPatternPage3" class="elektronLed elektronScaleDot mdScaleDot"/>
 					<div class="juceLabel elektronScalePageLabel">4:4</div>
 				</div>
 			</div>

--- a/source/elektron/md/mdJucePlugin/tus_settings_gui_Machinedrum.rml
+++ b/source/elektron/md/mdJucePlugin/tus_settings_gui_Machinedrum.rml
@@ -70,6 +70,8 @@
 	<settingsspacer1/>
 	<label id="plusDriveStatus" class="settings-sysex-status">PROJECT-OWNED +DRIVE</label>
 	<settingsspacer1/>
+	<label>After first-run sample or +Drive preparation, the emulation saves the validated data and reboots itself in process. If it remains on PLEASE REBOOT, keep host audio processing active for a few seconds; the button below is a recovery control.</label>
+	<settingsspacer1/>
 	<button id="btRebootMachinedrum" class="button">Reboot Machinedrum</button>
 	<button id="btResetPlusDrive" class="button">Create Blank +Drive...</button>
 	<settingsspacer1/>

--- a/source/elektron/md/mdLib/mddevice.cpp
+++ b/source/elektron/md/mdLib/mddevice.cpp
@@ -175,9 +175,27 @@ namespace md
 
 	Device::~Device()
 	{
-		if(m_mdFlashCacheFilename.empty() || !m_hardware
+		if(m_model != MachineModel::Machinedrum || !m_hardware
 			|| !m_hardware->factoryFlashCacheReady())
 			return;
+		std::string error;
+		if(!persistFactoryFlashCache(error) && !error.empty())
+			std::fprintf(stderr, "[MD] %s\n", error.c_str());
+	}
+
+	bool Device::persistFactoryFlashCache(std::string& _error)
+	{
+		_error.clear();
+		if(m_mdFlashCacheFilename.empty() || !m_hardware)
+		{
+			_error = "factory cache has no writable destination";
+			return false;
+		}
+		if(!m_hardware->factoryFlashCacheReady())
+		{
+			_error = "factory cache is not ready";
+			return false;
+		}
 
 		// Project activity can never update a valid cache. Invalid or ROM-mismatched
 		// data is replaced atomically so one damaged cache cannot poison every boot.
@@ -186,19 +204,27 @@ namespace md
 		const bool exists = baseLib::filesystem::readFile(existing, m_mdFlashCacheFilename);
 		if(exists && decodeFactoryFlashCache(decoded, existing,
 			m_hardware->flashBaseline()))
-			return;
+			return true;
 
 		auto cache = m_hardware->copyFactoryFlashCache();
 		if(cache.empty())
-			return;
+		{
+			_error = "validated factory cache could not be encoded";
+			return false;
+		}
 		baseLib::filesystem::createDirectory(
 			baseLib::filesystem::getPath(m_mdFlashCacheFilename));
 		const bool written = exists
 			? baseLib::filesystem::writeFileAtomic(m_mdFlashCacheFilename, cache)
 			: baseLib::filesystem::writeFileExclusive(m_mdFlashCacheFilename, cache);
 		if(written)
+		{
 			std::fprintf(stderr, "[MD] stored UW factory cache: %s\n",
 				m_mdFlashCacheFilename.c_str());
+			return true;
+		}
+		_error = "could not store UW factory cache at " + m_mdFlashCacheFilename;
+		return false;
 	}
 
 	float Device::getSamplerate() const

--- a/source/elektron/md/mdLib/mddevice.cpp
+++ b/source/elektron/md/mdLib/mddevice.cpp
@@ -185,7 +185,18 @@ namespace md
 
 	bool Device::persistFactoryFlashCache(std::string& _error)
 	{
+		std::string filename;
+		std::vector<uint8_t> cache;
+		return captureFactoryFlashCachePersistence(filename, cache, _error)
+			&& writeFactoryFlashCachePersistence(filename, cache, _error);
+	}
+
+	bool Device::captureFactoryFlashCachePersistence(std::string& _filename,
+		std::vector<uint8_t>& _cache, std::string& _error)
+	{
 		_error.clear();
+		_filename.clear();
+		_cache.clear();
 		if(m_mdFlashCacheFilename.empty() || !m_hardware)
 		{
 			_error = "factory cache has no writable destination";
@@ -197,33 +208,49 @@ namespace md
 			return false;
 		}
 
-		// Project activity can never update a valid cache. Invalid or ROM-mismatched
-		// data is replaced atomically so one damaged cache cannot poison every boot.
-		std::vector<uint8_t> existing;
-		std::vector<uint8_t> decoded;
-		const bool exists = baseLib::filesystem::readFile(existing, m_mdFlashCacheFilename);
-		if(exists && decodeFactoryFlashCache(decoded, existing,
-			m_hardware->flashBaseline()))
-			return true;
-
-		auto cache = m_hardware->copyFactoryFlashCache();
-		if(cache.empty())
+		_cache = m_hardware->copyFactoryFlashCache();
+		if(_cache.empty())
 		{
 			_error = "validated factory cache could not be encoded";
 			return false;
 		}
-		baseLib::filesystem::createDirectory(
-			baseLib::filesystem::getPath(m_mdFlashCacheFilename));
+		_filename = m_mdFlashCacheFilename;
+		return true;
+	}
+
+	bool Device::writeFactoryFlashCachePersistence(const std::string& _filename,
+		const std::vector<uint8_t>& _cache, std::string& _error)
+	{
+		_error.clear();
+		if(_filename.empty() || _cache.empty())
+		{
+			_error = "factory cache persistence data is incomplete";
+			return false;
+		}
+
+		// Filesystem work stays outside the plugin device lock. Identical bytes are
+		// already authoritative; damaged or ROM-mismatched bytes are replaced by the
+		// freshly validated cache captured from the live Hardware.
+		std::vector<uint8_t> existing;
+		const bool exists = baseLib::filesystem::readFile(existing, _filename);
+		if(exists && existing == _cache)
+			return true;
+		baseLib::filesystem::createDirectory(baseLib::filesystem::getPath(_filename));
 		const bool written = exists
-			? baseLib::filesystem::writeFileAtomic(m_mdFlashCacheFilename, cache)
-			: baseLib::filesystem::writeFileExclusive(m_mdFlashCacheFilename, cache);
+			? baseLib::filesystem::writeFileAtomic(_filename, _cache)
+			: baseLib::filesystem::writeFileExclusive(_filename, _cache);
 		if(written)
 		{
 			std::fprintf(stderr, "[MD] stored UW factory cache: %s\n",
-				m_mdFlashCacheFilename.c_str());
+				_filename.c_str());
 			return true;
 		}
-		_error = "could not store UW factory cache at " + m_mdFlashCacheFilename;
+		// Another instance may have won an exclusive create between our read and
+		// write. Treat the race as success only when it published the same cache.
+		existing.clear();
+		if(baseLib::filesystem::readFile(existing, _filename) && existing == _cache)
+			return true;
+		_error = "could not store UW factory cache at " + _filename;
 		return false;
 	}
 

--- a/source/elektron/md/mdLib/mddevice.h
+++ b/source/elektron/md/mdLib/mddevice.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "mdhardware.h"
@@ -101,6 +102,7 @@ namespace md
 		// retired Hardware in _prepared so its destruction can happen after the
 		// caller releases any process/control lock.
 		bool commitPreparedState(PreparedState& _prepared);
+		bool persistFactoryFlashCache(std::string& _error);
 		uint32_t getChannelCountIn() override;
 		uint32_t getChannelCountOut() override;
 		uint32_t getInternalLatencyInputToOutput() const override

--- a/source/elektron/md/mdLib/mddevice.h
+++ b/source/elektron/md/mdLib/mddevice.h
@@ -102,6 +102,10 @@ namespace md
 		// retired Hardware in _prepared so its destruction can happen after the
 		// caller releases any process/control lock.
 		bool commitPreparedState(PreparedState& _prepared);
+		bool captureFactoryFlashCachePersistence(std::string& _filename,
+			std::vector<uint8_t>& _cache, std::string& _error);
+		static bool writeFactoryFlashCachePersistence(const std::string& _filename,
+			const std::vector<uint8_t>& _cache, std::string& _error);
 		bool persistFactoryFlashCache(std::string& _error);
 		uint32_t getChannelCountIn() override;
 		uint32_t getChannelCountOut() override;

--- a/source/elektron/md/mdLib/mdfrontpanel.cpp
+++ b/source/elektron/md/mdLib/mdfrontpanel.cpp
@@ -211,12 +211,14 @@ namespace md
 		return ((raw >> static_cast<uint8_t>(_led)) & 1) == 0;
 	}
 
-	bool FrontPanelPublisher::tryPublish(const FrontPanel& _panel)
+	bool FrontPanelPublisher::tryPublish(const FrontPanel& _panel,
+		const uint64_t _emulationCycles)
 	{
 		std::unique_lock lock(m_mutex, std::try_to_lock);
 		if(!lock.owns_lock())
 			return false;
 		m_snapshot = _panel;
+		m_snapshotEmulationCycles = _emulationCycles;
 		m_publishedLedSequence.store(
 			m_ledTransitionSequence.load(std::memory_order_acquire),
 			std::memory_order_release);
@@ -245,6 +247,7 @@ namespace md
 		{
 			m_snapshot,
 			m_publishedLedSequence.load(std::memory_order_relaxed),
+			m_snapshotEmulationCycles,
 		};
 	}
 
@@ -301,6 +304,7 @@ namespace md
 	{
 		const std::lock_guard lock(m_mutex);
 		m_snapshot.reset();
+		m_snapshotEmulationCycles = 0;
 		m_ledTransitionRead.store(
 			m_ledTransitionWrite.load(std::memory_order_acquire),
 			std::memory_order_release);

--- a/source/elektron/md/mdLib/mdfrontpanel.h
+++ b/source/elektron/md/mdLib/mdfrontpanel.h
@@ -64,9 +64,9 @@ namespace md
 		// Bit positions inside the 0x22 status bank (active-low, 0 = lit).
 		enum class StatusLed : uint8_t
 		{
-			Clear     = 0, // lit by CLEAR
-			Tempo     = 1, // flashes with the clock
-			// bit 2 is unused
+			Page1     = 0,
+			Page2     = 1,
+			Page3     = 2,
 			Pattern   = 3,
 			Song      = 4,
 			Routing   = 5,
@@ -82,8 +82,9 @@ namespace md
 			BankGroupAD = 2,
 			BankGroupEH = 3,
 			Record      = 4, // grid-edit
-			GridBlink   = 5, // grid-edit blinker
-			// bits 6/7 are unused
+			Tempo       = 5,
+			Page4       = 6,
+			// bit 7 is unused
 		};
 
 		FrontPanel();

--- a/source/elektron/md/mdLib/mdfrontpanel.h
+++ b/source/elektron/md/mdLib/mdfrontpanel.h
@@ -10,6 +10,9 @@
 
 namespace md
 {
+	// Front-panel transition timestamps use the ColdFire system clock.
+	inline constexpr uint64_t g_frontPanelEmulationClockHz = 40'000'000;
+
 	// FrontPanel decodes the Elektron Machinedrum/Monomachine host->panel UART
 	// byte stream and reconstructs the two things the panel controller drives:
 	//
@@ -167,6 +170,7 @@ namespace md
 	{
 		FrontPanel panel;
 		uint64_t ledSequence = 0;
+		uint64_t emulationCycles = 0;
 	};
 
 	struct FrontPanelLedTransitionStatus
@@ -188,7 +192,7 @@ namespace md
 	public:
 		static constexpr size_t g_ledTransitionCapacity = 2048;
 
-		bool tryPublish(const FrontPanel& _panel);
+		bool tryPublish(const FrontPanel& _panel, uint64_t _emulationCycles);
 		bool tryRead(FrontPanel& _panel) const;
 		FrontPanel read() const;
 		FrontPanelPublishedState readPublishedState() const;
@@ -208,5 +212,6 @@ namespace md
 		std::atomic<uint64_t> m_ledTransitionDropped{0};
 		std::atomic<uint64_t> m_ledTransitionEpoch{0};
 		std::atomic<uint64_t> m_publishedLedSequence{0};
+		uint64_t m_snapshotEmulationCycles = 0;
 	};
 }

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -26,7 +26,7 @@ namespace md
 	// ColdFire MCF5206E system clock. The MAME driver clocks the CPU from a 25.447 MHz
 	// crystal (elektronmono.cpp); used to convert mixer-DSP execution -> UC cycle budget. The
 	// MD Sim doesn't model a PLL yet, so this is the fixed nominal rate.
-	constexpr uint64_t g_ucClockHz = 40'000'000;
+	constexpr uint64_t g_ucClockHz = g_frontPanelEmulationClockHz;
 
 	// One codec (ESSI1) stereo frame corresponds to a fixed number of DSP1-executed cycles. The
 	// firmware configures a 96-cycle base link slot; the ESSI1 divider and two stereo slots produce
@@ -115,6 +115,12 @@ namespace md
 		: m_model(_model)
 		, m_rom(initRom(_romData, _romName, _model, _syntheticProfile))
 		, m_firmwareFingerprint(_syntheticProfile ? 0 : fingerprintRom(m_rom.data()))
+		// A cold UW flash or a blank project-owned +Drive can make the firmware ask
+		// for the same one-time power cycle. A restored project has both images.
+		, m_factoryFlashInitializationExpected(!_syntheticProfile
+			&& _model == MachineModel::Machinedrum
+			&& ((_factoryFlashCache.empty() && _initialUserFlash.empty())
+				|| _initialPlusDrive.empty()))
 		, m_uc(m_rom, m_model, initPatchRam(m_rom,
 			_pendingFlashOverlay.valid ? std::vector<uint8_t>{} : _initialPatchRam),
 			initMainRam(m_rom), _initialUserFlash, _initialPlusDrive, _plusDriveEnabled)
@@ -665,6 +671,7 @@ namespace md
 
 		if(!m_pendingFlashOverlay.valid)
 		{
+			m_factoryFlashCapturedThisBoot.store(true, std::memory_order_release);
 			m_factoryFlashReady.store(true, std::memory_order_release);
 			return;
 		}
@@ -704,7 +711,27 @@ namespace md
 		m_pendingFlashOverlay.valid = false;
 		m_pendingFlashRestoreActive.store(false, std::memory_order_release);
 		m_externalInteraction.store(true, std::memory_order_relaxed);
+		m_factoryFlashCapturedThisBoot.store(true, std::memory_order_release);
 		m_factoryFlashReady.store(true, std::memory_order_release);
+	}
+
+	void Hardware::advanceFactoryRebootReadiness()
+	{
+		if(!m_factoryFlashInitializationExpected
+			|| m_plusDriveReadyForFactoryReboot.load(std::memory_order_relaxed))
+			return;
+		const auto commands = m_uc.getSim().getPlusDrive().commandCount();
+		const auto cycles = m_uc.getCycles();
+		if(commands != m_factoryRebootObservedPlusDriveCommands)
+		{
+			m_factoryRebootObservedPlusDriveCommands = commands;
+			m_factoryRebootLastPlusDriveCommandCycles = cycles;
+			return;
+		}
+		constexpr auto quietCycles = g_ucClockHz * 2;
+		if(m_uc.getSim().getPlusDrive().storedSectorCount() != 0
+			&& cycles - m_factoryRebootLastPlusDriveCommandCycles >= quietCycles)
+			m_plusDriveReadyForFactoryReboot.store(true, std::memory_order_release);
 	}
 
 	bool Hardware::factoryFlashCacheReady()
@@ -1278,10 +1305,11 @@ namespace md
 		}
 
 		schedDrainCodecOutput();					// final drain (also covers a UC-only advance window)
+		advanceFactoryRebootReadiness();
 		advanceFactoryFlashCapture();
 		// Never make the emulation/audio thread wait for a UI snapshot read. If the
 		// reader owns the short copy lock, the next machine interval republishes.
-		m_frontPanelPublisher->tryPublish(m_frontPanel);
+		m_frontPanelPublisher->tryPublish(m_frontPanel, m_uc.getCycles());
 	}
 
 	bool Hardware::sendMidi(const synthLib::SMidiEvent& _ev)

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -130,6 +130,8 @@ namespace md
 			&& !_initialUserFlash.empty() && _factoryFlashCache.empty()
 			&& !_pendingFlashOverlay.valid)
 		, m_factoryFlashReady(!_factoryFlashCache.empty())
+		, m_factoryFlashPreparationReady(!_factoryFlashCache.empty()
+			|| !_initialUserFlash.empty())
 		, m_factoryFlashCache(_factoryFlashCache)
 		, m_factoryFlashBaseline(_model == MachineModel::Machinedrum
 			&& _factoryFlashCache.empty() ? g_romSize : 0)
@@ -617,17 +619,28 @@ namespace md
 	{
 		if(m_model != MachineModel::Machinedrum
 			|| m_factoryFlashReady.load(std::memory_order_acquire)
-			|| m_pendingFlashRestoreFailed.load(std::memory_order_acquire)
-			|| m_externalInteraction.load(std::memory_order_relaxed))
+			|| m_pendingFlashRestoreFailed.load(std::memory_order_acquire))
+			return;
+
+		constexpr uint64_t minimumAge = g_ucClockHz * 10;
+		constexpr uint64_t quietPeriod = g_ucClockHz * 2;
+		const bool preparationReady = m_uc.flashDirty()
+			&& m_uc.getCycles() >= minimumAge
+			&& m_uc.flashIdleCycles() >= quietPeriod;
+		if(preparationReady)
+			m_factoryFlashPreparationReady.store(true, std::memory_order_release);
+
+		// Panel or host MIDI traffic makes this boot unsuitable as a reusable,
+		// machine-local factory baseline. It must not, however, strand the firmware
+		// at PLEASE REBOOT: once the flash has gone quiet, the complete project image
+		// remains safe to reboot in process without publishing a global cache.
+		if(m_externalInteraction.load(std::memory_order_acquire))
 			return;
 
 		constexpr size_t sliceSize = g_uwFlashSectorSize;
 		if(!m_factoryFlashCaptureComplete)
 		{
-			constexpr uint64_t minimumAge = g_ucClockHz * 10;
-			constexpr uint64_t quietPeriod = g_ucClockHz * 2;
-			if(!m_uc.flashDirty() || m_uc.getCycles() < minimumAge
-				|| m_uc.flashIdleCycles() < quietPeriod)
+			if(!preparationReady)
 			{
 				m_factoryFlashCaptureOffset = 0;
 				m_factoryFlashCaptureFingerprint = 14695981039346656037ull;

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -117,6 +117,18 @@ namespace md
 		{
 			return m_factoryFlashReady.load(std::memory_order_acquire);
 		}
+		bool isFactoryFlashInitializationExpected() const
+		{
+			return m_factoryFlashInitializationExpected;
+		}
+		bool wasFactoryFlashCapturedThisBoot() const
+		{
+			return m_factoryFlashCapturedThisBoot.load(std::memory_order_acquire);
+		}
+		bool isPlusDriveReadyForFactoryReboot() const
+		{
+			return m_plusDriveReadyForFactoryReboot.load(std::memory_order_acquire);
+		}
 		bool isProjectStateRestorePending() const
 		{
 			return m_pendingFlashRestoreActive.load(std::memory_order_acquire);
@@ -223,6 +235,7 @@ namespace md
 			bool _plusDriveEnabled);
 		void ensureBufferSize(uint32_t _frames);
 		void advanceFactoryFlashCapture();
+		void advanceFactoryRebootReadiness();
 		void registerExternalInteraction();
 		void setHostAudioInputLatency(uint32_t _latency);
 		void queueHostAudioInput(uint32_t _frames);
@@ -235,11 +248,16 @@ namespace md
 		const MachineModel m_model;
 		Rom m_rom;
 		const uint64_t m_firmwareFingerprint;
+		const bool m_factoryFlashInitializationExpected;
 		uint64_t m_firmwareUpdateMainFingerprint = 0;
 		size_t m_firmwareUpdateMainSize = 0;
 		Microcontroller m_uc;
 		std::atomic<bool> m_externalInteraction{false};
 		std::atomic<bool> m_factoryFlashReady{false};
+		std::atomic<bool> m_factoryFlashCapturedThisBoot{false};
+		std::atomic<bool> m_plusDriveReadyForFactoryReboot{false};
+		uint64_t m_factoryRebootObservedPlusDriveCommands = 0;
+		uint64_t m_factoryRebootLastPlusDriveCommandCycles = 0;
 		mutable std::mutex m_factoryFlashMutex;
 		std::vector<uint8_t> m_factoryFlashCache;
 		std::vector<uint8_t> m_factoryFlashBaseline;

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -121,6 +121,17 @@ namespace md
 		{
 			return m_factoryFlashInitializationExpected;
 		}
+		bool isFactoryFlashReadyForReboot() const
+		{
+			return m_factoryFlashReady.load(std::memory_order_acquire)
+				|| (m_externalInteraction.load(std::memory_order_acquire)
+					&& m_factoryFlashPreparationReady.load(std::memory_order_acquire));
+		}
+		bool isFactoryFlashCaptureDisqualified() const
+		{
+			return m_externalInteraction.load(std::memory_order_acquire)
+				&& !m_factoryFlashReady.load(std::memory_order_acquire);
+		}
 		bool wasFactoryFlashCapturedThisBoot() const
 		{
 			return m_factoryFlashCapturedThisBoot.load(std::memory_order_acquire);
@@ -254,6 +265,7 @@ namespace md
 		Microcontroller m_uc;
 		std::atomic<bool> m_externalInteraction{false};
 		std::atomic<bool> m_factoryFlashReady{false};
+		std::atomic<bool> m_factoryFlashPreparationReady{false};
 		std::atomic<bool> m_factoryFlashCapturedThisBoot{false};
 		std::atomic<bool> m_plusDriveReadyForFactoryReboot{false};
 		uint64_t m_factoryRebootObservedPlusDriveCommands = 0;

--- a/source/elektron/md/mdLibTest/turboMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/turboMidiTest.cpp
@@ -371,14 +371,16 @@ namespace
 		if(!check(beforePublish.producedSequence == 2
 				&& beforePublish.publishedSequence == 0,
 			"LED snapshot sequence advanced before publication")
-			|| !check(publisher.tryPublish(panel),
+			|| !check(publisher.tryPublish(panel, 456),
 				"front-panel snapshot publication failed"))
 			return false;
 		const auto published = publisher.readPublishedState();
 		if(!check(published.ledSequence == beforePublish.producedSequence
 				&& publisher.getLedTransitionStatus().publishedSequence
 					== published.ledSequence,
-			"front-panel snapshot did not capture its LED sequence"))
+			"front-panel snapshot did not capture its LED sequence")
+			|| !check(published.emulationCycles == 456,
+				"front-panel snapshot did not capture its emulation time"))
 			return false;
 
 		std::array<md::FrontPanelLedTransition, 4> output;
@@ -405,7 +407,7 @@ namespace
 		if(!check(publisher.readPublishedState().ledSequence
 				< overflowStatus.producedSequence,
 			"stale snapshot unexpectedly covered a dropped transition")
-			|| !check(publisher.tryPublish(panel),
+			|| !check(publisher.tryPublish(panel, 10000),
 				"post-overflow front-panel snapshot publication failed")
 			|| !check(publisher.readPublishedState().ledSequence
 				== overflowStatus.producedSequence,

--- a/source/framework/juce/jucePluginEditorLib/settingsCategory.cpp
+++ b/source/framework/juce/jucePluginEditorLib/settingsCategory.cpp
@@ -26,12 +26,16 @@ namespace jucePluginEditorLib
 		// add device specific settings if available
 		if (auto* containerDeviceSpecific = juceRmlUi::helper::findChild(m_page, "containerDeviceSpecific", false))
 		{
-			const auto templateName = _plugin->getTemplateName() + '_' + _settings.getEditor().getProcessor().getProperties().name;
-
-			if (juceRmlUi::helper::hasTemplate(templateName, containerDeviceSpecific))
+			const auto& properties = _settings.getEditor().getProcessor().getProperties();
+			for(const auto& templateName : makeDeviceSpecificSettingsTemplateNames(
+				_plugin->getTemplateName(), properties.name, properties.dataFolderName))
 			{
+				if(templateName.empty()
+					|| !juceRmlUi::helper::hasTemplate(templateName, containerDeviceSpecific))
+					continue;
 				auto* instance = juceRmlUi::helper::createTemplate(templateName, containerDeviceSpecific);
 				m_settingsDeviceSpecific = _settings.getEditor().createDeviceSpecificSettings(templateName, instance);
+				break;
 			}
 		}
 

--- a/source/framework/juce/jucePluginEditorLib/settingsDeviceSpecific.h
+++ b/source/framework/juce/jucePluginEditorLib/settingsDeviceSpecific.h
@@ -1,7 +1,22 @@
 #pragma once
 
+#include <array>
+#include <string>
+
 namespace jucePluginEditorLib
 {
+	inline std::array<std::string, 2> makeDeviceSpecificSettingsTemplateNames(
+		const std::string& _baseTemplateName,
+		const std::string& _productName,
+		const std::string& _dataFolderName)
+	{
+		const auto productTemplate = _baseTemplateName + '_' + _productName;
+		const auto deviceTemplate = _dataFolderName.empty()
+			|| _dataFolderName == _productName
+			? std::string{} : _baseTemplateName + '_' + _dataFolderName;
+		return {productTemplate, deviceTemplate};
+	}
+
 	class SettingsDeviceSpecific
 	{
 	public:


### PR DESCRIPTION
## Summary

- restore the device-specific MD/MM settings panels hidden in alpha.7
- preserve real emulation-cycle timing for front-panel LED edges so slow host rendering does not turn stale transitions into fresh flashes
- correct the Machinedrum tempo LED firmware binding and wire all four pattern-page LEDs
- automatically preserve validated Machinedrum UW data and reboot the emulation in process after first-run sample/+Drive preparation
- recover safely when panel or host MIDI activity disqualifies that boot from becoming the reusable global factory cache
- keep the first-run monitor active across later DAW state replacement and move cache filesystem work outside the device lock

## Restored UI

- LCD inversion
- SysEx file picker, drop target, and transfer status
- panel encoder/click speed controls
- Machinedrum +Drive import/export/status/reboot controls
- Monomachine installed factory storage controls

## Verification

- `mdSettingsTemplateTest`: PASS for both products, all hidden controls, and MD page/tempo skin elements
- `mdShiftTriggerLatchTest`: PASS, including verified MD tempo/page bit constants and stale/recent LED timing
- `mdLibTest`: PASS, including published emulation-cycle timestamps
- MD and MM shared plugin targets compile locally
- clean real MD 1.63 first run: PASS; prepared 4103 +Drive sectors, wrote the validated 36-byte factory cache, rebooted exactly once, and completed the second-boot storage/automation lifecycle
- interrupted first run with both panel and host MIDI input: PASS; rebooted exactly once, preserved project state, and correctly published no global cache
- exact final signed VST3 SHA-256 `119f9c20c4b8b418fa8ea2bef5a8e21a238e581b5f501bc209e1135d77d4a793`: fresh message-loop auto-reboot PASS and strictness-5 GUI pluginval SUCCESS

## Review notes

- An already-saved alpha.7 project containing a complete prepared image may still need the now-visible Reboot recovery button once; new/default first runs reboot automatically.
- Factory-cache encoding remains a one-time operation under the device lock during the otherwise unusable initialization screen; filesystem reads and writes are outside the lock.

## Context

Alpha.7 looked up embedded device templates by the display names `Gearmulator MD` / `Gearmulator MM`, while the resources use stable Machinedrum/Monomachine identities. It also exposed the real-hardware power-cycle step in a DAW and replayed queued LED edges at UI callback time.