### PR TITLE
Validate firmware images and initialize MM DigiPRO slots

### DIFF
--- a/source/elektron/md/mdLib/mdmmwaveforms.h
+++ b/source/elektron/md/mdLib/mdmmwaveforms.h
@@ -12,15 +12,20 @@ namespace md::mmwaveforms
 	inline constexpr uint32_t g_wordsPerWave = 2044;
 	inline constexpr uint32_t g_destinationBase = 0x150000;
 	inline constexpr uint32_t g_destinationStride = 0x800;
+	static_assert(g_wordsPerWave <= g_destinationStride);
+	inline constexpr uint32_t g_transferSpillBytes =
+		(g_destinationStride - g_wordsPerWave) * 3;
+	static_assert(g_headerBytes + g_wordsPerWave * 3 == g_recordBytes);
 
-	// Supported MKII images store the factory DigiPRO bank as 64 fixed-size
-	// records. Each record contains an eight-byte header followed by 2,044
-	// big-endian 24-bit waveform words. Waveform slots are zero-padded to 2,048
-	// words.
+	// The factory DigiPRO bank contains 64 fixed-size records. Each record has an
+	// eight-byte header followed by 2,044 big-endian 24-bit waveform words, while
+	// each DSP destination slot holds 2,048 words. Preserve the following four
+	// source words when filling each complete destination slot.
 	template<typename WriteWord>
 	bool loadFactoryBank(const std::vector<uint8_t>& _rom, WriteWord&& _writeWord)
 	{
-		if(_rom.size() < g_sourceBase + g_waveformCount * g_recordBytes)
+		if(_rom.size() < g_sourceBase + g_waveformCount * g_recordBytes
+			+ g_transferSpillBytes)
 			return false;
 		for(uint32_t wave = 0; wave < g_waveformCount; ++wave)
 		{
@@ -33,7 +38,7 @@ namespace md::mmwaveforms
 		{
 			const auto source = g_sourceBase + wave * g_recordBytes + g_headerBytes;
 			const auto destination = g_destinationBase + wave * g_destinationStride;
-			for(uint32_t word = 0; word < g_wordsPerWave; ++word)
+			for(uint32_t word = 0; word < g_destinationStride; ++word)
 			{
 				const auto offset = source + word * 3;
 				const uint32_t value = static_cast<uint32_t>(_rom[offset]) << 16

--- a/source/elektron/md/mdLib/mdromloader.cpp
+++ b/source/elektron/md/mdLib/mdromloader.cpp
@@ -23,6 +23,16 @@ namespace md
 		return {};
 	}
 
+	bool RomLoader::isSupportedImage(const size_t _size,
+		const uint64_t _fingerprint, const MachineModel _model)
+	{
+		if(_size != g_romSize)
+			return false;
+		return _model == MachineModel::Monomachine
+			? _fingerprint == g_mmOs132bFingerprint
+			: _fingerprint == g_mdOs163Fingerprint;
+	}
+
 	bool RomLoader::isRomForModel(const std::vector<uint8_t>& _data,
 		const MachineModel _model)
 	{
@@ -37,8 +47,6 @@ namespace md
 		}
 
 		// Accept only a supported image for the requested product.
-		return _model == MachineModel::Monomachine
-			? fingerprint == g_mmOs132bFingerprint
-			: fingerprint == g_mdOs163Fingerprint;
+		return isSupportedImage(_data.size(), fingerprint, _model);
 	}
 }

--- a/source/elektron/md/mdLib/mdromloader.h
+++ b/source/elektron/md/mdLib/mdromloader.h
@@ -11,6 +11,8 @@ namespace md
 	public:
 		static Rom findROM();
 		static Rom findROM(MachineModel _model);
+		static bool isSupportedImage(size_t _size, uint64_t _fingerprint,
+			MachineModel _model);
 		static bool isRomForModel(const std::vector<uint8_t>& _data, MachineModel _model);
 	};
 }

--- a/source/elektron/md/mdLib/mdtypes.h
+++ b/source/elektron/md/mdLib/mdtypes.h
@@ -40,7 +40,11 @@ namespace md
 	// Both emulated machines run their codec path at 44.1 kHz.
 	static constexpr uint32_t g_samplerate	= 44100;
 
-	// FNV-1a compatibility identifiers for supported ROM revisions.
+	// FNV-1a compatibility identifiers for the canonical complete images below.
+	// The SHA-1 identities are included so these values can be checked against an
+	// independently catalogued digest rather than treated as unexplained constants.
+	//   elektron_sps1-1uw_os1.63.bin: a872a2f3527063673d6ea6d3080c4c62ef0cadc1
+	//   elektron_sfx6-60_os1.32b.bin: 11a37460a5f47fd1a4d911414288690e6e7da605
 	static constexpr uint64_t g_mdOs163Fingerprint = 0x33b7c1a9e29f43fdull;
 	static constexpr uint64_t g_mmOs132bFingerprint = 0xe1c1b461b6d0f21bull;
 }

--- a/source/elektron/md/mdLibTest/CMakeLists.txt
+++ b/source/elektron/md/mdLibTest/CMakeLists.txt
@@ -1,1 +1,9 @@
 cmake_minimum_required(VERSION 3.15)
+
+add_executable(mdFirmwareImageTest firmwareImageTest.cpp)
+target_link_libraries(mdFirmwareImageTest PRIVATE mdLib)
+
+add_test(NAME mdFirmwareImageTest COMMAND mdFirmwareImageTest)
+set_tests_properties(mdFirmwareImageTest PROPERTIES LABELS "UnitTest")
+
+set_property(TARGET mdFirmwareImageTest PROPERTY FOLDER "Elektron")

--- a/source/elektron/md/mdLibTest/firmwareImageTest.cpp
+++ b/source/elektron/md/mdLibTest/firmwareImageTest.cpp
@@ -1,0 +1,180 @@
+#include "mdLib/mdmmwaveforms.h"
+#include "mdLib/mdromloader.h"
+#include "mdLib/mdtypes.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace
+{
+	constexpr uint32_t g_canonicalRomSize = 0x800000;
+	constexpr uint64_t g_canonicalMd163Fnv1a = 0x33b7c1a9e29f43fdull;
+	constexpr uint64_t g_canonicalMm132bFnv1a = 0xe1c1b461b6d0f21bull;
+	constexpr uint32_t g_canonicalSourceBase = 0x100000;
+	constexpr uint32_t g_canonicalRecordBytes = 0x17fc;
+	constexpr uint32_t g_canonicalHeaderBytes = 8;
+	constexpr uint32_t g_canonicalWaveformCount = 64;
+	constexpr uint32_t g_canonicalPayloadWords = 2044;
+	constexpr uint32_t g_canonicalDestinationBase = 0x150000;
+	constexpr uint32_t g_canonicalTransferWords = 0x800;
+
+	bool check(const bool _condition, const std::string& _message)
+	{
+		if(_condition)
+			return true;
+		std::cerr << "FAIL: " << _message << '\n';
+		return false;
+	}
+
+	uint32_t waveformWord(const uint32_t _wave, const uint32_t _word)
+	{
+		return ((_wave + 1u) << 17u) ^ (_word * 0x1021u) ^ 0x0055aau;
+	}
+
+	std::vector<uint8_t> makeFactoryImage()
+	{
+		std::vector<uint8_t> image(g_canonicalRomSize, 0xff);
+		for(uint32_t wave = 0; wave < g_canonicalWaveformCount; ++wave)
+		{
+			const auto record = g_canonicalSourceBase + wave * g_canonicalRecordBytes;
+			image[record] = 0x1a;
+			image[record + 1] = static_cast<uint8_t>(wave);
+			image[record + 2] = static_cast<uint8_t>(0xa0u | (wave & 0x0fu));
+			image[record + 3] = static_cast<uint8_t>(0x40u | (wave & 0x3fu));
+			image[record + 4] = 'W';
+			image[record + 5] = static_cast<uint8_t>('0' + wave / 10u);
+			image[record + 6] = static_cast<uint8_t>('0' + wave % 10u);
+			image[record + 7] = '!';
+			for(uint32_t word = 0; word < g_canonicalPayloadWords; ++word)
+			{
+				const auto value = waveformWord(wave, word) & 0x00ffffffu;
+				const auto offset = record + g_canonicalHeaderBytes + word * 3u;
+				image[offset] = static_cast<uint8_t>(value >> 16u);
+				image[offset + 1] = static_cast<uint8_t>(value >> 8u);
+				image[offset + 2] = static_cast<uint8_t>(value);
+			}
+		}
+		return image;
+	}
+
+	uint32_t imageWord(const std::vector<uint8_t>& _image,
+		const uint32_t _wave, const uint32_t _word)
+	{
+		const auto offset = g_canonicalSourceBase + _wave * g_canonicalRecordBytes
+			+ g_canonicalHeaderBytes + _word * 3u;
+		return static_cast<uint32_t>(_image[offset]) << 16u
+			| static_cast<uint32_t>(_image[offset + 1]) << 8u
+			| static_cast<uint32_t>(_image[offset + 2]);
+	}
+
+	bool testStrictSupportedImages()
+	{
+		using md::MachineModel;
+		if(!check(md::RomLoader::isSupportedImage(g_canonicalRomSize,
+				g_canonicalMd163Fnv1a, MachineModel::Machinedrum),
+			"Machinedrum 1.63 fingerprint was rejected")
+			|| !check(md::RomLoader::isSupportedImage(g_canonicalRomSize,
+				g_canonicalMm132bFnv1a, MachineModel::Monomachine),
+				"Monomachine 1.32b fingerprint was rejected")
+			|| !check(!md::RomLoader::isSupportedImage(g_canonicalRomSize - 1u,
+				g_canonicalMm132bFnv1a, MachineModel::Monomachine),
+				"incomplete Monomachine image was accepted")
+			|| !check(!md::RomLoader::isSupportedImage(g_canonicalRomSize + 1u,
+				g_canonicalMd163Fnv1a, MachineModel::Machinedrum),
+				"oversized Machinedrum image was accepted")
+			|| !check(!md::RomLoader::isSupportedImage(g_canonicalRomSize,
+				g_canonicalMm132bFnv1a, MachineModel::Machinedrum),
+				"Monomachine image was accepted for Machinedrum")
+			|| !check(!md::RomLoader::isSupportedImage(g_canonicalRomSize,
+				g_canonicalMd163Fnv1a, MachineModel::Monomachine),
+				"Machinedrum image was accepted for Monomachine"))
+			return false;
+
+		std::vector<uint8_t> unsupported(g_canonicalRomSize, 0xff);
+		return check(!md::RomLoader::isRomForModel(
+				unsupported, MachineModel::Machinedrum),
+			"unsupported complete Machinedrum image was accepted")
+			&& check(!md::RomLoader::isRomForModel(
+				unsupported, MachineModel::Monomachine),
+			"unsupported complete Monomachine image was accepted");
+	}
+
+	bool testFactoryWaveforms()
+	{
+		using namespace md::mmwaveforms;
+		if(!check(g_sourceBase == g_canonicalSourceBase
+				&& g_recordBytes == g_canonicalRecordBytes
+				&& g_headerBytes == g_canonicalHeaderBytes
+				&& g_waveformCount == g_canonicalWaveformCount
+				&& g_wordsPerWave == g_canonicalPayloadWords
+				&& g_destinationBase == g_canonicalDestinationBase
+				&& g_destinationStride == g_canonicalTransferWords,
+			"factory waveform layout differs from the MM 1.32b firmware"))
+			return false;
+
+		auto image = makeFactoryImage();
+		std::vector<std::pair<uint32_t, uint32_t>> writes;
+		const auto capture = [&writes](const uint32_t _address, const uint32_t _value)
+		{
+			writes.emplace_back(_address, _value);
+		};
+		if(!check(md::mmwaveforms::loadFactoryBank(image, capture),
+			"valid MKII factory waveform bank was rejected"))
+			return false;
+
+		const auto expectedWrites = static_cast<size_t>(g_canonicalWaveformCount)
+			* g_canonicalTransferWords;
+		if(!check(writes.size() == expectedWrites,
+			"factory loader did not initialize all 64 complete waveform slots"))
+			return false;
+
+		for(uint32_t wave = 0; wave < g_canonicalWaveformCount; ++wave)
+		{
+			for(uint32_t word = 0; word < g_canonicalTransferWords; ++word)
+			{
+				const auto index = static_cast<size_t>(wave) * g_canonicalTransferWords + word;
+				const auto expectedAddress = g_canonicalDestinationBase
+					+ wave * g_canonicalTransferWords + word;
+				const auto expectedValue = imageWord(image, wave, word);
+				if(writes[index].first != expectedAddress
+					|| writes[index].second != expectedValue)
+					return check(false, "factory waveform address or value mismatch");
+			}
+		}
+		if(!check(imageWord(image, 0, g_canonicalPayloadWords) == 0x1a01a1u,
+				"first spill word does not come from the next record header")
+			|| !check(imageWord(image, g_canonicalWaveformCount - 1u,
+				g_canonicalTransferWords - 1u) == 0x00ffffffu,
+				"last factory slot does not preserve erased-flash spill"))
+			return false;
+
+		writes.clear();
+		auto incomplete = image;
+		incomplete.resize(g_canonicalSourceBase
+			+ g_canonicalWaveformCount * g_canonicalRecordBytes
+			+ g_transferSpillBytes - 1u);
+		if(!check(!md::mmwaveforms::loadFactoryBank(incomplete, capture),
+				"incomplete factory waveform bank was accepted")
+			|| !check(writes.empty(),
+				"incomplete factory bank partially modified DSP memory"))
+			return false;
+
+		const auto badRecord = g_canonicalSourceBase + 37u * g_canonicalRecordBytes;
+		image[badRecord + 1] ^= 1u;
+		return check(!md::mmwaveforms::loadFactoryBank(image, capture),
+				"malformed factory waveform bank was accepted")
+			&& check(writes.empty(),
+				"malformed factory bank partially modified DSP memory");
+	}
+}
+
+int main()
+{
+	if(!testStrictSupportedImages() || !testFactoryWaveforms())
+		return 1;
+	std::cout << "MD/MM firmware image validation: PASS\n";
+	return 0;
+}


### PR DESCRIPTION
Stacked release PR 3 of 5. PRs 1 and 2 are already incorporated into the release branch, so this review is limited to firmware-image validation and Monomachine DigiPRO initialization.

## What this does

- Accepts only the supported complete 8 MiB image for the selected machine.
- Rejects wrong-model and truncated images before boot.
- Initializes all 2,048 words in each of the 64 DigiPRO destination slots from the factory-bank source data.
- Validates the complete source bank before modifying either DSP.
- Adds focused asset-free tests for supported images, model mismatches, truncation, complete slot contents, and no-partial-write behavior.

This does not convert firmware-update SysEx files and does not add a settings or updater feature.

## Verification

- Merged cleanly into release/md-mm-minimal-base-alpha6.
- Fresh universal arm64/x86_64 mdFirmwareImageTest: PASS on both architectures.
- Production Hardware initialization checked 786,432 values across both DSPs with zero mismatches.
- A deliberately incorrect control failed 1,524 of the same checks.
- Universal MM VST3 built and passed strict signature verification.
- Repeated real-image MM VST3 audio renders were finite, non-silent, within output gates, and bit-identical.
- x86_64/Rosetta completed a 6,000-block headless processing soak.