### PR TITLE
Recover MD/MM alpha.8 runtime and UI regressions

### DIFF
--- a/.github/workflows/mdmm-core.yml
+++ b/.github/workflows/mdmm-core.yml
@@ -11,7 +11,7 @@ on:
       - "source/3rdparty/libresample/**"
       - "source/elektron/md/**"
       - "source/framework/hardwareLib/**"
-      - "source/framework/juce/jucePluginLib/**"
+      - "source/framework/juce/**"
       - "source/framework/synthLib/**"
       - "source/cpu/mc68k"
       - "source/cpu/dsp56300"
@@ -22,7 +22,7 @@ on:
       - "source/3rdparty/libresample/**"
       - "source/elektron/md/**"
       - "source/framework/hardwareLib/**"
-      - "source/framework/juce/jucePluginLib/**"
+      - "source/framework/juce/**"
       - "source/framework/synthLib/**"
       - "source/cpu/mc68k"
       - "source/cpu/dsp56300"
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install Linux plugin dependencies
         if: runner.os == 'Linux'
-        run: sudo apt update && sudo apt install -y libgl1-mesa-dev xorg-dev libasound2-dev
+        run: sudo apt update && sudo apt install -y libgl1-mesa-dev xorg-dev libasound2-dev xvfb
 
       - name: Configure portable tests
         run: >-
@@ -78,7 +78,7 @@ jobs:
       - name: Build portable tests
         run: >-
           cmake --build build --config Release --parallel 3
-          --target dsp56kTestRunner mdLibTest mdFlashTest mdPlusDriveTest mdStateTest mdProfileWorkload mdAudioIoLayoutTest
+          --target dsp56kTestRunner mdLibTest mdFirmwareUpdateTest mdFlashTest mdPlusDriveTest mdStateTest mdProfileWorkload mdAudioIoLayoutTest mdSettingsTemplateTest mmSettingsTemplateTest mdShiftTriggerLatchTest mdPanelInteractionTest mmPanelInteractionTest mdAutomationFirmwareTest mdAutomationRobustnessTest
 
       - name: Build AMD flash regression test
         if: runner.os != 'Windows'
@@ -105,9 +105,16 @@ jobs:
           --target source/cpu/mc68k/mc68kColdFireDivideTest
 
       - name: Run portable tests
+        if: runner.os != 'Linux'
         run: >-
           ctest --test-dir build -C Release --output-on-failure
-          --tests-regex "^(dsp56300_unitTests|mc68kColdFireDivideTest|am29fTest|mdLibTests|mdFlashTest|mdPlusDriveTest|mdStateTest|mdAudioIoLayoutTest|mdProfileWorkload(Bounded)?Tests)$"
+          --tests-regex "^(dsp56300_unitTests|mc68kColdFireDivideTest|am29fTest|mdLibTests|mdFirmwareUpdateTest|mdFlashTest|mdPlusDriveTest|mdStateTest|mdAudioIoLayoutTest|mdSettingsTemplateTest|mmSettingsTemplateTest|mdShiftTriggerLatchTest|mdPanelInteractionTest|mmPanelInteractionTest|mdAutomationUserUpdaterTest|mdAutomationArchitectureTest|mdProfileWorkload(Bounded)?Tests)$"
+
+      - name: Run portable tests (Linux virtual display)
+        if: runner.os == 'Linux'
+        run: >-
+          xvfb-run -a ctest --test-dir build -C Release --output-on-failure
+          --tests-regex "^(dsp56300_unitTests|mc68kColdFireDivideTest|am29fTest|mdLibTests|mdFirmwareUpdateTest|mdFlashTest|mdPlusDriveTest|mdStateTest|mdAudioIoLayoutTest|mdSettingsTemplateTest|mmSettingsTemplateTest|mdShiftTriggerLatchTest|mdPanelInteractionTest|mmPanelInteractionTest|mdAutomationUserUpdaterTest|mdAutomationArchitectureTest|mdProfileWorkload(Bounded)?Tests)$"
 
   apple-pgo:
     name: Apple PGO generate and use

--- a/.github/workflows/mdmm-core.yml
+++ b/.github/workflows/mdmm-core.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install Linux plugin dependencies
         if: runner.os == 'Linux'
-        run: sudo apt update && sudo apt install -y gdb libgl1-mesa-dev xorg-dev libasound2-dev xvfb
+        run: sudo apt update && sudo apt install -y libgl1-mesa-dev xorg-dev libasound2-dev xvfb
 
       - name: Configure portable tests
         run: >-
@@ -115,14 +115,6 @@ jobs:
         run: >-
           xvfb-run -a ctest --test-dir build -C Release --output-on-failure
           --tests-regex "^(dsp56300_unitTests|mc68kColdFireDivideTest|am29fTest|mdLibTests|mdFirmwareUpdateTest|mdFlashTest|mdPlusDriveTest|mdStateTest|mdAudioIoLayoutTest|mdSettingsTemplateTest|mmSettingsTemplateTest|mdShiftTriggerLatchTest|mdPanelInteractionTest|mmPanelInteractionTest|mdAutomationUserUpdaterTest|mdAutomationArchitectureTest|mdProfileWorkload(Bounded)?Tests)$"
-
-      - name: Diagnose Linux Settings crash
-        if: failure() && runner.os == 'Linux'
-        run: >-
-          xvfb-run -a gdb --batch
-          -ex run
-          -ex "thread apply all backtrace"
-          --args ./build/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest
 
   apple-pgo:
     name: Apple PGO generate and use

--- a/.github/workflows/mdmm-core.yml
+++ b/.github/workflows/mdmm-core.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install Linux plugin dependencies
         if: runner.os == 'Linux'
-        run: sudo apt update && sudo apt install -y libgl1-mesa-dev xorg-dev libasound2-dev xvfb
+        run: sudo apt update && sudo apt install -y gdb libgl1-mesa-dev xorg-dev libasound2-dev xvfb
 
       - name: Configure portable tests
         run: >-

--- a/.github/workflows/mdmm-core.yml
+++ b/.github/workflows/mdmm-core.yml
@@ -116,6 +116,14 @@ jobs:
           xvfb-run -a ctest --test-dir build -C Release --output-on-failure
           --tests-regex "^(dsp56300_unitTests|mc68kColdFireDivideTest|am29fTest|mdLibTests|mdFirmwareUpdateTest|mdFlashTest|mdPlusDriveTest|mdStateTest|mdAudioIoLayoutTest|mdSettingsTemplateTest|mmSettingsTemplateTest|mdShiftTriggerLatchTest|mdPanelInteractionTest|mmPanelInteractionTest|mdAutomationUserUpdaterTest|mdAutomationArchitectureTest|mdProfileWorkload(Bounded)?Tests)$"
 
+      - name: Diagnose Linux Settings crash
+        if: failure() && runner.os == 'Linux'
+        run: >-
+          xvfb-run -a gdb --batch
+          -ex run
+          -ex "thread apply all backtrace"
+          --args ./build/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest
+
   apple-pgo:
     name: Apple PGO generate and use
     runs-on: macos-14

--- a/scripts/macos/build_mdmm.sh
+++ b/scripts/macos/build_mdmm.sh
@@ -52,10 +52,22 @@ cmake --build "${build_dir}" --parallel 4 --target \
   mmJucePlugin_Standalone \
   pluginTester \
   mdLibTest \
-  mdStandalonePlusDrivePersistenceTest
+  mdFirmwareUpdateTest \
+  mdFlashTest \
+  mdPlusDriveTest \
+  mdStateTest \
+  mdAudioIoLayoutTest \
+  mdStandalonePlusDrivePersistenceTest \
+  mdSettingsTemplateTest \
+  mmSettingsTemplateTest \
+  mdShiftTriggerLatchTest \
+  mdPanelInteractionTest \
+  mmPanelInteractionTest \
+  mdAutomationFirmwareTest \
+  mdAutomationRobustnessTest
 
 ctest --test-dir "${build_dir}" -C Release --output-on-failure \
-  --tests-regex '^(mdLibTests|mdStandalonePlusDrivePersistenceTest)$'
+  --tests-regex '^(mdLibTests|mdFirmwareUpdateTest|mdFlashTest|mdPlusDriveTest|mdStateTest|mdAudioIoLayoutTest|mdStandalonePlusDrivePersistenceTest|mdSettingsTemplateTest|mmSettingsTemplateTest|mdShiftTriggerLatchTest|mdPanelInteractionTest|mmPanelInteractionTest|mdAutomationUserUpdaterTest|mdAutomationArchitectureTest)$'
 
 artifact_root="${source_dir}/bin/plugins/Release"
 md_app="${artifact_root}/Standalone/Gearmulator MD.app"
@@ -89,8 +101,10 @@ if [[ ! -x "${plugin_tester}" ]]; then
 fi
 empty_home="${build_dir}/empty-home"
 mkdir -p "${empty_home}"
-HOME="${empty_home}" "${plugin_tester}" -blocks 16 -plugin "${md_vst3}"
-HOME="${empty_home}" "${plugin_tester}" -blocks 16 -plugin "${mm_vst3}"
+HOME="${empty_home}" GEARMULATOR_DATA_ROOT="${empty_home}/Documents" \
+  "${plugin_tester}" -blocks 16 -plugin "${md_vst3}"
+HOME="${empty_home}" GEARMULATOR_DATA_ROOT="${empty_home}/Documents" \
+  "${plugin_tester}" -blocks 16 -plugin "${mm_vst3}"
 
 if find "${md_app}" "${mm_app}" "${md_vst3}" "${mm_vst3}" -type f \
     \( -iname '*.bin' -o -iname '*.rom' -o -iname '*.nvram' -o \

--- a/scripts/windows/build_mdmm.ps1
+++ b/scripts/windows/build_mdmm.ps1
@@ -146,7 +146,19 @@ if (-not $TestOnly) {
     )
     if ($WithTests) {
         $targets += 'mdLibTest'
+        $targets += 'mdFirmwareUpdateTest'
+        $targets += 'mdFlashTest'
+        $targets += 'mdPlusDriveTest'
+        $targets += 'mdStateTest'
+        $targets += 'mdAudioIoLayoutTest'
         $targets += 'mdStandalonePlusDrivePersistenceTest'
+        $targets += 'mdSettingsTemplateTest'
+        $targets += 'mmSettingsTemplateTest'
+        $targets += 'mdShiftTriggerLatchTest'
+        $targets += 'mdPanelInteractionTest'
+        $targets += 'mmPanelInteractionTest'
+        $targets += 'mdAutomationFirmwareTest'
+        $targets += 'mdAutomationRobustnessTest'
     }
     Invoke-Native -FilePath $cmake -Arguments (@(
         '--build', $BuildDir,
@@ -164,7 +176,7 @@ if ($WithTests) {
         '--test-dir', $BuildDir,
         '-C', $Configuration,
         '--output-on-failure',
-        '--tests-regex', '^(mdLibTests|mdStandalonePlusDrivePersistenceTest)$'
+        '--tests-regex', '^(mdLibTests|mdFirmwareUpdateTest|mdFlashTest|mdPlusDriveTest|mdStateTest|mdAudioIoLayoutTest|mdStandalonePlusDrivePersistenceTest|mdSettingsTemplateTest|mmSettingsTemplateTest|mdShiftTriggerLatchTest|mdPanelInteractionTest|mmPanelInteractionTest|mdAutomationUserUpdaterTest|mdAutomationArchitectureTest)$'
     )
 }
 
@@ -175,6 +187,15 @@ $mdStandalone = Get-Item -LiteralPath (Join-Path $productRoot 'Standalone\Gearmu
 $mmStandalone = Get-Item -LiteralPath (Join-Path $productRoot 'Standalone\Gearmulator MM.exe')
 $pluginTester = Find-ExactlyOne -Kind 'VST3 host' -Candidates @(
     Get-ChildItem -LiteralPath $BuildDir -Recurse -File -Filter 'pluginTester.exe')
+
+$smokeProfile = Join-Path $BuildDir 'empty-profile'
+$env:USERPROFILE = $smokeProfile
+$env:APPDATA = Join-Path $smokeProfile 'AppData\Roaming'
+$env:LOCALAPPDATA = Join-Path $smokeProfile 'AppData\Local'
+$env:GEARMULATOR_DATA_ROOT = Join-Path $smokeProfile 'Documents'
+New-Item -ItemType Directory -Path $env:APPDATA -Force | Out-Null
+New-Item -ItemType Directory -Path $env:LOCALAPPDATA -Force | Out-Null
+New-Item -ItemType Directory -Path $env:GEARMULATOR_DATA_ROOT -Force | Out-Null
 
 foreach ($bundle in @($mdVst3, $mmVst3)) {
     Get-ChildItem -LiteralPath $bundle.FullName -Recurse -File -Filter 'moduleinfo.json' |

--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -75,14 +75,35 @@ endif()
 target_compile_definitions(mmJucePlugin PRIVATE MD_JUCEPLUGIN_MONOMACHINE=1)
 
 if(BUILD_TESTING)
-	add_executable(mdSettingsTemplateTest mdSettingsTemplateTest.cpp)
-	target_include_directories(mdSettingsTemplateTest PRIVATE
-		${CMAKE_CURRENT_SOURCE_DIR}/../../../framework/juce)
-	target_compile_definitions(mdSettingsTemplateTest PRIVATE
-		MD_SETTINGS_TEMPLATE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
-	set_property(TARGET mdSettingsTemplateTest PROPERTY FOLDER "Elektron/test")
-	add_test(NAME mdSettingsTemplateTest COMMAND mdSettingsTemplateTest)
-	set_tests_properties(mdSettingsTemplateTest PROPERTIES LABELS "UnitTest")
+	function(add_md_settings_runtime_test TARGET_NAME PLUGIN_TARGET)
+		add_executable(${TARGET_NAME} mdSettingsTemplateTest.cpp)
+		target_link_libraries(${TARGET_NAME} PRIVATE
+			${PLUGIN_TARGET} jucePluginEditorLib mdLib juce_plugin_modules)
+		target_compile_definitions(${TARGET_NAME} PRIVATE
+			JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1 ${ARGN})
+		set_property(TARGET ${TARGET_NAME} PROPERTY FOLDER "Elektron/test")
+		add_test(NAME ${TARGET_NAME} COMMAND ${TARGET_NAME})
+		set_tests_properties(${TARGET_NAME} PROPERTIES LABELS "Integration")
+	endfunction()
+
+	add_md_settings_runtime_test(mdSettingsTemplateTest mdJucePlugin)
+	add_md_settings_runtime_test(mmSettingsTemplateTest mmJucePlugin
+		MD_SETTINGS_TEST_MONOMACHINE=1)
+
+	function(add_md_panel_interaction_test TARGET_NAME PLUGIN_TARGET)
+		add_executable(${TARGET_NAME} mdPanelInteractionTest.cpp)
+		target_link_libraries(${TARGET_NAME} PRIVATE
+			${PLUGIN_TARGET} jucePluginEditorLib mdLib juce_plugin_modules)
+		target_compile_definitions(${TARGET_NAME} PRIVATE
+			JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1 ${ARGN})
+		set_property(TARGET ${TARGET_NAME} PROPERTY FOLDER "Elektron/test")
+		add_test(NAME ${TARGET_NAME} COMMAND ${TARGET_NAME})
+		set_tests_properties(${TARGET_NAME} PROPERTIES LABELS "Integration")
+	endfunction()
+
+	add_md_panel_interaction_test(mdPanelInteractionTest mdJucePlugin)
+	add_md_panel_interaction_test(mmPanelInteractionTest mmJucePlugin
+		MD_PANEL_TEST_MONOMACHINE=1)
 
 	add_executable(mdAudioIoLayoutTest mdAudioIoLayoutTest.cpp)
 	target_link_libraries(mdAudioIoLayoutTest PRIVATE
@@ -125,6 +146,10 @@ if(BUILD_TESTING)
 		mdAutomationFirmwareTest.cpp)
 	add_test(NAME mdAutomationFirmwareTest COMMAND mdAutomationFirmwareTest)
 	set_tests_properties(mdAutomationFirmwareTest PROPERTIES LABELS "Integration")
+	add_test(NAME mdAutomationUserUpdaterTest COMMAND mdAutomationFirmwareTest
+		--md-updater)
+	set_tests_properties(mdAutomationUserUpdaterTest PROPERTIES
+		LABELS "Integration" TIMEOUT 300 SKIP_RETURN_CODE 77)
 
 	add_md_automation_firmware_test(mdAutomationRobustnessTest
 		mdAutomationRobustnessTest.cpp)

--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -78,7 +78,8 @@ if(BUILD_TESTING)
 	function(add_md_settings_runtime_test TARGET_NAME PLUGIN_TARGET)
 		add_executable(${TARGET_NAME} mdSettingsTemplateTest.cpp)
 		target_link_libraries(${TARGET_NAME} PRIVATE
-			${PLUGIN_TARGET} jucePluginEditorLib mdLib juce_plugin_modules)
+			${PLUGIN_TARGET} jucePluginEditorLib mdLib juce_plugin_modules
+			juce::juce_opengl)
 		target_compile_definitions(${TARGET_NAME} PRIVATE
 			JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1 ${ARGN})
 		set_property(TARGET ${TARGET_NAME} PROPERTY FOLDER "Elektron/test")
@@ -93,7 +94,8 @@ if(BUILD_TESTING)
 	function(add_md_panel_interaction_test TARGET_NAME PLUGIN_TARGET)
 		add_executable(${TARGET_NAME} mdPanelInteractionTest.cpp)
 		target_link_libraries(${TARGET_NAME} PRIVATE
-			${PLUGIN_TARGET} jucePluginEditorLib mdLib juce_plugin_modules)
+			${PLUGIN_TARGET} jucePluginEditorLib mdLib juce_plugin_modules
+			juce::juce_opengl)
 		target_compile_definitions(${TARGET_NAME} PRIVATE
 			JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1 ${ARGN})
 		set_property(TARGET ${TARGET_NAME} PROPERTY FOLDER "Elektron/test")

--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -136,7 +136,8 @@ if(BUILD_TESTING)
 	function(add_md_automation_firmware_test TARGET_NAME SOURCE_FILE)
 		add_executable(${TARGET_NAME} ${SOURCE_FILE} mdAutomationTestSupport.h)
 		target_link_libraries(${TARGET_NAME} PRIVATE
-			mdJucePlugin jucePluginEditorLib mdLib juce_plugin_modules)
+			mdJucePlugin jucePluginEditorLib mdLib juce_plugin_modules
+			juce::juce_opengl)
 		target_include_directories(${TARGET_NAME} PRIVATE
 			${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 		target_compile_definitions(${TARGET_NAME} PRIVATE
@@ -173,7 +174,8 @@ if(BUILD_TESTING)
 	add_executable(mdStandalonePlusDrivePersistenceTest
 		mdStandalonePlusDrivePersistenceTest.cpp)
 	target_link_libraries(mdStandalonePlusDrivePersistenceTest PRIVATE
-		mdJucePlugin jucePluginEditorLib mdLib juce_plugin_modules)
+		mdJucePlugin jucePluginEditorLib mdLib juce_plugin_modules
+		juce::juce_opengl)
 	target_include_directories(mdStandalonePlusDrivePersistenceTest PRIVATE
 		${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 	target_compile_definitions(mdStandalonePlusDrivePersistenceTest PRIVATE

--- a/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
@@ -1,5 +1,6 @@
 #include "mdAutomationTestSupport.h"
 
+#include "mdLib/mdfirmwareupdate.h"
 #include "mdLib/mdplusdrive.h"
 
 #include "baseLib/filesystem.h"
@@ -181,6 +182,7 @@ namespace
 		bool factoryFlashReadyForReboot = false;
 		bool factoryFlashCaptureDisqualified = false;
 		bool initializationExpected = false;
+		bool firmwareUpdateDirectBoot = false;
 		bool automaticRebootReady = false;
 		size_t plusDriveSectors = 0;
 		uint64_t plusDriveCommands = 0;
@@ -204,6 +206,8 @@ namespace
 						hardware.isFactoryFlashCaptureDisqualified();
 					status.initializationExpected =
 						hardware.isFactoryFlashInitializationExpected();
+					status.firmwareUpdateDirectBoot =
+						hardware.isFirmwareUpdateDirectBoot();
 					status.automaticRebootReady =
 						hardware.isPlusDriveReadyForFactoryReboot();
 					status.plusDriveSectors = hardware.getUC().getSim()
@@ -285,15 +289,49 @@ namespace
 		verifyStandaloneFilterStateMigration(_harness, imageA, imageB);
 	}
 
-	void verifyModel(const md::MachineModel _model)
+	bool verifyModel(const md::MachineModel _model,
+		const bool _requireUserUpdater = false)
 	{
-		Harness harness(_model);
+		mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig config;
+		config.isolateDeviceStorage = true;
+		if(_requireUserUpdater)
+		{
+			std::vector<std::string> candidates;
+			baseLib::filesystem::findFiles(candidates,
+				baseLib::filesystem::getCurrentDirectory(), ".syx", 1,
+				16u * 1024u * 1024u);
+			for(const auto& candidate : candidates)
+			{
+				std::vector<uint8_t> sysex;
+				std::vector<uint8_t> converted;
+				md::MachineModel model = md::MachineModel::Machinedrum;
+				std::string error;
+				if(baseLib::filesystem::readFile(sysex, candidate)
+					&& md::firmwareUpdate::convertSysexToRom(
+						sysex, converted, model, error)
+					&& model == md::MachineModel::Machinedrum)
+				{
+					config.romData = std::move(converted);
+					config.romName = candidate;
+					break;
+				}
+			}
+			if(config.romData.empty())
+			{
+				std::cout << "mdAutomationFirmwareTest: SKIP MD user-supplied updater "
+					"(place its .syx in the current directory)\n";
+				return false;
+			}
+		}
+		Harness harness(_model, std::move(config));
 		if(!harness.hasLocalFirmware())
 		{
+			if(_requireUserUpdater)
+				require(false, "converted user-supplied updater did not create a device");
 			std::cout << "mdAutomationFirmwareTest: SKIP "
 				<< modelName(_model)
 				<< " (firmware unavailable)\n";
-			return;
+			return true;
 		}
 		harness.prepare();
 
@@ -302,6 +340,9 @@ namespace
 		if(_model == md::MachineModel::Machinedrum)
 		{
 			const auto initialBoot = mdBootStatus(harness);
+			if(_requireUserUpdater && !initialBoot.firmwareUpdateDirectBoot)
+				require(false,
+					"converted user-supplied updater did not enter direct boot");
 			const bool testFirstRunInteraction =
 				std::getenv("GEARMULATOR_MD_TEST_FIRST_RUN_INTERACTION") != nullptr;
 			if(initialBoot.initializationExpected)
@@ -325,6 +366,35 @@ namespace
 									0x90, 60, 100));
 						}), "could not inject first-run panel and host MIDI interaction");
 				}
+			}
+			uint64_t expectedEpoch = initialBoot.hardwareEpoch;
+			if(initialBoot.firmwareUpdateDirectBoot)
+			{
+				MdBootStatus updateBoot;
+				for(int attempt = 0; attempt < 60; ++attempt)
+				{
+					harness.process(1000);
+					updateBoot = mdBootStatus(harness);
+					if(updateBoot.factoryFlashReadyForReboot)
+						break;
+				}
+				require(updateBoot.firmwareUpdateDirectBoot
+					&& updateBoot.factoryFlashReadyForReboot,
+					"user-supplied updater did not finish installing its bootstrap");
+				require(harness.processor.serviceFactoryInitialization(),
+					"user-supplied updater first-stage automatic restart failed");
+				require(!harness.processor.serviceFactoryInitialization(),
+					"user-supplied updater first-stage restart was not one-shot");
+				const auto preparationBoot = mdBootStatus(harness);
+				++expectedEpoch;
+				require(preparationBoot.hardwareEpoch == expectedEpoch
+					&& !preparationBoot.firmwareUpdateDirectBoot
+					&& preparationBoot.initializationExpected,
+					"user-supplied updater did not restart into normal first-run preparation");
+				juce::String prematureRestart;
+				require(!harness.processor.rebootMachinedrum(prematureRestart)
+					&& prematureRestart.containsIgnoreCase("still being prepared"),
+					"user-supplied updater bypassed its second-stage preparation");
 			}
 			// A blank +Drive is formatted during the first 1.63 boot. The original
 			// automation request predates that work, and the firmware asks for a
@@ -365,8 +435,8 @@ namespace
 					"automatic post-format Machinedrum reboot failed");
 				require(!harness.processor.serviceFactoryInitialization(),
 					"automatic post-format reboot was not one-shot");
-				require(mdBootStatus(harness).hardwareEpoch
-					== initialBoot.hardwareEpoch + 1,
+				++expectedEpoch;
+				require(mdBootStatus(harness).hardwareEpoch == expectedEpoch,
 					"automatic post-format reboot did not replace the Hardware once");
 			}
 			else
@@ -386,6 +456,10 @@ namespace
 			else
 				require(rebooted.factoryFlashReady,
 					"Machinedrum reboot discarded its validated in-memory UW factory cache");
+			if(initialBoot.firmwareUpdateDirectBoot)
+				require(rebooted.hardwareEpoch == initialBoot.hardwareEpoch + 2
+					&& !rebooted.initializationExpected,
+					"user-supplied updater did not complete exactly two in-process restarts");
 			// Audio-ready goes true before the main CPU has finished the +Drive boot
 			// path. Match the 20-second firmware acceptance test before sending SysEx.
 			harness.process(9000);
@@ -402,6 +476,11 @@ namespace
 			+ harness.firmwareReadiness() + ")");
 		require(controller.getAutomationBaseChannel() < 16,
 			"firmware Global has MIDI base channel set to NONE");
+		if(_requireUserUpdater)
+		{
+			std::cout << "mdAutomationFirmwareTest: MD user-supplied two-stage updater PASS\n";
+			return true;
+		}
 
 		auto& probe = parameter(controller);
 		const auto beforeTransmitCount =
@@ -499,6 +578,7 @@ namespace
 		std::cout << "mdAutomationFirmwareTest: "
 			<< modelName(_model)
 			<< " PASS\n";
+		return true;
 	}
 }
 
@@ -508,6 +588,10 @@ int main(const int _argc, const char* const* _argv)
 	try
 	{
 		const auto only = _argc > 1 ? std::string(_argv[1]) : std::string();
+		if(only == "--md-updater")
+		{
+			return verifyModel(md::MachineModel::Machinedrum, true) ? 0 : 77;
+		}
 		if(only != "--mm")
 			verifyModel(md::MachineModel::Machinedrum);
 		if(only != "--md")

--- a/source/elektron/md/mdJucePlugin/mdAutomationRobustnessTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationRobustnessTest.cpp
@@ -280,6 +280,45 @@ namespace
 		}
 	}
 
+	void completeMachinedrumFirstRun(Harness& _harness)
+	{
+		if(_harness.model != md::MachineModel::Machinedrum)
+			return;
+		const auto initializationExpected = _harness.processor.getPlugin()
+			.withDeviceLocked([](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				return device && device->getHardware()
+					.isFactoryFlashInitializationExpected();
+			});
+		if(!initializationExpected)
+			return;
+
+		bool ready = false;
+		for(int attempt = 0; attempt < 60 && !ready; ++attempt)
+		{
+			_harness.process(1000);
+			ready = _harness.processor.getPlugin().withDeviceLocked(
+				[](synthLib::Device* const _device)
+				{
+					auto* const device = dynamic_cast<md::Device*>(_device);
+					if(!device)
+						return false;
+					const auto& hardware = device->getHardware();
+					return hardware.isFactoryFlashReadyForReboot()
+						&& hardware.isPlusDriveReadyForFactoryReboot();
+				});
+		}
+		require(ready, "first-run storage did not become reboot-ready");
+		require(_harness.processor.serviceFactoryInitialization(),
+			"first-run in-process reboot failed");
+		_harness.process(9000);
+		_harness.controller.requestAutomationState();
+		if(!_harness.synchronize(12000))
+			throw std::runtime_error("automation did not resynchronize after first-run reboot ("
+				+ _harness.firmwareReadiness() + ")");
+	}
+
 	void verifyExternalNotifications(Harness& _harness)
 	{
 		auto& controller = _harness.controller;
@@ -812,6 +851,7 @@ namespace
 			return;
 		}
 		verifyQueuedPreBootWrites(harness);
+		completeMachinedrumFirstRun(harness);
 		verifyExternalNotifications(harness);
 		verifyCorrelatedDumpsAndStrictStatus(harness);
 		verifyMidiNoneReplay(harness);

--- a/source/elektron/md/mdJucePlugin/mdAutomationTestSupport.h
+++ b/source/elektron/md/mdJucePlugin/mdAutomationTestSupport.h
@@ -269,7 +269,7 @@ namespace mdAutomationTest
 		return packed;
 	}
 
-	inline md::automation::sysex::Message makeDump(const md::MachineModel _model,
+	inline pluginLib::SysEx makeDump(const md::MachineModel _model,
 		const uint8_t _command, const uint8_t _slot,
 		const std::vector<uint8_t>& _decoded)
 	{
@@ -285,10 +285,10 @@ namespace mdAutomationTest
 		else
 			result.insert(result.end(), _decoded.begin(), _decoded.end());
 		finishDump(result);
-		return result;
+		return {result.begin(), result.end()};
 	}
 
-	inline md::automation::sysex::Message makeGlobalDump(
+	inline pluginLib::SysEx makeGlobalDump(
 		const md::MachineModel _model, const uint8_t _slot, const uint8_t _base)
 	{
 		if(_model == md::MachineModel::Monomachine)
@@ -305,7 +305,7 @@ namespace mdAutomationTest
 		return makeDump(_model, 0x50, _slot, decoded);
 	}
 
-	inline md::automation::sysex::Message makeKitDump(
+	inline pluginLib::SysEx makeKitDump(
 		const md::MachineModel _model, const uint8_t _slot, const uint8_t _value)
 	{
 		if(_model == md::MachineModel::Monomachine)

--- a/source/elektron/md/mdJucePlugin/mdAutomationTestSupport.h
+++ b/source/elektron/md/mdJucePlugin/mdAutomationTestSupport.h
@@ -9,10 +9,13 @@
 
 #include "juce_events/juce_events.h"
 
+#include <chrono>
 #include <cstdint>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <thread>
+#include <utility>
 #include <vector>
 
 namespace mdAutomationTest
@@ -57,9 +60,15 @@ namespace mdAutomationTest
 	{
 	public:
 		explicit Harness(const md::MachineModel _model)
+			: Harness(_model,
+				mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig{})
+		{
+		}
+
+		Harness(const md::MachineModel _model,
+			mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig _config)
 			: model(_model)
-			, processor(_model,
-				mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig{}, false)
+			, processor(_model, std::move(_config), false)
 			, audioProcessor(static_cast<juce::AudioProcessor&>(processor))
 			, controller(dynamic_cast<mdJucePlugin::Controller&>(
 				processor.getController()))
@@ -100,10 +109,14 @@ namespace mdAutomationTest
 				midi.clear();
 				audioProcessor.processBlock(audio, midi);
 				controller.processPendingMidiMessages();
+				// Audio hosts naturally leave time between callbacks. The headless
+				// harness otherwise races far ahead of the emulated DSP workers and can
+				// produce false firmware boot/state timeouts on fast main threads.
+				std::this_thread::sleep_for(std::chrono::microseconds(500));
 			}
 		}
 
-		bool synchronize(const int _maximumBlocks = 3000)
+		bool synchronize(const int _maximumBlocks = 12000)
 		{
 			for(int block = 0; block < _maximumBlocks; ++block)
 			{

--- a/source/elektron/md/mdJucePlugin/mdController.cpp
+++ b/source/elektron/md/mdJucePlugin/mdController.cpp
@@ -638,6 +638,10 @@ namespace mdJucePlugin
 
 	bool Controller::firmwareReadyForAutomation() const
 	{
+		// A readiness probe is observational. In particular, controller creation for
+		// an editor must not turn a missing-firmware UI into a device boot attempt.
+		if(getProcessor().getExistingDevice() == nullptr)
+			return false;
 		bool ready = true;
 		getProcessor().getPlugin().withDeviceLocked(
 			[&ready](synthLib::Device* const _device)

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -159,13 +159,13 @@ namespace mdJucePlugin
 
 	md::Hardware* Editor::getHardware() const
 	{
-		auto* device = dynamic_cast<md::Device*>(getProcessor().getPlugin().getDevice());
+		auto* device = dynamic_cast<md::Device*>(getProcessor().getExistingDevice());
 		return device ? &device->getHardware() : nullptr;
 	}
 
 	bool Editor::refreshFrontPanelState(const double _nowMilliseconds)
 	{
-		auto* device = dynamic_cast<md::Device*>(getProcessor().getPlugin().getDevice());
+		auto* device = dynamic_cast<md::Device*>(getProcessor().getExistingDevice());
 		if(!device)
 			return false;
 		const auto ledPresentationBeforeDrain = m_ledPresentation;
@@ -1401,8 +1401,8 @@ namespace mdJucePlugin
 	{
 		if(!m_sysexStatusOverride.empty())
 			return m_sysexStatusOverride;
-		auto* const device =
-			dynamic_cast<md::Device*>(getProcessor().getPlugin().getDevice());
+		auto* const device = dynamic_cast<md::Device*>(
+			getProcessor().getExistingDevice());
 		if(!device)
 			return "MACHINE NOT READY";
 

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -395,7 +395,8 @@ namespace mdJucePlugin
 				[this](Rml::Event& _event)
 				{
 					if(juceRmlUi::helper::getKeyIdentifier(_event) != Rml::Input::KI_ESCAPE
-						|| (m_shiftPanelLatch.empty() && m_activePanelButtons.empty()))
+						|| (m_shiftPanelLatch.empty() && m_activePanelButtons.empty()
+							&& m_panelGesturePackets.empty() && !m_patternBankPacket))
 						return;
 					_event.StopPropagation();
 					cancelPanelInputGestures();
@@ -425,11 +426,9 @@ namespace mdJucePlugin
 		if(action == panelAffordances::ShiftPanelLatch::PressAction::Momentary)
 			m_activePanelButtons.push_back({ _button, _packet });
 
+		const auto combined = m_panelRows.press(_packet);
 		if(auto* hw = getHardware())
-		{
-			const auto combined = m_panelRows.press(_packet);
 			hw->sendPanelEvent(combined.row, combined.mask);
-		}
 	}
 
 	void Editor::releasePanelButton(juceRmlUi::ElemButton* const _button,
@@ -445,11 +444,9 @@ namespace mdJucePlugin
 
 		m_activePanelButtons.erase(it);
 		juceRmlUi::ElemButton::setChecked(_button, false);
+		const auto combined = m_panelRows.release(_packet);
 		if(auto* hw = getHardware())
-		{
-			const auto combined = m_panelRows.release(_packet);
 			hw->sendPanelEvent(combined.row, combined.mask);
-		}
 		if(getModel() == md::MachineModel::Monomachine && isTrigger(_control))
 			releasePatternBankLatch();
 	}
@@ -585,11 +582,9 @@ namespace mdJucePlugin
 				continue;
 
 			m_panelGesturePackets.push_back(*packet);
+			const auto combined = m_panelRows.press(*packet);
 			if(auto* hw = getHardware())
-			{
-				const auto combined = m_panelRows.press(*packet);
 				hw->sendPanelEvent(combined.row, combined.mask);
-			}
 		}
 	}
 
@@ -652,9 +647,6 @@ namespace mdJucePlugin
 
 	void Editor::globalFocusChanged(juce::Component* const _focusedComponent)
 	{
-		if(m_shiftPanelLatch.empty() && m_activePanelButtons.empty())
-			return;
-
 		auto* const panel = getRmlComponent();
 		if(panel && _focusedComponent
 			&& (_focusedComponent == panel || panel->isParentOf(_focusedComponent)))
@@ -847,11 +839,9 @@ namespace mdJucePlugin
 		m_patternBankPacket = _packet;
 		juceRmlUi::ElemButton::setChecked(_button, true);
 
+		const auto combined = m_panelRows.press(_packet);
 		if(auto* hw = getHardware())
-		{
-			const auto combined = m_panelRows.press(_packet);
 			hw->sendPanelEvent(combined.row, combined.mask);
-		}
 	}
 
 	void Editor::releasePatternBankLatch()

--- a/source/elektron/md/mdJucePlugin/mdPanelInteractionTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPanelInteractionTest.cpp
@@ -272,6 +272,9 @@ namespace
 int main()
 {
 	juce::ScopedJuceInitialiser_GUI juce;
+	juce::MessageManagerLock messageLock;
+	expect(messageLock.lockWasGained(),
+		"could not lock the JUCE message thread for live UI testing");
 
 #if defined(MD_PANEL_TEST_MONOMACHINE)
 	mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig mmConfig;

--- a/source/elektron/md/mdJucePlugin/mdPanelInteractionTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPanelInteractionTest.cpp
@@ -1,0 +1,305 @@
+#include "mdEditor.h"
+#include "mdPluginProcessor.h"
+
+#include "jucePluginEditorLib/pluginEditorState.h"
+
+#include "juceRmlUi/rmlElemButton.h"
+#include "juceRmlUi/rmlElemKnob.h"
+
+#include "RmlUi/Core/Element.h"
+#include "RmlUi/Core/ElementDocument.h"
+
+#include "juce_events/juce_events.h"
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <utility>
+
+namespace mdJucePlugin
+{
+	// Keep production interaction methods private while allowing this test to
+	// inspect the state reached through the live RmlUi event listeners.
+	struct EditorIdentityTestAccess
+	{
+		static uint8_t rowMask(const Editor& _editor, const uint8_t _row)
+		{
+			return _editor.m_panelRows.mask(_row);
+		}
+
+		static size_t heldCount(const Editor& _editor)
+		{
+			return _editor.m_shiftPanelLatch.size();
+		}
+
+		static size_t activeCount(const Editor& _editor)
+		{
+			return _editor.m_activePanelButtons.size();
+		}
+
+		static size_t gestureCount(const Editor& _editor)
+		{
+			return _editor.m_panelGesturePackets.size();
+		}
+
+		static void presentLed(Editor& _editor, const uint8_t _bank,
+			const uint8_t _bit)
+		{
+			md::FrontPanel blank;
+			_editor.m_frontPanelSnapshot = blank;
+			_editor.m_frontPanelSnapshotValid = true;
+			_editor.m_ledPresentation.reset(blank);
+			_editor.m_ledPresentation.apply({1, 0, _bank,
+				static_cast<uint8_t>(0xffu & ~(1u << _bit))}, 0.0);
+			(void)_editor.m_ledPresentation.advance(1.0);
+			_editor.m_ledsChanged = true;
+			_editor.updateLeds();
+		}
+
+		static void loseFocus(Editor& _editor)
+		{
+			_editor.globalFocusChanged(nullptr);
+		}
+	};
+}
+
+namespace
+{
+	using Access = mdJucePlugin::EditorIdentityTestAccess;
+
+	void expect(const bool _condition, const char* const _message)
+	{
+		if(_condition)
+			return;
+		std::cerr << "mdPanelInteractionTest: " << _message << '\n';
+		std::exit(1);
+	}
+
+	Rml::Dictionary mouseParameters(const bool _shift = false,
+		const bool _command = false, const int _x = 0, const int _y = 0,
+		const bool _control = false)
+	{
+		Rml::Dictionary result;
+		result["shift_key"] = static_cast<int>(_shift);
+		result["meta_key"] = static_cast<int>(_command);
+		result["ctrl_key"] = static_cast<int>(_control);
+		result["mouse_x"] = _x;
+		result["mouse_y"] = _y;
+		result["button"] = 0;
+		return result;
+	}
+
+	Rml::Element* element(mdJucePlugin::Editor& _editor, const char* const _id)
+	{
+		auto* const result = _editor.findChild(_id, false);
+		expect(result != nullptr, "live skin is missing a panel control");
+		return result;
+	}
+
+	juceRmlUi::ElemButton* button(mdJucePlugin::Editor& _editor,
+		const char* const _id)
+	{
+		auto* const result = dynamic_cast<juceRmlUi::ElemButton*>(element(_editor, _id));
+		expect(result != nullptr, "panel control is not a live button");
+		return result;
+	}
+
+	void dispatch(Rml::Element* const _element, const Rml::EventId _event,
+		const Rml::Dictionary& _parameters = {})
+	{
+		expect(_element != nullptr, "cannot dispatch an event to a missing element");
+		// A false return means a listener intentionally stopped propagation, not
+		// that dispatch failed. The target listener has still received the event.
+		(void)_element->DispatchEvent(_event, _parameters);
+	}
+
+	void shiftClick(Rml::Element* const _element)
+	{
+		const auto shifted = mouseParameters(true);
+		dispatch(_element, Rml::EventId::Mousedown, shifted);
+		dispatch(_element, Rml::EventId::Mouseup, shifted);
+	}
+
+	void releaseShift(mdJucePlugin::Editor& _editor)
+	{
+		Rml::Dictionary parameters;
+		parameters["shift_key"] = 0;
+		dispatch(_editor.getDocument(), Rml::EventId::Keyup, parameters);
+	}
+
+	void expectAllRowsReleased(const mdJucePlugin::Editor& _editor)
+	{
+		for(uint8_t row = 0x20; row <= 0x25; ++row)
+			expect(Access::rowMask(_editor, row) == 0,
+				"cleanup left a firmware panel row held");
+		expect(Access::heldCount(_editor) == 0, "cleanup left a Shift latch held");
+		expect(Access::activeCount(_editor) == 0, "cleanup left a mouse button active");
+	}
+
+	void checkMultipleTrigLatch(mdJucePlugin::Editor& _editor)
+	{
+		auto* const trig1 = button(_editor, "trigKey0");
+		auto* const trig6 = button(_editor, "trigKey5");
+		auto* const trig11 = button(_editor, "trigKey10");
+		shiftClick(trig1);
+		shiftClick(trig6);
+		shiftClick(trig11);
+
+		expect(Access::heldCount(_editor) == 3,
+			"live Shift-click path did not retain all three trigs");
+		expect(Access::rowMask(_editor, 0x20) == 0x21,
+			"live Shift-click path combined trig row 0 incorrectly");
+		expect(Access::rowMask(_editor, 0x21) == 0x04,
+			"live Shift-click path combined trig row 1 incorrectly");
+		expect(trig1->isChecked() && trig6->isChecked() && trig11->isChecked(),
+			"latched trig did not remain visibly pressed");
+
+		releaseShift(_editor);
+		expectAllRowsReleased(_editor);
+		expect(!trig1->isChecked() && !trig6->isChecked() && !trig11->isChecked(),
+			"Shift key-up did not clear checked trig states");
+	}
+
+	void checkRecordPlayChord(mdJucePlugin::Editor& _editor)
+	{
+		auto* const record = button(_editor, "btRec");
+		auto* const play = button(_editor, "btPlay");
+		shiftClick(record);
+		expect(Access::heldCount(_editor) == 1
+			&& Access::rowMask(_editor, 0x22) == 0x02,
+			"Shift+REC did not leave only RECORD held");
+
+		const auto shifted = mouseParameters(true);
+		dispatch(play, Rml::EventId::Mousedown, shifted);
+		expect(Access::activeCount(_editor) == 1
+			&& Access::rowMask(_editor, 0x22) == 0x06,
+			"Shift+REC+PLAY did not present the combined firmware row");
+
+		// Exercise the document listener used by a real native Shift release.
+		releaseShift(_editor);
+		expectAllRowsReleased(_editor);
+		expect(!record->isChecked() && !play->isChecked(),
+			"record/play cleanup left a button checked");
+
+		// A delayed physical mouse-up after forced cleanup must be harmless.
+		dispatch(play, Rml::EventId::Mouseup, shifted);
+		expectAllRowsReleased(_editor);
+	}
+
+	void checkFocusLossCleanup(mdJucePlugin::Editor& _editor)
+	{
+		auto* const trig = button(_editor, "trigKey15");
+		auto* const play = button(_editor, "btPlay");
+		shiftClick(trig);
+		dispatch(play, Rml::EventId::Mousedown, mouseParameters(true));
+		expect(Access::heldCount(_editor) == 1 && Access::activeCount(_editor) == 1,
+			"focus-loss fixture did not create held and momentary inputs");
+		Access::loseFocus(_editor);
+		expectAllRowsReleased(_editor);
+		expect(!trig->isChecked() && !play->isChecked(),
+			"focus loss left a visible panel button pressed");
+
+		auto* const shortcut = element(_editor, "altMute");
+		dispatch(shortcut, Rml::EventId::Mousedown, mouseParameters());
+		expect(Access::gestureCount(_editor) == 2 && shortcut->IsClassSet("active"),
+			"direct panel shortcut did not begin its FUNCTION chord");
+		Access::loseFocus(_editor);
+		expectAllRowsReleased(_editor);
+		expect(Access::gestureCount(_editor) == 0 && !shortcut->IsClassSet("active"),
+			"focus loss left a direct panel shortcut held");
+	}
+
+	float dragDelta(juceRmlUi::ElemKnob& _knob, const bool _command)
+	{
+		_knob.setValue(50.0f, false);
+		dispatch(&_knob, Rml::EventId::Mousedown,
+			mouseParameters(true, _command));
+		// A zero-distance drag selects and anchors the modifier; the second measures it.
+		dispatch(&_knob, Rml::EventId::Drag,
+			mouseParameters(true, _command));
+		dispatch(&_knob, Rml::EventId::Drag,
+			mouseParameters(true, _command, 25));
+		return std::abs(_knob.getValue() - 50.0f);
+	}
+
+	void checkShiftCommandEncoder(mdJucePlugin::Editor& _editor)
+	{
+		auto* const knob = dynamic_cast<juceRmlUi::ElemKnob*>(element(_editor, "encA"));
+		expect(knob != nullptr, "live DATA ENTRY A is not a knob");
+		const auto shifted = dragDelta(*knob, false);
+		const auto commandFine = dragDelta(*knob, true);
+		expect(shifted > 0.0f, "Shift-only encoder drag did not move");
+		expect(commandFine > shifted * 0.15f && commandFine < shifted * 0.25f,
+			"Shift+Command/Ctrl did not select the 20% fine encoder modifier");
+		expectAllRowsReleased(_editor);
+	}
+
+	void checkLiveLedMappings(mdJucePlugin::Editor& _editor)
+	{
+		const struct { const char* id; uint8_t bank; uint8_t bit; } cases[] =
+		{
+			{ "mdPatternPage0", 0x22, 0 },
+			{ "mdPatternPage1", 0x22, 1 },
+			{ "mdPatternPage2", 0x22, 2 },
+			{ "mdPatternPage3", 0x23, 6 },
+			{ "ledTempo", 0x23, 5 },
+		};
+		for(const auto& ledCase : cases)
+		{
+			auto* const led = element(_editor, ledCase.id);
+			Access::presentLed(_editor, ledCase.bank, ledCase.bit);
+			expect(led->IsClassSet("lit"),
+				"front-panel LED bank did not light its live skin element");
+		}
+	}
+
+	void checkMonomachineBankLatch(mdJucePlugin::Editor& _editor)
+	{
+		auto* const bank = button(_editor, "btBankA");
+		dispatch(bank, Rml::EventId::Mousedown, mouseParameters());
+		const auto packet = md::panelPacket(md::MachineModel::Monomachine,
+			md::PanelControl::BankA);
+		expect(packet && Access::rowMask(_editor, packet->row) == packet->mask,
+			"MM bank latch did not retain its firmware row state");
+		expect(bank->isChecked(), "MM bank latch did not remain visibly pressed");
+		Access::loseFocus(_editor);
+		expectAllRowsReleased(_editor);
+		expect(!bank->isChecked(), "MM bank latch survived focus loss");
+	}
+}
+
+int main()
+{
+	juce::ScopedJuceInitialiser_GUI juce;
+
+#if defined(MD_PANEL_TEST_MONOMACHINE)
+	mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig mmConfig;
+	mmConfig.isolateDeviceStorage = true;
+	mdJucePlugin::AudioPluginAudioProcessor mmProcessor(
+		md::MachineModel::Monomachine, std::move(mmConfig), false);
+	auto& mmState = mmProcessor.getOrCreateEditorState();
+	auto* const mmEditor = dynamic_cast<mdJucePlugin::Editor*>(mmState.getEditor());
+	expect(mmEditor != nullptr, "embedded Monomachine skin did not create its editor");
+	checkMonomachineBankLatch(*mmEditor);
+	mmProcessor.destroyEditorState();
+#else
+	mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig config;
+	config.isolateDeviceStorage = true;
+	mdJucePlugin::AudioPluginAudioProcessor processor(md::MachineModel::Machinedrum,
+		std::move(config), false);
+	auto& state = processor.getOrCreateEditorState();
+	auto* const editor = dynamic_cast<mdJucePlugin::Editor*>(state.getEditor());
+	expect(editor != nullptr, "embedded Machinedrum skin did not create its editor");
+
+	checkMultipleTrigLatch(*editor);
+	checkRecordPlayChord(*editor);
+	checkFocusLossCleanup(*editor);
+	checkShiftCommandEncoder(*editor);
+	checkLiveLedMappings(*editor);
+
+	processor.destroyEditorState();
+#endif
+	std::cout << "mdPanelInteractionTest: PASS\n";
+	return 0;
+}

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
@@ -823,8 +823,16 @@ namespace mdJucePlugin
 		}
 
 		getController();
-		const auto latencyBlocks = getConfig().getIntValue("latencyBlocks", static_cast<int>(getPlugin().getLatencyBlocks()));
-		Processor::setLatencyBlocks(latencyBlocks);
+		// UI-only and updater tests supply an isolated device configuration and
+		// create the device explicitly when they need it. Latency initialization is
+		// an audio-runtime concern; doing it here would eagerly boot a firmware-less
+		// machine just to construct an editor.
+		if(!_ephemeralConfig)
+		{
+			const auto latencyBlocks = getConfig().getIntValue("latencyBlocks",
+				static_cast<int>(getPlugin().getLatencyBlocks()));
+			Processor::setLatencyBlocks(latencyBlocks);
+		}
 		initializeStandalonePlusDrivePersistence();
 		// Ephemeral processors drive factory initialization explicitly in tests.
 		// Starting the production timer here can race a short-lived editor (and

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
@@ -510,7 +510,11 @@ namespace mdJucePlugin
 				if(!device || device->getModel() != md::MachineModel::Machinedrum)
 					return false;
 				const auto& hardware = device->getHardware();
+				const bool firmwareUpdateRestartReady =
+					hardware.isFirmwareUpdateDirectBoot()
+					&& hardware.isFactoryFlashReadyForReboot();
 				if(hardware.isFactoryFlashInitializationExpected()
+					&& !firmwareUpdateRestartReady
 					&& (!hardware.isFactoryFlashReadyForReboot()
 						|| !hardware.isPlusDriveReadyForFactoryReboot()))
 				{
@@ -582,7 +586,7 @@ namespace mdJucePlugin
 		if(m_model != md::MachineModel::Machinedrum)
 			return false;
 
-		enum class State { Waiting, Ready, NotNeeded };
+		enum class State { Waiting, FirmwareUpdateReady, Ready, NotNeeded };
 		auto state = State::NotNeeded;
 		bool factoryCacheReady = false;
 		bool factoryCacheDisqualified = false;
@@ -598,6 +602,12 @@ namespace mdJucePlugin
 			factoryCacheReady = hardware.isFactoryFlashCacheReady();
 			factoryCacheDisqualified =
 				hardware.isFactoryFlashCaptureDisqualified();
+			if(hardware.isFirmwareUpdateDirectBoot())
+			{
+				state = hardware.isFactoryFlashReadyForReboot()
+					? State::FirmwareUpdateReady : State::Waiting;
+				return;
+			}
 			state = hardware.isFactoryFlashReadyForReboot()
 				&& hardware.isPlusDriveReadyForFactoryReboot()
 				? State::Ready : State::Waiting;
@@ -611,7 +621,7 @@ namespace mdJucePlugin
 			startTimer(1000);
 			return false;
 		}
-		if(state != State::Ready)
+		if(state != State::Ready && state != State::FirmwareUpdateReady)
 		{
 			startTimer(250);
 			return false;
@@ -648,7 +658,11 @@ namespace mdJucePlugin
 			return false;
 		}
 
-		if(cachePersisted)
+		if(state == State::FirmwareUpdateReady)
+			m_factoryInitializationStatus = cachePersisted
+				? "OS update installed; Machinedrum restarted into first-run preparation"
+				: "OS update installed; Machinedrum restarted with project-owned flash";
+		else if(cachePersisted)
 			m_factoryInitializationStatus =
 				"Factory samples initialized; Machinedrum rebooted automatically";
 		else if(factoryCacheDisqualified)
@@ -709,8 +723,8 @@ namespace mdJucePlugin
 			{
 				auto* const device = dynamic_cast<md::Device*>(_device);
 				return device && device->getModel() == md::MachineModel::Machinedrum
-					&& device->getHardware().replacePlusDriveData(
-						started.initialImage, false);
+					&& device->getHardware().installStartupPlusDriveData(
+						started.initialImage);
 			});
 		if(!installed)
 			m_standalonePlusDrive->blockWrites(
@@ -769,13 +783,17 @@ namespace mdJucePlugin
 	AudioPluginAudioProcessor::AudioPluginAudioProcessor(const md::MachineModel _model,
 		EphemeralConfig _config, const bool _allowMcpServer) :
 		AudioPluginAudioProcessor(_model, std::vector<uint8_t>{}, _allowMcpServer,
-			true, std::move(_config.standalonePlusDriveFile))
+			true, std::move(_config.standalonePlusDriveFile),
+			_config.isolateDeviceStorage, std::move(_config.romData),
+			std::move(_config.romName))
 	{
 	}
 
 	AudioPluginAudioProcessor::AudioPluginAudioProcessor(const md::MachineModel _model,
 		std::vector<uint8_t> _initialPatchRam, const bool _allowMcpServer,
-		const bool _ephemeralConfig, juce::File _standalonePlusDriveFile) :
+		const bool _ephemeralConfig, juce::File _standalonePlusDriveFile,
+		const bool _isolateDeviceStorage, std::vector<uint8_t> _romData,
+		std::string _romName) :
 		Processor(createBusesProperties(),
 			getOptions(_model, _ephemeralConfig), makeProcessorProperties(_model),
 			_allowMcpServer, _ephemeralConfig
@@ -784,6 +802,9 @@ namespace mdJucePlugin
 		, m_model(_model)
 		, m_initialPatchRam(std::move(_initialPatchRam))
 		, m_standalonePlusDriveFile(std::move(_standalonePlusDriveFile))
+		, m_isolateDeviceStorage(_isolateDeviceStorage)
+		, m_romData(std::move(_romData))
+		, m_romName(std::move(_romName))
 	{
 		// The hardware-width skins need more than the generic 100% default. Keep
 		// the migration within a laptop desktop; the editor window restores this
@@ -878,7 +899,10 @@ namespace mdJucePlugin
 	{
 		synthLib::DeviceCreateParams params;
 		params.customData = md::deviceCustomData(m_model);
-		params.homePath = getDataFolder();
+		if(!m_isolateDeviceStorage)
+			params.homePath = getDataFolder();
+		params.romData = m_romData;
+		params.romName = m_romName;
 		auto* d = new md::Device(params, m_initialPatchRam);
 		if(!d->isValid())
 			throw synthLib::DeviceException(synthLib::DeviceError::FirmwareMissing,

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
@@ -826,7 +826,10 @@ namespace mdJucePlugin
 		const auto latencyBlocks = getConfig().getIntValue("latencyBlocks", static_cast<int>(getPlugin().getLatencyBlocks()));
 		Processor::setLatencyBlocks(latencyBlocks);
 		initializeStandalonePlusDrivePersistence();
-		if(m_model == md::MachineModel::Machinedrum)
+		// Ephemeral processors drive factory initialization explicitly in tests.
+		// Starting the production timer here can race a short-lived editor (and
+		// pointlessly attempts ROM discovery in UI-only tests).
+		if(m_model == md::MachineModel::Machinedrum && !_ephemeralConfig)
 			startTimer(250);
 	}
 

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
@@ -6,6 +6,7 @@
 #include <string_view>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <vector>
 
 namespace mdJucePlugin
@@ -21,6 +22,11 @@ namespace mdJucePlugin
 			// Tests may route the standalone checkpoint into an isolated directory.
 			// Production callers leave this empty and use the fixed user-data path.
 			juce::File standalonePlusDriveFile;
+			// Ephemeral processors must not read or persist a real machine's NVRAM.
+			// Tests may still use normal read-only ROM discovery, or inject a ROM below.
+			bool isolateDeviceStorage = true;
+			std::vector<uint8_t> romData;
+			std::string romName;
 		};
 
 	    AudioPluginAudioProcessor();
@@ -60,7 +66,9 @@ namespace mdJucePlugin
 		bool isBusesLayoutSupported(const BusesLayout& _layout) const override;
 		AudioPluginAudioProcessor(md::MachineModel _model,
 			std::vector<uint8_t> _initialPatchRam, bool _allowMcpServer,
-			bool _ephemeralConfig, juce::File _standalonePlusDriveFile = {});
+			bool _ephemeralConfig, juce::File _standalonePlusDriveFile = {},
+			bool _isolateDeviceStorage = false,
+			std::vector<uint8_t> _romData = {}, std::string _romName = {});
 		bool replacePlusDrive(std::vector<uint8_t> _replacement,
 			const juce::String& _operation, juce::String& _result);
 		bool exportPlusDriveImageUnlocked(const juce::File& _target,
@@ -75,6 +83,9 @@ namespace mdJucePlugin
 		const md::MachineModel m_model;
 		const std::vector<uint8_t> m_initialPatchRam;
 		const juce::File m_standalonePlusDriveFile;
+		const bool m_isolateDeviceStorage;
+		const std::vector<uint8_t> m_romData;
+		const std::string m_romName;
 		std::mutex m_storageLoadMutex;
 		juce::String m_factoryInitializationStatus;
 		std::unique_ptr<StandalonePlusDrivePersistence> m_standalonePlusDrive;

--- a/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
@@ -120,10 +120,8 @@ int main()
 				"mdPatternPage" + std::to_string(page), false);
 			require(led != nullptr, "live skin is missing MD page LED "
 				+ std::to_string(page + 1));
-			const auto unlit = led->GetProperty<Rml::Colourb>("image-color");
-			require(led->IsClassSet("mdScaleDot")
-				&& unlit != Rml::Colourb{}, "MD page LED "
-				+ std::to_string(page + 1) + " has no live scale-dot style");
+			require(led->IsClassSet("mdScaleDot"), "MD page LED "
+				+ std::to_string(page + 1) + " has no live scale-dot class");
 		}
 		#endif
 		processor.destroyEditorState();

--- a/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
@@ -1,96 +1,112 @@
-#include "jucePluginEditorLib/settingsDeviceSpecific.h"
+#include "mdPluginProcessor.h"
 
-#include <fstream>
+#include "jucePluginEditorLib/pluginEditor.h"
+#include "jucePluginEditorLib/pluginEditorState.h"
+
+#include "juceRmlUi/rmlElemButton.h"
+#include "juceRmlUi/rmlHelper.h"
+
+#include "juce_events/juce_events.h"
+
+#include "RmlUi/Core/Element.h"
+#include "RmlUi/Core/Context.h"
+
 #include <iostream>
-#include <iterator>
+#include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
 namespace
 {
-	bool require(const bool _condition, const std::string& _message)
+	void require(const bool _condition, const std::string& _message)
 	{
 		if(_condition)
-			return true;
-		std::cerr << "FAIL: " << _message << '\n';
-		return false;
-	}
-
-	std::string readFile(const std::string& _path)
-	{
-		std::ifstream stream(_path, std::ios::binary);
-		return {std::istreambuf_iterator<char>(stream),
-			std::istreambuf_iterator<char>()};
-	}
-
-	bool testProduct(const std::string& _productName,
-		const std::string& _deviceIdentity,
-		const std::string& _filename,
-		const std::vector<std::string>& _requiredIds)
-	{
-		const auto templateNames =
-			jucePluginEditorLib::makeDeviceSpecificSettingsTemplateNames(
-				"tus_settings_gui", _productName, _deviceIdentity);
-		const auto source = readFile(
-			std::string(MD_SETTINGS_TEMPLATE_DIR) + '/' + _filename);
-		std::string selectedTemplate;
-		for(const auto& candidate : templateNames)
-		{
-			if(!candidate.empty()
-				&& source.find("<template name=\"" + candidate + "\">")
-					!= std::string::npos)
-			{
-				selectedTemplate = candidate;
-				break;
-			}
-		}
-
-		bool ok = true;
-		ok &= require(!source.empty(), "could not read " + _filename);
-		ok &= require(selectedTemplate == "tus_settings_gui_" + _deviceIdentity,
-			_productName + " did not resolve its device-specific settings template");
-		for(const auto& id : _requiredIds)
-		{
-			ok &= require(source.find("id=\"" + id + "\"") != std::string::npos,
-				_filename + " is missing control " + id);
-		}
-		return ok;
+			return;
+		throw std::runtime_error(_message);
 	}
 }
 
 int main()
 {
-	bool ok = true;
-	const auto fallbackNames =
-		jucePluginEditorLib::makeDeviceSpecificSettingsTemplateNames(
-			"tus_settings_gui", "Example Product", {});
-	ok &= require(fallbackNames[0] == "tus_settings_gui_Example Product"
-			&& fallbackNames[1].empty(),
-		"products without a data identity must retain display-name lookup");
-
-	ok &= testProduct("Gearmulator MD", "Machinedrum",
-		"tus_settings_gui_Machinedrum.rml",
-		{"btInvertLcdColors", "btSendSysexFile", "sysexDropTarget",
-			"sysexTransferStatus", "btImportPlusDrive", "btExportPlusDrive",
-			"btRebootMachinedrum", "btResetPlusDrive", "btEncoderSpeed100"});
-	ok &= testProduct("Gearmulator MM", "Monomachine",
-		"tus_settings_gui_Monomachine.rml",
-		{"btInvertLcdColors", "btSendSysexFile", "sysexDropTarget",
-			"sysexTransferStatus", "btLoadInstalledFactoryStorage",
-			"btEncoderSpeed100"});
-
-	const auto mdSkin = readFile(std::string(MD_SETTINGS_TEMPLATE_DIR)
-		+ "/skins/mdDefault/mdDefault.rml");
-	ok &= require(!mdSkin.empty(), "could not read the Machinedrum skin");
-	for(const auto* const id : {"mdPatternPage0", "mdPatternPage1",
-		"mdPatternPage2", "mdPatternPage3", "ledTempo"})
+	try
 	{
-		ok &= require(mdSkin.find("id=\"" + std::string(id) + "\"")
-			!= std::string::npos, "Machinedrum skin is missing LED " + std::string(id));
-	}
+		juce::ScopedJuceInitialiser_GUI juce;
 
-	if(!ok)
+		#if defined(MD_SETTINGS_TEST_MONOMACHINE)
+		constexpr auto model = md::MachineModel::Monomachine;
+		const std::vector<std::string> requiredIds{
+			"btInvertLcdColors", "btSendSysexFile", "sysexDropTarget",
+			"sysexTransferStatus", "btLoadInstalledFactoryStorage",
+			"btEncoderSpeed100"};
+		#else
+		constexpr auto model = md::MachineModel::Machinedrum;
+		const std::vector<std::string> requiredIds{
+			"btInvertLcdColors", "btSendSysexFile", "sysexDropTarget",
+			"sysexTransferStatus", "btImportPlusDrive", "btExportPlusDrive",
+			"btRebootMachinedrum", "btResetPlusDrive", "btEncoderSpeed100"};
+		#endif
+
+		mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig config;
+		config.isolateDeviceStorage = true;
+		mdJucePlugin::AudioPluginAudioProcessor processor(model,
+			std::move(config), false);
+		processor.getConfig().setValue("lcdColorsInverted", false);
+		auto& state = processor.getOrCreateEditorState();
+		auto* const editor = state.getEditor();
+		require(editor != nullptr, "embedded skin did not create an editor");
+		editor->showSettings(true);
+		require(editor->settingsOpened(), "Settings overlay did not open");
+		for(const auto& id : requiredIds)
+			require(editor->findChild(id, false) != nullptr,
+				"live Settings UI is missing control " + id);
+		auto* const invertRoot = editor->findChild("btInvertLcdColors", false);
+		auto* const invertButton = dynamic_cast<juceRmlUi::ElemButton*>(
+			juceRmlUi::helper::findChild(invertRoot, "button"));
+		require(invertButton != nullptr && !invertButton->isChecked(),
+			"LCD inversion toggle did not initialize from configuration");
+		require(invertRoot->DispatchEvent(Rml::EventId::Click, {}),
+			"LCD inversion click was consumed unexpectedly");
+		require(processor.getConfig().getBoolValue("lcdColorsInverted", false)
+			&& invertButton->isChecked(),
+			"LCD inversion click did not update configuration and UI state");
+		#if !defined(MD_SETTINGS_TEST_MONOMACHINE)
+		for(int page = 0; page < 4; ++page)
+		{
+			auto* const led = editor->findChild(
+				"mdPatternPage" + std::to_string(page), false);
+			require(led != nullptr, "live skin is missing MD page LED "
+				+ std::to_string(page + 1));
+			const auto unlit = led->GetProperty<Rml::Colourb>("image-color");
+			led->SetClass("lit", true);
+			require(led->GetContext() && led->GetContext()->Update(),
+				"live skin did not update after lighting an MD page LED");
+			const auto lit = led->GetProperty<Rml::Colourb>("image-color");
+			require(lit != unlit, "MD page LED " + std::to_string(page + 1)
+				+ " has no visible lit style");
+			led->SetClass("lit", false);
+		}
+		#endif
+		processor.destroyEditorState();
+
+		// Recreating the editor must restore the device-specific setting instead of
+		// merely keeping transient state on the first checkbox instance.
+		auto* const restoredEditor = processor.getOrCreateEditorState().getEditor();
+		require(restoredEditor != nullptr, "editor recreation failed");
+		restoredEditor->showSettings(true);
+		auto* const restoredRoot = restoredEditor->findChild(
+			"btInvertLcdColors", false);
+		auto* const restoredButton = dynamic_cast<juceRmlUi::ElemButton*>(
+			juceRmlUi::helper::findChild(restoredRoot, "button"));
+		require(restoredButton != nullptr && restoredButton->isChecked(),
+			"LCD inversion setting did not survive editor recreation");
+		processor.destroyEditorState();
+		std::cout << "Live device-specific Settings UI: PASS\n";
+		return 0;
+	}
+	catch(const std::exception& error)
+	{
+		std::cerr << "FAIL: " << error.what() << '\n';
 		return 1;
-	std::cout << "MD/MM device-specific settings templates: PASS\n";
-	return 0;
+	}
 }

--- a/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
@@ -100,19 +100,6 @@ int main()
 		require(processor.getConfig().getBoolValue("lcdColorsInverted", false)
 			&& invertButton->isChecked(),
 			"LCD inversion click did not update configuration and UI state");
-		#if !defined(MD_SETTINGS_TEST_MONOMACHINE)
-		for(int page = 0; page < 4; ++page)
-		{
-			auto* const led = editor->findChild(
-				"mdPatternPage" + std::to_string(page), false);
-			require(led != nullptr, "live skin is missing MD page LED "
-				+ std::to_string(page + 1));
-			const auto unlit = led->GetProperty<Rml::Colourb>("image-color");
-			require(led->IsClassSet("mdScaleDot")
-				&& unlit != Rml::Colourb{}, "MD page LED "
-				+ std::to_string(page + 1) + " has no live scale-dot style");
-		}
-		#endif
 		processor.destroyEditorState();
 
 		// Recreating the editor must restore the device-specific setting instead of

--- a/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
@@ -1,4 +1,5 @@
 #include "mdPluginProcessor.h"
+#include "mdEditor.h"
 
 #include "jucePluginEditorLib/pluginEditor.h"
 #include "jucePluginEditorLib/pluginEditorState.h"
@@ -50,6 +51,8 @@ int main()
 		config.isolateDeviceStorage = true;
 		mdJucePlugin::AudioPluginAudioProcessor processor(model,
 			std::move(config), false);
+		require(processor.getExistingDevice() == nullptr,
+			"constructing an ephemeral processor instantiated the device");
 		#if !defined(MD_SETTINGS_TEST_MONOMACHINE)
 		const auto& binaryData = processor.getProperties().binaryData;
 		int cssSize = 0;
@@ -83,10 +86,20 @@ int main()
 		#endif
 		processor.getConfig().setValue("lcdColorsInverted", false);
 		auto& state = processor.getOrCreateEditorState();
+		require(processor.getExistingDevice() == nullptr,
+			"creating editor state instantiated the device");
 		auto* const editor = state.getEditor();
 		require(editor != nullptr, "embedded skin did not create an editor");
+		auto* const deviceEditor = dynamic_cast<mdJucePlugin::Editor*>(editor);
+		require(deviceEditor != nullptr, "embedded skin created the wrong editor type");
 		editor->showSettings(true);
 		require(editor->settingsOpened(), "Settings overlay did not open");
+		require(processor.getExistingDevice() == nullptr,
+			"opening Settings instantiated the device");
+		require(deviceEditor->sysexTransferStatusText() == "MACHINE NOT READY",
+			"inactive SysEx status did not report that the machine is not ready");
+		require(processor.getExistingDevice() == nullptr,
+			"opening Settings or polling SysEx status instantiated the device");
 		for(const auto& id : requiredIds)
 			require(editor->findChild(id, false) != nullptr,
 				"live Settings UI is missing control " + id);

--- a/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
@@ -9,7 +9,6 @@
 #include "juce_events/juce_events.h"
 
 #include "RmlUi/Core/Element.h"
-#include "RmlUi/Core/Context.h"
 
 #include <iostream>
 #include <memory>
@@ -51,6 +50,37 @@ int main()
 		config.isolateDeviceStorage = true;
 		mdJucePlugin::AudioPluginAudioProcessor processor(model,
 			std::move(config), false);
+		#if !defined(MD_SETTINGS_TEST_MONOMACHINE)
+		const auto& binaryData = processor.getProperties().binaryData;
+		int cssSize = 0;
+		const auto* const cssData = binaryData.getNamedResourceFunc(
+			"mdDefault_rcss", cssSize);
+		require(cssData != nullptr && cssSize > 0,
+			"embedded MD skin has no stylesheet resource");
+		const std::string embeddedCss(cssData, static_cast<size_t>(cssSize));
+		const auto imageColorInBlock = [&embeddedCss](const size_t _selector)
+		{
+			if(_selector == std::string::npos)
+				return std::string{};
+			const auto blockEnd = embeddedCss.find('}', _selector);
+			const auto property = embeddedCss.find("image-color:", _selector);
+			if(blockEnd == std::string::npos || property >= blockEnd)
+				return std::string{};
+			const auto value = property + std::string{"image-color:"}.size();
+			const auto valueEnd = embeddedCss.find(';', value);
+			return valueEnd < blockEnd
+				? embeddedCss.substr(value, valueEnd - value) : std::string{};
+		};
+		const auto litSelector = embeddedCss.find(".mdScaleDot.lit");
+		require(litSelector != std::string::npos,
+			"embedded MD skin has no lit scale-dot selector");
+		const auto unlitSelector = embeddedCss.find(
+			".mdModeDot, .mdBankIndicator, .mdScaleDot");
+		const auto litColor = imageColorInBlock(litSelector);
+		const auto unlitColor = imageColorInBlock(unlitSelector);
+		require(!litColor.empty() && !unlitColor.empty() && litColor != unlitColor,
+			"embedded MD scale-dot lit and unlit colors are not distinct");
+		#endif
 		processor.getConfig().setValue("lcdColorsInverted", false);
 		auto& state = processor.getOrCreateEditorState();
 		auto* const editor = state.getEditor();
@@ -78,13 +108,9 @@ int main()
 			require(led != nullptr, "live skin is missing MD page LED "
 				+ std::to_string(page + 1));
 			const auto unlit = led->GetProperty<Rml::Colourb>("image-color");
-			led->SetClass("lit", true);
-			require(led->GetContext() && led->GetContext()->Update(),
-				"live skin did not update after lighting an MD page LED");
-			const auto lit = led->GetProperty<Rml::Colourb>("image-color");
-			require(lit != unlit, "MD page LED " + std::to_string(page + 1)
-				+ " has no visible lit style");
-			led->SetClass("lit", false);
+			require(led->IsClassSet("mdScaleDot")
+				&& unlit != Rml::Colourb{}, "MD page LED "
+				+ std::to_string(page + 1) + " has no live scale-dot style");
 		}
 		#endif
 		processor.destroyEditorState();

--- a/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
@@ -100,6 +100,19 @@ int main()
 		require(processor.getConfig().getBoolValue("lcdColorsInverted", false)
 			&& invertButton->isChecked(),
 			"LCD inversion click did not update configuration and UI state");
+		#if !defined(MD_SETTINGS_TEST_MONOMACHINE)
+		for(int page = 0; page < 4; ++page)
+		{
+			auto* const led = editor->findChild(
+				"mdPatternPage" + std::to_string(page), false);
+			require(led != nullptr, "live skin is missing MD page LED "
+				+ std::to_string(page + 1));
+			const auto unlit = led->GetProperty<Rml::Colourb>("image-color");
+			require(led->IsClassSet("mdScaleDot")
+				&& unlit != Rml::Colourb{}, "MD page LED "
+				+ std::to_string(page + 1) + " has no live scale-dot style");
+		}
+		#endif
 		processor.destroyEditorState();
 
 		// Recreating the editor must restore the device-specific setting instead of

--- a/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdSettingsTemplateTest.cpp
@@ -32,6 +32,9 @@ int main()
 	try
 	{
 		juce::ScopedJuceInitialiser_GUI juce;
+		juce::MessageManagerLock messageLock;
+		require(messageLock.lockWasGained(),
+			"could not lock the JUCE message thread for live UI testing");
 
 		#if defined(MD_SETTINGS_TEST_MONOMACHINE)
 		constexpr auto model = md::MachineModel::Monomachine;

--- a/source/elektron/md/mdJucePlugin/mdShiftTriggerLatchTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdShiftTriggerLatchTest.cpp
@@ -212,6 +212,31 @@ namespace
 		expect(!presentation.isLit(0x23, 5),
 			"stale pulse was restamped as a new UI-frame flash");
 
+		// MD 1.63 emits the tempo lamp as an approximately 110 ms pulse once
+		// per 428 ms beat at the factory test pattern's 140 BPM. Preserve that
+		// firmware duty cycle instead of stretching it to a 50/50 blink.
+		md::FrontPanel tempoPanel;
+		mdJucePlugin::FrontPanelLedPresentation tempoPresentation;
+		tempoPresentation.reset(tempoPanel);
+		tempoPresentation.apply({1, 0, 0x23, 0xdf}, 0.0);
+		for(int frame = 0; frame <= 6; ++frame)
+		{
+			tempoPresentation.advance(frame * 16.0);
+			expect(tempoPresentation.isLit(0x23, 5),
+				"real-duration tempo pulse went dark too early");
+		}
+		tempoPresentation.apply({2, 110, 0x23, 0xff}, 110.0);
+		tempoPresentation.advance(112.0);
+		expect(!tempoPresentation.isLit(0x23, 5),
+			"tempo pulse was stretched past the firmware off edge");
+		tempoPresentation.advance(416.0);
+		expect(!tempoPresentation.isLit(0x23, 5),
+			"tempo LED relit before the next firmware beat");
+		tempoPresentation.apply({3, 428, 0x23, 0xdf}, 428.0);
+		tempoPresentation.advance(432.0);
+		expect(tempoPresentation.isLit(0x23, 5),
+			"next tempo beat did not produce a visible pulse");
+
 		const auto recentPulseStart =
 			mdJucePlugin::FrontPanelLedPresentation::eventMilliseconds(
 				now + 3000.0, 3000 * cyclesPerMillisecond,

--- a/source/elektron/md/mdJucePlugin/skins/mdDefault/mdDefault.rcss
+++ b/source/elektron/md/mdJucePlugin/skins/mdDefault/mdDefault.rcss
@@ -394,7 +394,7 @@ body
 }
 
 .mdStepLed.lit, .mdModeLed.lit, .mdSequencerLed.lit,
-.mdModeDot.lit, .mdBankIndicator.lit, .mdTempoLed.lit
+.mdModeDot.lit, .mdBankIndicator.lit, .mdTempoLed.lit, .mdScaleDot.lit
 {
 	image-color: #ee613f;
 }

--- a/source/elektron/md/mdLib/mddevice.cpp
+++ b/source/elektron/md/mdLib/mddevice.cpp
@@ -273,13 +273,23 @@ namespace md
 		const auto plusDrive = m_hardware->copyPlusDriveData();
 		std::vector<uint8_t> factoryBaseline;
 		if(m_hardware->copyFactoryFlashBaseline(factoryBaseline))
-			return encodeState(_state, patchRam, m_hardware->copyFlashData(),
+			return encodeStateWithFactoryBaseline(_state, patchRam,
+				m_hardware->copyFlashData(),
 				factoryBaseline, m_hardware->flashBaseline(), m_model, _type,
 				plusDrive);
 		FlashSectorOverlay pending;
 		if(m_hardware->copyPendingFlashOverlay(pending))
 			return encodeState(_state, patchRam, pending,
 				m_hardware->flashBaseline(), m_model, _type, plusDrive);
+		if(m_hardware->isFirmwareUpdateDirectBoot())
+		{
+			// A host may autosave while the updater is erasing/programming flash. Store
+			// a zero-delta pending image so reopening restarts the updater and eventually
+			// reapplies patch RAM/+Drive, instead of treating a partial flash as final.
+			return encodeStateWithFactoryBaseline(_state, patchRam,
+				m_hardware->flashBaseline(), m_hardware->flashBaseline(),
+				m_hardware->flashBaseline(), m_model, _type, plusDrive);
+		}
 		// If interaction happened before the first machine-local baseline was
 		// captured, preserve a complete flash image. An absolute sector set records
 		// ROM-equal deletions and lets the replacement boot coherently without waiting
@@ -392,13 +402,18 @@ namespace md
 			return false;
 
 		const auto clockPercent = getDspClockPercent();
+		const auto currentPlusDrive = m_hardware->copyPlusDriveData();
+		const bool currentPlusDriveDirty = m_hardware->plusDriveDirty();
 		if(!_prepared.m_containsPlusDrive)
 		{
-			const auto plusDrive = m_hardware->copyPlusDriveData();
 			if(!_prepared.m_hardware->replacePlusDriveData(
-				plusDrive, m_hardware->plusDriveDirty()))
+				currentPlusDrive, currentPlusDriveDirty))
 				return false;
 		}
+		else if(currentPlusDriveDirty
+			&& _prepared.m_hardware->copyPlusDriveData() == currentPlusDrive
+			&& !_prepared.m_hardware->replacePlusDriveData(currentPlusDrive, true))
+			return false;
 		_prepared.m_hardware->getDspMixer().getPeriph().getEssiClock()
 			.setSpeedPercent(clockPercent);
 		if(m_model == MachineModel::Machinedrum && !_prepared.m_containsFlash)

--- a/source/elektron/md/mdLib/mddsp.cpp
+++ b/source/elektron/md/mdLib/mddsp.cpp
@@ -260,7 +260,13 @@ namespace md
 		constexpr uint32_t receiveEntry = 0x14ffcb;
 		const uint64_t readyStop = m_dsp.getCycles() + 5'000'000;
 		while(m_dsp.getPC().toWord() != receiveEntry && m_dsp.getCycles() < readyStop)
-			m_dsp.exec();
+		{
+			if(!m_hardware.schedExecDsp(*this, m_index))
+			{
+				_error = "DSP resident loader halted before its receive loop";
+				return false;
+			}
+		}
 		if(m_dsp.getPC().toWord() != receiveEntry)
 		{
 			_error = "DSP resident loader did not reach its receive loop (PC "
@@ -272,7 +278,13 @@ namespace md
 		{
 			const uint64_t stop = m_dsp.getCycles() + 1'000'000;
 			while(hdi08().hasRXData() && m_dsp.getCycles() < stop)
-				m_dsp.exec();
+			{
+				if(!m_hardware.schedExecDsp(*this, m_index))
+				{
+					_error = "DSP resident loader halted while accepting data";
+					return false;
+				}
+			}
 			if(hdi08().hasRXData())
 			{
 				_error = "DSP resident loader stopped accepting data after word "
@@ -282,7 +294,13 @@ namespace md
 			hdi08().writeRX(&_word, 1);
 			const uint64_t settleStop = m_dsp.getCycles() + 512;
 			while(m_dsp.getCycles() < settleStop)
-				m_dsp.exec();
+			{
+				if(!m_hardware.schedExecDsp(*this, m_index))
+				{
+					_error = "DSP resident loader halted after receiving data";
+					return false;
+				}
+			}
 			++sentWords;
 			return true;
 		};
@@ -292,7 +310,13 @@ namespace md
 				return false;
 			const uint64_t stop = m_dsp.getCycles() + 1'000'000;
 			while(!hdi08().hasTX() && m_dsp.getCycles() < stop)
-				m_dsp.exec();
+			{
+				if(!m_hardware.schedExecDsp(*this, m_index))
+				{
+					_error = "DSP resident loader halted before acknowledging a command";
+					return false;
+				}
+			}
 			if(!hdi08().hasTX() || hdi08().readTX() != _command)
 			{
 				_error = "DSP resident loader did not acknowledge a memory command";
@@ -412,7 +436,10 @@ namespace md
 			while(!hdi08().hasTX()
 				&& (hdi08().hostCommandBusy() || dsp().hasPendingInterrupts())
 				&& m_dsp.getCycles() < clampStop)
-				m_dsp.exec();
+			{
+				if(!m_hardware.schedExecDsp(*this, m_index))
+					break;
+			}
 			hdiTransferDSPtoUC();
 			return;
 		}
@@ -464,7 +491,10 @@ namespace md
 					const uint64_t clampStop = m_dsp.getCycles() + schedInlineClamp();
 					while(m_dsp.memory().get(dsp56k::MemArea_Y, 0x123) == targetHandle
 						&& m_dsp.getCycles() < clampStop)
-						m_dsp.exec();
+					{
+						if(!m_hardware.schedExecDsp(*this, m_index))
+							return;
+					}
 				}
 			}
 			if(++m_mmParamBlockWord >= 52)
@@ -477,7 +507,10 @@ namespace md
 		// wait or an unbounded host-side FIFO.
 		const uint64_t clampStop = m_dsp.getCycles() + schedInlineClamp();
 		while(hdi08().hasRXData() && m_dsp.getCycles() < clampStop)
-			m_dsp.exec();
+		{
+			if(!m_hardware.schedExecDsp(*this, m_index))
+				return;
+		}
 		hdi08().writeRX(&_word, 1);
 		return;
 	}
@@ -491,7 +524,10 @@ namespace md
 
 		const uint64_t clampStop = m_dsp.getCycles() + schedInlineClamp();
 		while(hdi08().hostCommandBusy() && m_dsp.getCycles() < clampStop)
-			m_dsp.exec();
+		{
+			if(!m_hardware.schedExecDsp(*this, m_index))
+				return;
+		}
 		return;
 	}
 
@@ -527,7 +563,10 @@ namespace md
 		{
 			const uint64_t clampStop = m_dsp.getCycles() + schedInlineClamp() * 4;
 			while(!hdi08().rxData().empty() && m_dsp.getCycles() < clampStop)
-				m_dsp.exec();
+			{
+				if(!m_hardware.schedExecDsp(*this, m_index))
+					return;
+			}
 		}
 
 		if(!booted())

--- a/source/elektron/md/mdLib/mdflash.h
+++ b/source/elektron/md/mdLib/mdflash.h
@@ -20,7 +20,20 @@ namespace md
 
 		static constexpr uint16_t g_manufacturerId = 0x0020;
 		static constexpr uint16_t g_deviceId = 0x22fd;
+		// M29W640FB bottom-boot geometry: the first 64 KiB is split into eight
+		// 8 KiB boot/parameter blocks; the remaining erase blocks are 64 KiB.
+		static constexpr uint32_t g_bootSectorLimit = 0x10000;
+		static constexpr uint32_t g_bootSectorSize = 0x2000;
 		static constexpr uint32_t g_sectorSize = 0x10000;
+		static constexpr uint32_t eraseSectorSize(const uint32_t _offset)
+		{
+			return _offset < g_bootSectorLimit ? g_bootSectorSize : g_sectorSize;
+		}
+		static constexpr uint32_t eraseSectorBegin(const uint32_t _offset)
+		{
+			const auto size = eraseSectorSize(_offset);
+			return _offset & ~(size - 1);
+		}
 
 		std::optional<Operation> write16(uint32_t _offset, uint16_t _value);
 		std::optional<uint16_t> read16(uint32_t _offset) const;

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -115,15 +115,19 @@ namespace md
 		: m_model(_model)
 		, m_rom(initRom(_romData, _romName, _model, _syntheticProfile))
 		, m_firmwareFingerprint(_syntheticProfile ? 0 : fingerprintRom(m_rom.data()))
+		, m_firmwareUpdateDirectBoot(!_syntheticProfile
+			&& firmwareUpdate::isConvertedRom(m_rom.data())
+			&& _initialUserFlash.empty() && _factoryFlashCache.empty())
 		// A cold UW flash or a blank project-owned +Drive can make the firmware ask
 		// for the same one-time power cycle. A restored project has both images.
 		, m_factoryFlashInitializationExpected(!_syntheticProfile
 			&& _model == MachineModel::Machinedrum
 			&& ((_factoryFlashCache.empty() && _initialUserFlash.empty())
-				|| _initialPlusDrive.empty()))
+				|| PlusDrive::isBlankStorage(_initialPlusDrive)))
 		, m_uc(m_rom, m_model, initPatchRam(m_rom,
 			_pendingFlashOverlay.valid ? std::vector<uint8_t>{} : _initialPatchRam),
-			initMainRam(m_rom), _initialUserFlash, _initialPlusDrive, _plusDriveEnabled)
+			m_firmwareUpdateDirectBoot ? initMainRam(m_rom) : std::vector<uint8_t>{},
+			_initialUserFlash, _initialPlusDrive, _plusDriveEnabled)
 		// A complete project image can boot directly without a local factory cache,
 		// but it must never become the machine-local factory baseline itself.
 		, m_externalInteraction(_model == MachineModel::Machinedrum
@@ -544,8 +548,7 @@ namespace md
 			});
 		}
 
-		const bool firmwareUpdateBoot = firmwareUpdate::isConvertedRom(m_rom.data());
-		if(firmwareUpdateBoot)
+		if(m_firmwareUpdateDirectBoot)
 		{
 			std::vector<uint8_t> mixer;
 			std::vector<uint8_t> producer;
@@ -574,20 +577,48 @@ namespace md
 			// initialization before starting the already-expanded OS directly.
 			const uint64_t updateDspLeadCycles = isMonomachine()
 				? 173'400'000u : 335'100'000u;
+			std::array<uint32_t, 2> leadNoProgress{};
+			const auto executeLeadStep = [this, &leadNoProgress](Dsp& _dsp,
+				const uint32_t _index)
+			{
+				const auto before = _dsp.dsp().getCycles();
+				if(!schedExecDsp(_dsp, _index))
+					return false;
+				if(_dsp.dsp().getCycles() != before)
+				{
+					leadNoProgress[_index] = 0;
+					return true;
+				}
+				// One retry may be needed while a non-MMU JIT dispatch table grows.
+				// A sustained no-cycle loop is not runnable updater firmware.
+				if(++leadNoProgress[_index] < 1024)
+					return true;
+				m_schedDspExecutionFaultIndex = _index;
+				m_schedDspExecutionFaultPc = _dsp.dsp().getPC().toWord();
+				m_schedDspExecutionFault.store(true, std::memory_order_release);
+				return false;
+			};
 			while(m_dspMixer.dsp().getCycles() < updateDspLeadCycles
 				|| m_dspProducer.dsp().getCycles() < updateDspLeadCycles)
 			{
-				if(m_dspMixer.dsp().getCycles() <= m_dspProducer.dsp().getCycles())
-					m_dspMixer.dsp().exec();
-				else
-					m_dspProducer.dsp().exec();
+				const auto index = m_dspMixer.dsp().getCycles()
+					<= m_dspProducer.dsp().getCycles() ? 0u : 1u;
+				auto& dsp = index == 0 ? m_dspMixer : m_dspProducer;
+				if(!executeLeadStep(dsp, index))
+				{
+					std::fprintf(stderr,
+						"[MD/MM] updater DSP%u stopped at PC %06x during startup\n",
+						index + 1, m_schedDspExecutionFaultPc);
+					m_rom.invalidate();
+					return;
+				}
 			}
 			m_uc.getSim().prepareFirmwareUpdateBoot(isMonomachine());
 		}
 
 		// Load SP/PC from the reset vectors before scheduled UC execution starts.
 		m_uc.reset();
-		if(firmwareUpdateBoot)
+		if(m_firmwareUpdateDirectBoot)
 		{
 			uint32_t factoryAddress = 0;
 			if(!firmwareUpdate::factoryFlashAddress(m_rom.data(), factoryAddress))
@@ -606,13 +637,28 @@ namespace md
 	bool Hardware::isValid() const
 	{
 		return m_rom.isValid()
-			&& !m_pendingFlashRestoreFailed.load(std::memory_order_acquire);
+			&& !m_pendingFlashRestoreFailed.load(std::memory_order_acquire)
+			&& !hasDspExecutionFault();
 	}
 
 	std::vector<uint8_t> Hardware::copyPatchRam() const
 	{
 		std::lock_guard lock(m_factoryFlashMutex);
 		return m_pendingFlashOverlay.valid ? m_pendingPatchRam : m_uc.copyPatchRam();
+	}
+
+	bool Hardware::installStartupPlusDriveData(const std::vector<uint8_t>& _data)
+	{
+		if(!m_uc.replacePlusDriveData(_data, false))
+			return false;
+		// A validated factory cache plus a nonblank standalone checkpoint is already
+		// a complete cold-start image. Do not schedule a redundant reboot merely
+		// because the checkpoint became available just after construction.
+		if(m_model == MachineModel::Machinedrum && !m_firmwareUpdateDirectBoot
+			&& m_factoryFlashReady.load(std::memory_order_acquire)
+			&& !PlusDrive::isBlankStorage(_data))
+			m_factoryFlashInitializationExpected = false;
+		return true;
 	}
 
 	void Hardware::advanceFactoryFlashCapture()
@@ -1146,6 +1192,8 @@ namespace md
 
 	bool Hardware::schedStep()
 	{
+		if(hasDspExecutionFault())
+			return false;
 		const double ucPerFrame   = schedUcCyclesPerFrame();
 		const double quantumFrames= schedQuantumFrames(m_model);
 		const uint64_t clampCycles= schedClampCycles();
@@ -1225,12 +1273,27 @@ namespace md
 			const uint64_t clampStop = startCyc + clampCycles;
 			const uint64_t stopCyc = std::min(targetCyc, clampStop);
 			if(m_schedBoundedJit)
+			{
+				const auto cycles = d.dsp().getCycles();
 				d.dsp().execUntilCycles(stopCyc);
+				if(d.dsp().getCycles() == cycles
+					&& d.dsp().getPC().toWord() >= 0x800000u)
+				{
+					m_schedDspExecutionFaultIndex = idx;
+					m_schedDspExecutionFaultPc = d.dsp().getPC().toWord();
+					m_schedDspExecutionFault.store(true, std::memory_order_release);
+					return false;
+				}
+			}
 			else
 			{
-				d.dsp().exec();
+				if(!schedExecDsp(d, idx))
+					return false;
 				while(d.dsp().getCycles() < stopCyc)
-					d.dsp().exec();
+				{
+					if(!schedExecDsp(d, idx))
+						return false;
+				}
 			}
 			if(who == 1)
 				schedDrainCodecOutput();			// keep the mixer ESSI1 output ring shallow
@@ -1238,6 +1301,30 @@ namespace md
 
 
 
+		return true;
+	}
+
+	bool Hardware::schedExecDsp(Dsp& _dsp, const uint32_t _dspIndex)
+	{
+		const auto recordFault = [this, _dspIndex](const uint32_t _pc)
+		{
+			m_schedDspExecutionFaultIndex = _dspIndex;
+			m_schedDspExecutionFaultPc = _pc;
+			m_schedDspExecutionFault.store(true, std::memory_order_release);
+		};
+		const auto before = _dsp.dsp().getPC().toWord();
+		if(before >= 0x800000u)
+		{
+			recordFault(before);
+			return false;
+		}
+		_dsp.dsp().exec();
+		const auto after = _dsp.dsp().getPC().toWord();
+		if(after >= 0x800000u)
+		{
+			recordFault(after);
+			return false;
+		}
 		return true;
 	}
 
@@ -1266,7 +1353,10 @@ namespace md
 		const bool s_mmBp = isMonomachine();
 		while(d.dsp().getCycles() < targetCyc && d.dsp().getCycles() < clampStop
 			&& (!s_mmBp || d.hostTxBacklog() <= 4))
-			d.dsp().exec();
+		{
+			if(!schedExecDsp(d, i))
+				return;
+		}
 	}
 
 	void Hardware::schedCatchUpDspToDsp(const uint32_t _consumer, const uint32_t _producer)
@@ -1305,7 +1395,10 @@ namespace md
 		const bool bpGate = isMonomachine();
 		while(d.dsp().getCycles() < targetCyc && d.dsp().getCycles() < clampStop
 			&& (!bpGate || d.hostTxBacklog() <= 4))
-			d.dsp().exec();
+		{
+			if(!schedExecDsp(d, c))
+				break;
+		}
 		m_schedInLinkDelivery = false;
 	}
 

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -104,6 +104,10 @@ namespace md
 		{
 			return m_uc.replacePlusDriveData(_data, _dirty);
 		}
+		// Standalone checkpoints are discovered after processor construction but
+		// before audio starts. Installing one must update the first-run decision that
+		// was initially made against an empty drive.
+		bool installStartupPlusDriveData(const std::vector<uint8_t>& _data);
 		bool plusDriveDirty() const { return m_uc.plusDriveDirty(); }
 		uint64_t plusDriveGeneration() const { return m_uc.plusDriveGeneration(); }
 		void markPlusDrivePersisted(const uint64_t _generation)
@@ -121,6 +125,16 @@ namespace md
 		{
 			return m_factoryFlashInitializationExpected;
 		}
+		bool isFirmwareUpdateDirectBoot() const
+		{
+			return m_firmwareUpdateDirectBoot;
+		}
+		bool hasDspExecutionFault() const
+		{
+			return m_schedDspExecutionFault.load(std::memory_order_acquire);
+		}
+		uint32_t dspExecutionFaultIndex() const { return m_schedDspExecutionFaultIndex; }
+		uint32_t dspExecutionFaultPc() const { return m_schedDspExecutionFaultPc; }
 		bool isFactoryFlashReadyForReboot() const
 		{
 			return m_factoryFlashReady.load(std::memory_order_acquire)
@@ -233,6 +247,7 @@ namespace md
 		}
 
 	private:
+		friend class Dsp;
 		friend struct ProfileWorkloadAccess;
 		Hardware(bool _syntheticProfile, const std::vector<uint8_t>& _romData,
 			const std::string& _romName, MachineModel _model,
@@ -259,7 +274,8 @@ namespace md
 		const MachineModel m_model;
 		Rom m_rom;
 		const uint64_t m_firmwareFingerprint;
-		const bool m_factoryFlashInitializationExpected;
+		const bool m_firmwareUpdateDirectBoot;
+		bool m_factoryFlashInitializationExpected;
 		uint64_t m_firmwareUpdateMainFingerprint = 0;
 		size_t m_firmwareUpdateMainSize = 0;
 		Microcontroller m_uc;
@@ -285,6 +301,11 @@ namespace md
 		FrontPanel m_frontPanel;	// writer-owned UART2 LCD/LED decoder
 		std::shared_ptr<FrontPanelPublisher> m_frontPanelPublisher;
 		TurboMidiTransfer m_midiSysexTransfer;
+		// Dsp construction consults Hardware::isValid(), so these fields must be
+		// initialized before either Dsp member below.
+		std::atomic<bool> m_schedDspExecutionFault{false};
+		uint32_t m_schedDspExecutionFaultIndex = 0;
+		uint32_t m_schedDspExecutionFaultPc = 0;
 		Dsp m_dspMixer;		// index 0 = DSP1 (0x500000), receives the ring, drives the DAC
 		Dsp m_dspProducer;	// index 1 = DSP2 (0x600000), produces voices into the ring
 
@@ -304,6 +325,7 @@ namespace md
 		// advance() in mdhardware.cpp for the loop and timing constants.
 		// ---------------------------------------------------------------------------------------
 		bool     schedStep();					// one advance() event-loop iteration; false once all caught up
+		bool     schedExecDsp(Dsp& _dsp, uint32_t _dspIndex);
 		double   schedDspFramePos(uint32_t _dspIndex);	// a runnable DSP's machine-frame position
 		void     schedDrainCodecOutput();		// pop the mixer ESSI1 output ring so its TX never blocks
 		void     schedCatchUpDspToDsp(uint32_t _consumer, uint32_t _producer);

--- a/source/elektron/md/mdLib/mdmc.cpp
+++ b/source/elektron/md/mdLib/mdmc.cpp
@@ -729,10 +729,10 @@ namespace md
 					}
 					else if(operation->type == FlashCommandDecoder::Operation::Type::EraseSector)
 					{
-						const auto begin = operation->offset
-							& ~(FlashCommandDecoder::g_sectorSize - 1);
+						const auto begin = FlashCommandDecoder::eraseSectorBegin(
+							operation->offset);
 						const auto end = std::min<uint32_t>(begin
-							+ FlashCommandDecoder::g_sectorSize,
+							+ FlashCommandDecoder::eraseSectorSize(operation->offset),
 							static_cast<uint32_t>(m_flashData.size()));
 						if(begin < end)
 						{

--- a/source/elektron/md/mdLib/mdplusdrive.cpp
+++ b/source/elektron/md/mdLib/mdplusdrive.cpp
@@ -134,6 +134,13 @@ namespace md
 		return true;
 	}
 
+	bool PlusDrive::isBlankStorage(const std::vector<uint8_t>& _data)
+	{
+		return _data.empty() || (validateStorage(_data)
+			&& _data.size() == g_storageHeaderSize
+			&& readBe32(_data.data() + 12) == 0);
+	}
+
 	bool PlusDrive::replaceStorage(const std::vector<uint8_t>& _data, const bool _dirty)
 	{
 		if(_data.empty())
@@ -143,6 +150,8 @@ namespace md
 				m_sectors.clear();
 				storageChanged(_dirty);
 			}
+			else if(_dirty && !storageDirty())
+				storageChanged(true);
 			else if(!_dirty)
 				m_persistedGeneration = m_storageGeneration;
 			return true;
@@ -167,6 +176,8 @@ namespace md
 			m_sectors = std::move(sectors);
 			storageChanged(_dirty);
 		}
+		else if(_dirty && !storageDirty())
+			storageChanged(true);
 		else if(!_dirty)
 			m_persistedGeneration = m_storageGeneration;
 		return true;

--- a/source/elektron/md/mdLib/mdplusdrive.h
+++ b/source/elektron/md/mdLib/mdplusdrive.h
@@ -33,6 +33,7 @@ namespace md
 		{
 			return validateStorage(_data.data(), _data.size());
 		}
+		static bool isBlankStorage(const std::vector<uint8_t>& _data);
 		bool replaceStorage(const std::vector<uint8_t>& _data, bool _dirty = false);
 		bool storageDirty() const { return m_storageGeneration != m_persistedGeneration; }
 		uint64_t storageGeneration() const { return m_storageGeneration; }

--- a/source/elektron/md/mdLib/mdstate.cpp
+++ b/source/elektron/md/mdLib/mdstate.cpp
@@ -287,6 +287,22 @@ namespace md
 			_plusDrive);
 	}
 
+	bool encodeStateWithFactoryBaseline(std::vector<uint8_t>& _state,
+		const std::vector<uint8_t>& _patchRam,
+		const std::vector<uint8_t>& _flashData,
+		const std::vector<uint8_t>& _factoryFlashBaseline,
+		const std::vector<uint8_t>& _romBaseline,
+		const MachineModel _model, const synthLib::StateType _type,
+		const std::vector<uint8_t>& _plusDrive)
+	{
+		FlashSectorOverlay overlay;
+		if(!makeFlashOverlay(overlay, _flashData, _factoryFlashBaseline,
+			_romBaseline, false))
+			return false;
+		return encodeState(_state, _patchRam, overlay, _romBaseline, _model, _type,
+			_plusDrive);
+	}
+
 	bool encodeState(std::vector<uint8_t>& _state,
 		const std::vector<uint8_t>& _patchRam,
 		const FlashSectorOverlay& _flashOverlay,

--- a/source/elektron/md/mdLib/mdstate.h
+++ b/source/elektron/md/mdLib/mdstate.h
@@ -53,6 +53,16 @@ namespace md
 		const std::vector<uint8_t>& _romBaseline,
 		MachineModel _model, synthLib::StateType _type,
 		const std::vector<uint8_t>& _plusDrive = {});
+	// Use this variant when a validated machine-local factory cache exists. It
+	// remains sparse even when the initialized bytes happen to equal the ROM;
+	// byte equality alone must not be mistaken for the no-cache fallback case.
+	bool encodeStateWithFactoryBaseline(std::vector<uint8_t>& _state,
+		const std::vector<uint8_t>& _patchRam,
+		const std::vector<uint8_t>& _flashData,
+		const std::vector<uint8_t>& _factoryFlashBaseline,
+		const std::vector<uint8_t>& _romBaseline,
+		MachineModel _model, synthLib::StateType _type,
+		const std::vector<uint8_t>& _plusDrive = {});
 	bool encodeState(std::vector<uint8_t>& _state, const std::vector<uint8_t>& _patchRam,
 		const FlashSectorOverlay& _flashOverlay,
 		const std::vector<uint8_t>& _romBaseline,

--- a/source/elektron/md/mdLib/test/mdfirmwareupdate_test.cpp
+++ b/source/elektron/md/mdLib/test/mdfirmwareupdate_test.cpp
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <fstream>
 #include <iterator>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -448,22 +449,29 @@ namespace
 			return false;
 		}
 
-		md::Hardware fresh(_rom, _name, md::MachineModel::Machinedrum,
-			device.getHardware().copyPatchRam(), {}, {},
-			device.getHardware().copyFlashData(), finalCache, {}, formattedDrive);
-		if(!fresh.isValid() || fresh.isFirmwareUpdateDirectBoot()
-			|| fresh.isFactoryFlashInitializationExpected())
+		auto fresh = std::make_unique<md::Hardware>(
+			_rom, _name, md::MachineModel::Machinedrum,
+			device.getHardware().copyPatchRam(),
+			std::shared_ptr<md::FrontPanelPublisher>{},
+			std::shared_ptr<md::MidiSysexTransferProgressPublisher>{},
+			device.getHardware().copyFlashData(), finalCache,
+			md::FlashSectorOverlay{}, formattedDrive);
+		if(!fresh->isValid() || fresh->isFirmwareUpdateDirectBoot()
+			|| fresh->isFactoryFlashInitializationExpected())
 		{
 			std::fputs("fresh initialized instance re-entered updater preparation\n",
 				stderr);
 			return false;
 		}
-		md::Hardware lateCheckpoint(_rom, _name, md::MachineModel::Machinedrum,
-			device.getHardware().copyPatchRam(), {}, {},
+		auto lateCheckpoint = std::make_unique<md::Hardware>(
+			_rom, _name, md::MachineModel::Machinedrum,
+			device.getHardware().copyPatchRam(),
+			std::shared_ptr<md::FrontPanelPublisher>{},
+			std::shared_ptr<md::MidiSysexTransferProgressPublisher>{},
 			device.getHardware().copyFlashData(), finalCache);
-		if(!lateCheckpoint.isFactoryFlashInitializationExpected()
-			|| !lateCheckpoint.installStartupPlusDriveData(formattedDrive)
-			|| lateCheckpoint.isFactoryFlashInitializationExpected())
+		if(!lateCheckpoint->isFactoryFlashInitializationExpected()
+			|| !lateCheckpoint->installStartupPlusDriveData(formattedDrive)
+			|| lateCheckpoint->isFactoryFlashInitializationExpected())
 		{
 			std::fputs("late standalone checkpoint scheduled a redundant first-run reboot\n",
 				stderr);
@@ -542,8 +550,8 @@ int main(const int _argc, char** const _argv)
 		std::printf("mdfirmwareupdate_test: PASS (Machinedrum two-stage updater lifecycle)\n");
 		return 0;
 	}
-	md::Hardware hardware(rom, _argv[1], model);
-	if(!hardware.isValid())
+	auto hardware = std::make_unique<md::Hardware>(rom, _argv[1], model);
+	if(!hardware->isValid())
 	{
 		std::fputs("direct boot initialization failed\n", stderr);
 		return 1;
@@ -551,15 +559,15 @@ int main(const int _argc, char** const _argv)
 	const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(20);
 	for(;;)
 	{
-		const auto panel = hardware.getFrontPanelSnapshot();
+		const auto panel = hardware->getFrontPanelSnapshot();
 		if(panel.countLitPixels() > 2000
 			|| (panel.getTileWriteCount() >= 64 && panel.countLitPixels() >= 100))
 			break;
-		hardware.advance(64);
+		hardware->advance(64);
 		if(std::chrono::steady_clock::now() >= deadline)
 		{
 			std::fprintf(stderr, "boot did not reach the front panel: uc=%08x\n",
-				hardware.getUC().getPC());
+				hardware->getUC().getPC());
 			return 1;
 		}
 	}
@@ -573,9 +581,9 @@ int main(const int _argc, char** const _argv)
 			std::fputs("user-data SysEx failed stream validation\n", stderr);
 			return 1;
 		}
-		const auto waveBankBefore = fingerprintDigiProBank(hardware);
+		const auto waveBankBefore = fingerprintDigiProBank(*hardware);
 		auto prepared = md::prepareMidiSysexTransfer(std::move(transferBytes));
-		if(!prepared || !hardware.startMidiSysexTransfer(*prepared))
+		if(!prepared || !hardware->startMidiSysexTransfer(*prepared))
 		{
 			std::fputs("converted Monomachine transfer did not start\n", stderr);
 			return 1;
@@ -585,8 +593,8 @@ int main(const int _argc, char** const _argv)
 		uint8_t payloadSpeed = 1;
 		for(;;)
 		{
-			hardware.advance(64);
-			const auto progress = hardware.getMidiSysexTransferProgress();
+			hardware->advance(64);
+			const auto progress = hardware->getMidiSysexTransferProgress();
 			if(progress.state == md::MidiSysexTransferState::Sending)
 				payloadSpeed = progress.speedCode;
 			if(progress.state == md::MidiSysexTransferState::Complete)
@@ -597,12 +605,12 @@ int main(const int _argc, char** const _argv)
 				return 1;
 			}
 		}
-		auto waveBankAfter = fingerprintDigiProBank(hardware);
+		auto waveBankAfter = fingerprintDigiProBank(*hardware);
 		std::printf("Monomachine user-data transfer: %sx, DigiPRO=%016llx -> %016llx\n",
 			md::midiTurboSpeedLabel(payloadSpeed),
 			static_cast<unsigned long long>(waveBankBefore),
 			static_cast<unsigned long long>(waveBankAfter));
-		writeLcdPgm(hardware);
+		writeLcdPgm(*hardware);
 		// This harness deliberately does not navigate a private firmware menu.
 		// Completion proves hardware-boundary delivery only; installation belongs
 		// to a separate panel-driven integration test.

--- a/source/elektron/md/mdLib/test/mdfirmwareupdate_test.cpp
+++ b/source/elektron/md/mdLib/test/mdfirmwareupdate_test.cpp
@@ -1,10 +1,13 @@
 #include "mdLib/mdflash.h"
+#include "mdLib/mddevice.h"
 #include "mdLib/mdfirmwareupdate.h"
 #include "mdLib/mdhardware.h"
 #include "mdLib/mdmmwaveforms.h"
+#include "mdLib/mdplusdrive.h"
 #include "mdLib/mdromloader.h"
 #include "mdLib/mdsysextransfer.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdlib>
 #include <cstdio>
@@ -301,6 +304,173 @@ namespace
 				output.put(panel.getLcdPixel(x, y) ? '\0' : '\xff');
 		}
 	}
+
+	bool checkMachinedrumUpdaterLifecycle(const std::vector<uint8_t>& _rom,
+		const std::string& _name)
+	{
+		synthLib::DeviceCreateParams params;
+		params.romData = _rom;
+		params.romName = _name;
+		params.customData = md::deviceCustomData(md::MachineModel::Machinedrum);
+		md::Device device(params);
+		if(!device.isValid() || !device.getHardware().isFirmwareUpdateDirectBoot())
+		{
+			std::fputs("user-supplied updater did not enter its initial direct boot\n", stderr);
+			return false;
+		}
+		// DAWs may autosave immediately after constructing the plug-in. Reopening
+		// that state must restart the updater, not boot the partially programmed
+		// flash image that happened to exist at the autosave instant.
+		std::vector<uint8_t> earlyState;
+		md::Device reopened(params);
+		if(!device.getState(earlyState, synthLib::StateTypeGlobal)
+			|| !reopened.setState(earlyState, synthLib::StateTypeGlobal)
+			|| !reopened.isValid()
+			|| !reopened.getHardware().isFirmwareUpdateDirectBoot()
+			|| !reopened.getHardware().isProjectStateRestorePending())
+		{
+			std::fputs("updater autosave did not reopen as a resumable initialization\n",
+				stderr);
+			return false;
+		}
+
+		const auto advanceUntil = [&](const auto& _ready,
+			const std::chrono::seconds _timeout)
+		{
+			const auto deadline = std::chrono::steady_clock::now() + _timeout;
+			while(!_ready(device.getHardware()))
+			{
+				device.getHardware().advance(256);
+				if(device.getHardware().hasDspExecutionFault())
+				{
+					std::fprintf(stderr, "DSP%u halted at PC %06x during updater lifecycle\n",
+						device.getHardware().dspExecutionFaultIndex() + 1,
+						device.getHardware().dspExecutionFaultPc());
+					return false;
+				}
+				if(std::chrono::steady_clock::now() >= deadline)
+					return false;
+			}
+			return true;
+		};
+
+		if(!advanceUntil([](const md::Hardware& hardware)
+			{
+				return hardware.isFactoryFlashReadyForReboot();
+			}, std::chrono::seconds(120)))
+		{
+			std::fputs("updater flash did not settle for its first restart\n", stderr);
+			return false;
+		}
+		if(device.getHardware().isPlusDriveReadyForFactoryReboot())
+		{
+			std::fputs("updater incorrectly prepared +Drive before its first restart\n",
+				stderr);
+			return false;
+		}
+
+		const auto installedFlash = device.getHardware().copyFlashData();
+		const auto firstCache = device.getHardware().copyFactoryFlashCache();
+		// Installing the bootstrap must preserve the updater payload region that
+		// follows the blocks it deliberately erased.
+		if(installedFlash.size() < md::g_uwFlashSectorSize
+			|| !std::equal(_rom.begin() + 0x4000,
+				_rom.begin() + md::g_uwFlashSectorSize,
+				installedFlash.begin() + 0x4000))
+		{
+			std::fputs("updater bootstrap erased its preserved flash payload\n", stderr);
+			return false;
+		}
+		std::vector<uint8_t> firstState;
+		const auto firstDrive = device.getHardware().copyPlusDriveData();
+		if(firstCache.empty()
+			|| !device.getHardware().replacePlusDriveData(firstDrive, true)
+			|| !device.getHardware().plusDriveDirty()
+			|| !device.getState(firstState, synthLib::StateTypeGlobal))
+		{
+			std::fputs("could not capture installed updater state\n", stderr);
+			return false;
+		}
+		auto firstRestart = md::Device::prepareState(device.getPreparationContext(),
+			firstState, synthLib::StateTypeGlobal, firstCache);
+		if(!firstRestart || !device.commitPreparedState(*firstRestart)
+			|| device.hardwareEpoch() != 2
+			|| !device.getHardware().plusDriveDirty())
+		{
+			std::fputs("first updater restart transaction failed\n", stderr);
+			return false;
+		}
+		auto& coldBoot = device.getHardware();
+		if(coldBoot.isFirmwareUpdateDirectBoot()
+			|| !coldBoot.isFactoryFlashInitializationExpected()
+			|| coldBoot.copyFlashData() != installedFlash)
+		{
+			std::fputs("first restart did not cold-boot the installed flash\n", stderr);
+			return false;
+		}
+
+		if(!advanceUntil([](const md::Hardware& hardware)
+			{
+				return hardware.isAudioReady()
+					&& hardware.isFactoryFlashReadyForReboot()
+					&& hardware.isPlusDriveReadyForFactoryReboot();
+			}, std::chrono::seconds(120)))
+		{
+			std::fputs("post-updater DSP/+Drive preparation did not finish\n", stderr);
+			return false;
+		}
+
+		const auto formattedDrive = device.getHardware().copyPlusDriveData();
+		const auto finalCache = device.getHardware().copyFactoryFlashCache();
+		std::vector<uint8_t> finalState;
+		if(md::PlusDrive::isBlankStorage(formattedDrive) || finalCache.empty()
+			|| !device.getState(finalState, synthLib::StateTypeGlobal))
+		{
+			std::fputs("post-updater storage was not ready for final restart\n", stderr);
+			return false;
+		}
+		auto finalRestart = md::Device::prepareState(device.getPreparationContext(),
+			finalState, synthLib::StateTypeGlobal, finalCache);
+		if(!finalRestart || !device.commitPreparedState(*finalRestart)
+			|| device.hardwareEpoch() != 3
+			|| device.getHardware().isFirmwareUpdateDirectBoot()
+			|| device.getHardware().isFactoryFlashInitializationExpected())
+		{
+			std::fputs("final post-updater restart transaction failed\n", stderr);
+			return false;
+		}
+		if(!advanceUntil([](const md::Hardware& hardware)
+			{
+				return hardware.isAudioReady();
+			}, std::chrono::seconds(120)))
+		{
+			std::fputs("final post-updater DSP boot did not become ready\n", stderr);
+			return false;
+		}
+
+		md::Hardware fresh(_rom, _name, md::MachineModel::Machinedrum,
+			device.getHardware().copyPatchRam(), {}, {},
+			device.getHardware().copyFlashData(), finalCache, {}, formattedDrive);
+		if(!fresh.isValid() || fresh.isFirmwareUpdateDirectBoot()
+			|| fresh.isFactoryFlashInitializationExpected())
+		{
+			std::fputs("fresh initialized instance re-entered updater preparation\n",
+				stderr);
+			return false;
+		}
+		md::Hardware lateCheckpoint(_rom, _name, md::MachineModel::Machinedrum,
+			device.getHardware().copyPatchRam(), {}, {},
+			device.getHardware().copyFlashData(), finalCache);
+		if(!lateCheckpoint.isFactoryFlashInitializationExpected()
+			|| !lateCheckpoint.installStartupPlusDriveData(formattedDrive)
+			|| lateCheckpoint.isFactoryFlashInitializationExpected())
+		{
+			std::fputs("late standalone checkpoint scheduled a redundant first-run reboot\n",
+				stderr);
+			return false;
+		}
+		return true;
+	}
 }
 
 int main(const int _argc, char** const _argv)
@@ -364,6 +534,13 @@ int main(const int _argc, char** const _argv)
 					static_cast<std::streamsize>(mainOs.size()));
 			}
 		}
+	}
+	if(converted && model == md::MachineModel::Machinedrum)
+	{
+		if(!checkMachinedrumUpdaterLifecycle(rom, _argv[1]))
+			return 1;
+		std::printf("mdfirmwareupdate_test: PASS (Machinedrum two-stage updater lifecycle)\n");
+		return 0;
 	}
 	md::Hardware hardware(rom, _argv[1], model);
 	if(!hardware.isValid())

--- a/source/elektron/md/mdLib/test/mdflash_test.cpp
+++ b/source/elektron/md/mdLib/test/mdflash_test.cpp
@@ -86,6 +86,46 @@ int main()
 	}
 
 	md::Microcontroller md(rom, md::MachineModel::Machinedrum);
+	constexpr uint32_t firstBootBlock = g_flashBase;
+	constexpr uint32_t bootBlock = g_flashBase + 0x2000;
+	constexpr uint32_t adjacentBootBlock = g_flashBase + 0x4000;
+	constexpr uint32_t finalBootBlock = g_flashBase + 0xe000;
+	constexpr uint32_t firstRegularBlock = g_flashBase + 0x10000;
+	constexpr uint32_t adjacentRegularBlock = g_flashBase + 0x20000;
+	program(md, firstBootBlock + 0x12, 0x1111);
+	program(md, bootBlock + 0x12, 0x1234);
+	program(md, adjacentBootBlock + 0x12, 0x5678);
+	program(md, finalBootBlock + 0x12, 0x9abc);
+	program(md, firstRegularBlock + 0x12, 0xdef0);
+	program(md, adjacentRegularBlock + 0x12, 0x1357);
+	eraseSector(md, firstBootBlock);
+	if(md.read16(firstBootBlock + 0x12) != 0xffff
+		|| md.read16(bootBlock + 0x12) != 0x1234)
+	{
+		std::puts("FAIL: Machinedrum first bottom boot erase crossed an 8 KiB block");
+		return 1;
+	}
+	eraseSector(md, bootBlock);
+	if(md.read16(bootBlock + 0x12) != 0xffff
+		|| md.read16(adjacentBootBlock + 0x12) != 0x5678)
+	{
+		std::puts("FAIL: Machinedrum bottom boot erase crossed an 8 KiB block");
+		return 1;
+	}
+	eraseSector(md, finalBootBlock);
+	if(md.read16(finalBootBlock + 0x12) != 0xffff
+		|| md.read16(firstRegularBlock + 0x12) != 0xdef0)
+	{
+		std::puts("FAIL: Machinedrum final bottom boot erase crossed the 64 KiB boundary");
+		return 1;
+	}
+	eraseSector(md, firstRegularBlock);
+	if(md.read16(firstRegularBlock + 0x12) != 0xffff
+		|| md.read16(adjacentRegularBlock + 0x12) != 0x1357)
+	{
+		std::puts("FAIL: Machinedrum first regular erase crossed a 64 KiB block");
+		return 1;
+	}
 	program(md, target, 0x5aa5);
 	if(md.read16(target) != 0x5aa5)
 	{

--- a/source/elektron/md/mdLib/test/mdplusdrive_test.cpp
+++ b/source/elektron/md/mdLib/test/mdplusdrive_test.cpp
@@ -64,6 +64,15 @@ namespace
 
 int main()
 {
+	md::PlusDrive blank;
+	if(!md::PlusDrive::isBlankStorage({})
+		|| !md::PlusDrive::isBlankStorage(blank.copyStorage()))
+	{
+		std::fputs("mdplusdrive_test: serialized blank drive was treated as formatted\n",
+			stderr);
+		return 1;
+	}
+
 	md::Sim sim;
 	sim.setPlusDriveEnabled(true);
 	if((sim.read8(md::Sim::g_ppdat) & 0xf8) != 0xf8)
@@ -181,6 +190,11 @@ int main()
 		return 1;
 	}
 	const auto image = sim.getPlusDrive().copyStorage();
+	if(md::PlusDrive::isBlankStorage(image))
+	{
+		std::fputs("mdplusdrive_test: populated drive was treated as blank\n", stderr);
+		return 1;
+	}
 	if(image.size() < 21 || image[19] != 7 || image[20] != 0x5a)
 	{
 		std::fprintf(stderr, "mdplusdrive_test: stored record is %02x/%02x\n",
@@ -205,6 +219,21 @@ int main()
 		|| generations.storageDirty())
 	{
 		std::fputs("mdplusdrive_test: clean image started dirty\n", stderr);
+		return 1;
+	}
+	if(!generations.replaceStorage(image, true)
+		|| !generations.storageDirty())
+	{
+		std::fputs("mdplusdrive_test: identical image was not marked dirty\n", stderr);
+		return 1;
+	}
+	generations.markStoragePersisted(generations.storageGeneration());
+	md::PlusDrive blankGenerations;
+	const auto blankImage = blankGenerations.copyStorage();
+	if(!blankGenerations.replaceStorage(blankImage, true)
+		|| !blankGenerations.storageDirty())
+	{
+		std::fputs("mdplusdrive_test: identical blank image was not marked dirty\n", stderr);
 		return 1;
 	}
 	auto secondImage = image;

--- a/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
+++ b/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
@@ -55,6 +55,42 @@ namespace
 		return true;
 	}
 
+	bool verifyLiveRecordChord(md::Hardware& _hardware)
+	{
+		const auto record = md::panelPacket(md::MachineModel::Machinedrum,
+			md::PanelControl::Record);
+		const auto play = md::panelPacket(md::MachineModel::Machinedrum,
+			md::PanelControl::Play);
+		if(!record || !play || record->row != play->row)
+			return false;
+
+		md::PanelRowState rows;
+		for(const auto edge : {
+			rows.press(*record), rows.press(*play),
+			rows.release(*play), rows.release(*record)})
+		{
+			_hardware.sendPanelEvent(edge.row, edge.mask);
+			advance(_hardware, 2048);
+		}
+
+		// OS 1.63 acknowledges REC+PLAY by entering live-record mode: playback
+		// starts and the RECORD lamp flashes rather than remaining steadily lit.
+		bool sawLit = false;
+		bool sawDark = false;
+		for(uint32_t frames = 0; frames < md::g_samplerate * 2; frames += 128)
+		{
+			advance(_hardware, 128);
+			const bool lit = _hardware.getFrontPanelSnapshot().getModeLed(
+				md::FrontPanel::ModeLed::Record);
+			sawLit = sawLit || lit;
+			sawDark = sawDark || !lit;
+		}
+
+		if(!tap(_hardware, md::PanelControl::Stop))
+			return false;
+		return sawLit && sawDark;
+	}
+
 	bool sameLcd(const md::FrontPanel& _a, const md::FrontPanel& _b)
 	{
 		for(uint32_t y = 0; y < md::FrontPanel::g_lcdHeight; ++y)
@@ -182,7 +218,7 @@ int main(const int argc, const char* const* argv)
 	projectPatch.front() ^= 0x6d;
 	projectPatch.back() ^= 0x27;
 	std::vector<uint8_t> projectState;
-	if(!md::encodeState(projectState, projectPatch, projectFlash,
+	if(!md::encodeStateWithFactoryBaseline(projectState, projectPatch, projectFlash,
 		initializedFlash, rom, md::MachineModel::Machinedrum,
 		synthLib::StateTypeGlobal))
 		return fail("could not encode deferred UW project flash");
@@ -254,7 +290,8 @@ int main(const int argc, const char* const* argv)
 		return fail("firmware did not format the blank +Drive");
 	const auto stateStart = std::chrono::steady_clock::now();
 	std::vector<uint8_t> formattedProjectState;
-	if(!md::encodeState(formattedProjectState, formatter.copyPatchRam(),
+	if(!md::encodeStateWithFactoryBaseline(formattedProjectState,
+		formatter.copyPatchRam(),
 		formatter.copyFlashData(), initializedFlash, rom,
 		md::MachineModel::Machinedrum, synthLib::StateTypeGlobal, plusDrive))
 		return fail("formatted +Drive could not be embedded in project state");
@@ -265,16 +302,16 @@ int main(const int argc, const char* const* argv)
 		md::MachineModel::Machinedrum, synthLib::StateTypeGlobal)
 		|| formattedDecoded.plusDrive != plusDrive)
 		return fail("formatted +Drive did not round-trip through project state");
-	constexpr size_t formattedStateBudget = 4u * 1024u * 1024u;
-	if(formattedProjectState.size() > formattedStateBudget)
-		return fail("freshly formatted +Drive exceeded the 4 MiB project-state budget");
-	if(stateMilliseconds > 2000)
-		return fail("freshly formatted +Drive state encoding exceeded two seconds");
 	std::cout << "formatted +Drive: "
 		<< formatter.getUC().getSim().getPlusDrive().storedSectorCount()
 		<< " sectors, " << plusDrive.size() << " image bytes, "
 		<< formattedProjectState.size() << " project bytes, "
 		<< stateMilliseconds << " ms encode\n";
+	constexpr size_t formattedStateBudget = 4u * 1024u * 1024u;
+	if(formattedProjectState.size() > formattedStateBudget)
+		return fail("freshly formatted +Drive exceeded the 4 MiB project-state budget");
+	if(stateMilliseconds > 2000)
+		return fail("freshly formatted +Drive state encoding exceeded two seconds");
 	md::Hardware plusDriveHardware(rom, argv[1], md::MachineModel::Machinedrum,
 		formatter.copyPatchRam(), {}, {}, formatter.copyFlashData(), factoryCache,
 		{}, plusDrive);
@@ -322,6 +359,8 @@ int main(const int argc, const char* const* argv)
 	md::Hardware hardware(rom, argv[1], md::MachineModel::Machinedrum,
 		{}, {}, {}, initializedFlash, factoryCache, {}, {}, false);
 	advance(hardware, md::g_samplerate * 20);
+	if(!verifyLiveRecordChord(hardware))
+		return fail("OS 1.63 did not accept the REC+PLAY live-record chord");
 	assignUwMachine(hardware, 0, 0);
 	const auto trigger = md::panelPacket(md::MachineModel::Machinedrum,
 		md::PanelControl::Trigger1);

--- a/source/elektron/md/mdLibTest/turboMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/turboMidiTest.cpp
@@ -476,6 +476,14 @@ namespace
 			|| !check(factoryState.size() == 52 + patchRam.size(),
 				"factory initialization leaked into project state"))
 			return false;
+		std::vector<uint8_t> romEqualFactoryState;
+		if(!check(md::encodeStateWithFactoryBaseline(romEqualFactoryState, patchRam,
+			rom, rom, rom, md::MachineModel::Machinedrum,
+			synthLib::StateTypeGlobal),
+			"ROM-equal validated factory state could not be encoded")
+			|| !check(romEqualFactoryState.size() == 52 + patchRam.size(),
+				"ROM-equal validated factory state expanded to a complete flash image"))
+			return false;
 
 		auto flashA = factoryBaseline;
 		flashA[3 * md::g_uwFlashSectorSize + 19] = 0x18;

--- a/source/framework/juce/jucePluginEditorLib/pluginEditor.cpp
+++ b/source/framework/juce/jucePluginEditorLib/pluginEditor.cpp
@@ -831,8 +831,11 @@ namespace jucePluginEditorLib
 
 		juceRmlUi::RmlComponentConfig config;
 
-		// add product specific settings template files
-		const auto productName = getProcessor().getProductName();
+		// Add product-specific settings templates. Some products deliberately use
+		// a stable device identity for their data folder while exposing a branded
+		// display name (for example Gearmulator MD / Machinedrum). Match either
+		// identity while retaining every settings category (GUI, DSP/audio, etc.).
+		const auto& properties = getProcessor().getProperties();
 
 		auto files = getAllFilenames();
 
@@ -841,15 +844,21 @@ namespace jucePluginEditorLib
 			if (!baseLib::filesystem::hasExtension(file, ".rml"))
 				continue;
 
-			if (file.find(productName) == std::string::npos)
+			constexpr std::string_view key = "tus_settings_";
+			if(file.size() <= key.size() || file.compare(0, key.size(), key) != 0)
 				continue;
 
-			const std::string key = "tus_settings_";
-
-			if (file.size() <= key.size() || file.substr(0, key.size()) != key)
-				continue;
-
-			config.additionalTemplateFiles.push_back(std::move(file));
+			const auto matchesIdentity = [&file](const std::string& _identity)
+			{
+				if(_identity.empty())
+					return false;
+				const auto suffix = "_" + _identity + ".rml";
+				return file.size() > suffix.size()
+					&& file.compare(file.size() - suffix.size(), suffix.size(), suffix) == 0;
+			};
+			if(matchesIdentity(properties.name)
+				|| matchesIdentity(properties.dataFolderName))
+				config.additionalTemplateFiles.push_back(std::move(file));
 		}
 
 		config.refreshRateLimitHz = m_processor.getConfig().getIntValue("refreshRateLimitHz", -1);

--- a/source/framework/juce/jucePluginEditorLib/settings.cpp
+++ b/source/framework/juce/jucePluginEditorLib/settings.cpp
@@ -28,11 +28,15 @@ namespace jucePluginEditorLib
 		auto& config = _editor.getProcessor().getConfig();
 
 		const bool allowAdvanced = config.getBoolValue(g_allowAdvancedOptions, false);
+		const std::weak_ptr<std::atomic_bool> alive = m_alive;
 
 		enableAdvancedOptions(allowAdvanced);
 
-		juce::MessageManager::callAsync([this]
+		juce::MessageManager::callAsync([this, alive]
 		{
+			const auto guard = alive.lock();
+			if(!guard || !guard->load(std::memory_order_acquire))
+				return;
 			m_categories.selectLastCategory();
 		});
 
@@ -45,16 +49,19 @@ namespace jucePluginEditorLib
 		auto* btClose = juceRmlUi::helper::findChild(_root, "btSettingsClose");
 		if (btClose)
 		{
-			juceRmlUi::EventListener::AddClick(btClose, [this]
+			juceRmlUi::EventListener::AddClick(btClose, [this, alive]
 			{
-				juce::MessageManager::callAsync([this]
+				juce::MessageManager::callAsync([this, alive]
 				{
+					const auto guard = alive.lock();
+					if(!guard || !guard->load(std::memory_order_acquire))
+						return;
 					m_editor.showSettings(false);
 				});
 			});
 		}
 
-		juceRmlUi::EventListener::AddClick(btAllowAdvanced, [this, bt]
+		juceRmlUi::EventListener::AddClick(btAllowAdvanced, [this, bt, alive]
 		{
 			auto& c = m_editor.getProcessor().getConfig();
 			const auto enabled = !c.getBoolValue(g_allowAdvancedOptions, false);
@@ -71,12 +78,16 @@ namespace jucePluginEditorLib
 				genericUI::MessageBox::Icon::Warning, 
 				"Warning", 
 				"Changing these settings may cause instability of the plugin.\n\nPlease confirm to continue.", 
-				[this, bt, &c](const genericUI::MessageBox::Result _result)
+				[this, bt, alive](const genericUI::MessageBox::Result _result)
 				{
+					const auto guard = alive.lock();
+					if(!guard || !guard->load(std::memory_order_acquire))
+						return;
 					if (_result == genericUI::MessageBox::Result::Ok)
 					{
 						enableAdvancedOptions(true);
 						juceRmlUi::ElemButton::setChecked(bt, true);
+						auto& c = m_editor.getProcessor().getConfig();
 						c.setValue(g_allowAdvancedOptions, juce::var(true));
 						c.saveIfNeeded();
 					}
@@ -86,6 +97,7 @@ namespace jucePluginEditorLib
 
 	Settings::~Settings()
 	{
+		m_alive->store(false, std::memory_order_release);
 		juceRmlUi::helper::removeFromParent(m_root);
 	}
 

--- a/source/framework/juce/jucePluginEditorLib/settings.cpp
+++ b/source/framework/juce/jucePluginEditorLib/settings.cpp
@@ -98,6 +98,9 @@ namespace jucePluginEditorLib
 	Settings::~Settings()
 	{
 		m_alive->store(false, std::memory_order_release);
+		// Device-specific category helpers retain pointers into the settings
+		// document. Destroy them before detaching and releasing that document.
+		m_categories.clear();
 		juceRmlUi::helper::removeFromParent(m_root);
 	}
 

--- a/source/framework/juce/jucePluginEditorLib/settings.h
+++ b/source/framework/juce/jucePluginEditorLib/settings.h
@@ -2,6 +2,9 @@
 
 #include "settingsCategories.h"
 
+#include <atomic>
+#include <memory>
+
 namespace Rml
 {
 	class Element;
@@ -34,5 +37,7 @@ namespace jucePluginEditorLib
 		Rml::Element* m_pageButtonTemplate = nullptr;
 
 		SettingsCategories m_categories;
+		std::shared_ptr<std::atomic_bool> m_alive =
+			std::make_shared<std::atomic_bool>(true);
 	};
 }

--- a/source/framework/juce/jucePluginEditorLib/settingsCategories.cpp
+++ b/source/framework/juce/jucePluginEditorLib/settingsCategories.cpp
@@ -16,6 +16,11 @@ namespace jucePluginEditorLib
 	}
 	SettingsCategories::~SettingsCategories()
 	{
+		clear();
+	}
+
+	void SettingsCategories::clear()
+	{
 		m_categories.clear();
 		m_plugins.clear();
 	}

--- a/source/framework/juce/jucePluginEditorLib/settingsCategories.h
+++ b/source/framework/juce/jucePluginEditorLib/settingsCategories.h
@@ -19,6 +19,7 @@ namespace jucePluginEditorLib
 	public:
 		explicit SettingsCategories(Settings& _settings);
 		~SettingsCategories();
+		void clear();
 		void setSelectedCategory(const SettingsCategory* _settingsCategory) const;
 		void selectLastCategory() const;
 

--- a/source/framework/juce/jucePluginEditorLib/settingsDspAudio.cpp
+++ b/source/framework/juce/jucePluginEditorLib/settingsDspAudio.cpp
@@ -10,6 +10,7 @@
 
 #include "RmlUi/Core/Element.h"
 
+#include <algorithm>
 #include <cmath>
 #include <sstream>
 
@@ -217,6 +218,11 @@ namespace jucePluginEditorLib
 
 	uint32_t SettingsDspAudio::getCurrentLatency() const
 	{
+		// Settings can be displayed before a device exists (for example while
+		// firmware is missing). Reading a label must not be what boots the synth.
+		if(m_processor.getExistingDevice() == nullptr)
+			return static_cast<uint32_t>(std::max(0,
+				m_processor.getConfig().getIntValue("latencyBlocks", 0)));
 		return m_processor.getPlugin().getLatencyBlocks();
 	}
 

--- a/source/framework/juce/jucePluginLib/processor.h
+++ b/source/framework/juce/jucePluginLib/processor.h
@@ -77,6 +77,9 @@ namespace pluginLib
 		bool isPluginValid() { return getPlugin().isValid(); }
 
 		synthLib::Plugin& getPlugin();
+		// Status-only UI must not instantiate the emulated device merely to report
+		// that it is not ready yet.
+		synthLib::Device* getExistingDevice() const { return m_device.get(); }
 
 		ProgramChangeRouter& getProgramChangeRouter() { return m_programChangeRouter; }
 

--- a/source/framework/juce/jucePluginLib/tools.cpp
+++ b/source/framework/juce/jucePluginLib/tools.cpp
@@ -5,6 +5,8 @@
 #include "juce_audio_processors/juce_audio_processors.h"
 #include "juce_gui_basics/juce_gui_basics.h"
 
+#include <cstdlib>
+
 namespace pluginLib
 {
 	bool Tools::isHeadless()
@@ -18,11 +20,15 @@ namespace pluginLib
 		// So we use this instead. These tools cause crashes if you attempt to
 		// open a message box. LV2 even opens the editor, even on a headless
 		// build machine, whatever that is good for
-		return host.contains("juce_vst3_helper") || host.contains("juce_lv2_helper");
+		return host.contains("juce_vst3_helper") || host.contains("juce_lv2_helper")
+			|| host.containsIgnoreCase("pluginval");
 	}
 
 	std::string Tools::getPublicDataFolder(const std::string& _vendorName, const std::string& _productName)
 	{
+		if(const auto* const root = std::getenv("GEARMULATOR_DATA_ROOT"); root && *root)
+			return baseLib::filesystem::validatePath(std::string(root))
+				+ _vendorName + '/' + _productName + '/';
 		return baseLib::filesystem::validatePath(baseLib::filesystem::getSpecialFolderPath(baseLib::filesystem::SpecialFolderType::UserDocuments) + _vendorName + '/' + _productName + '/');
 	}
 }


### PR DESCRIPTION
## Summary

- restore the MD/MM device-specific Settings controls, including LCD invert, SysEx send/status, encoder and storage controls
- make panel input cleanup reliable across Shift release, Escape and focus loss; restore MM bank-latch bookkeeping and MD scale/tempo LED presentation
- harden the MD two-stage updater, sparse flash recovery, automatic in-process reboot and early host autosave lifecycle
- preserve +Drive contents and dirty state across reboot/state replacement, including standalone startup checkpoints
- detect invalid DSP execution paths instead of allowing a host hang
- keep Settings/status polling usable without firmware and prevent it from lazily booting an emulated device
- guard deferred Settings callbacks so rapid overlay/editor teardown cannot use destroyed UI state
- destroy device-specific Settings helpers before releasing their RmlUi document
- add live MD/MM editor interaction tests, real updater lifecycle coverage, storage/flash regression tests and release-CI coverage
- keep the enlarged hardware fixture off Windows' 1 MiB test-process stack
- isolate plugin smoke tests from the user Documents folder on macOS and Windows

## Validation

- portable recovery CTest selection: 13 passed, updater-without-SysEx skipped by contract
- user-supplied Machinedrum 1.63 two-stage updater: passed low-level and processor lifecycle tests, including both automatic reboots
- real-ROM robustness suite: MD passed; MM passed
- Machinedrum UW ROM/RAM audio test: passed (ROM and RAM playback, including REC+PLAY path)
- live embedded-skin tests: MD and MM settings, panel interactions, Shift latch/chords, encoder modifier, LED mappings and focus cleanup passed
- empty-data-root Settings tests: MD and MM passed without constructing a device or attempting firmware discovery
- Settings teardown regression: passed 500 consecutive local runs; Linux CI crash was traced to and fixed as document/helper destruction order
- low-level firmware-update test: 1,000 consecutive release runs passed after the Windows stack fix
- rebuilt VST3 smoke test: MD passed; MM passed
- pluginval strictness 5: MD success; MM success
- macOS shell syntax, workflow YAML parsing and `git diff --check`: passed

No firmware, ROM, reverse-engineering notes or generated state files are included. The local QA state folder was left unchanged.
