### PR TITLE
Restore validated MD/MM performance paths

### DIFF
--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -99,9 +99,10 @@ namespace md
 		, m_dspMixer(*this, m_uc.getHdi08Dsp1(), 0)		// DSP1, mixer/main
 		, m_dspProducer(*this, m_uc.getHdi08Dsp2(), 1)	// DSP2, producer
 	{
-		// Keep the new dispatcher selectable so the established path remains
-		// available for exact A/B tests and field fallback.
-		m_schedBoundedJit = std::getenv("GEARMULATOR_MDMM_BOUNDED_JIT") != nullptr;
+		// Ship the validated bounded dispatcher by default while retaining the
+		// established path as a field fallback and exact A/B control.
+		const auto* const boundedJit = std::getenv("GEARMULATOR_MDMM_BOUNDED_JIT");
+		m_schedBoundedJit = boundedJit == nullptr || std::strcmp(boundedJit, "0") != 0;
 
 		if(!m_rom.isValid())
 			return;

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <mutex>
@@ -98,6 +99,10 @@ namespace md
 		, m_dspMixer(*this, m_uc.getHdi08Dsp1(), 0)		// DSP1, mixer/main
 		, m_dspProducer(*this, m_uc.getHdi08Dsp2(), 1)	// DSP2, producer
 	{
+		// Keep the new dispatcher selectable so the established path remains
+		// available for exact A/B tests and field fallback.
+		m_schedBoundedJit = std::getenv("GEARMULATOR_MDMM_BOUNDED_JIT") != nullptr;
+
 		if(!m_rom.isValid())
 			return;
 		if(isMonomachine())
@@ -1124,10 +1129,15 @@ namespace md
 				+ static_cast<uint64_t>((subTarget - m_schedDspOriginFrame[idx]) * static_cast<double>(g_dsp1CyclesPerEsaiFrame));
 			if(targetCyc <= startCyc)
 				targetCyc = startCyc + 1;			// guarantee >=1 step of progress (float rounding)
-			const uint64_t clampStop = startCyc + clampCycles;
-			d.dsp().exec();
-			while(d.dsp().getCycles() < targetCyc && d.dsp().getCycles() < clampStop)
+			const uint64_t stopCyc = std::min(targetCyc, startCyc + clampCycles);
+			if(m_schedBoundedJit)
+				d.dsp().execUntilCycles(stopCyc);
+			else
+			{
 				d.dsp().exec();
+				while(d.dsp().getCycles() < stopCyc)
+					d.dsp().exec();
+			}
 			if(who == 1)
 				schedDrainCodecOutput();			// keep the mixer ESSI1 output ring shallow
 		}

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -272,7 +272,7 @@ namespace md
 		RealtimeHostAudioQueue m_schedHostAudio;
 		std::atomic<uint64_t> m_schedHostAudioOverflow{0};
 		bool     m_schedHostAudioActive = false;	// retain drained frames for a host callback
-		bool     m_schedBoundedJit = false;		// cycle-bounded DSP background slices
+		bool     m_schedBoundedJit = true;		// cycle-bounded DSP background slices
 		RealtimeHostAudioInputQueue m_hostAudioInput;
 		std::atomic<uint64_t> m_hostAudioInputUnderflow{0};
 		std::atomic<uint64_t> m_hostAudioInputOverflow{0};

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -272,6 +272,7 @@ namespace md
 		RealtimeHostAudioQueue m_schedHostAudio;
 		std::atomic<uint64_t> m_schedHostAudioOverflow{0};
 		bool     m_schedHostAudioActive = false;	// retain drained frames for a host callback
+		bool     m_schedBoundedJit = false;		// cycle-bounded DSP background slices
 		RealtimeHostAudioInputQueue m_hostAudioInput;
 		std::atomic<uint64_t> m_hostAudioInputUnderflow{0};
 		std::atomic<uint64_t> m_hostAudioInputOverflow{0};

--- a/source/elektron/md/mdLib/mdmc.cpp
+++ b/source/elektron/md/mdLib/mdmc.cpp
@@ -364,7 +364,7 @@ namespace md
 	{
 
 		// Step the CPU one instruction, then advance the derived SIM and interrupt wiring.
-		const auto cycles = Mc68k::exec();
+		const auto cycles = execInstruction();
 		advanceAfterCpu(cycles);
 		return cycles;
 	}


### PR DESCRIPTION
## What this restores

The release reconstruction after PR #1 dropped two MD/MM performance paths. This PR restores them on top of the current release branch:

- step each ColdFire instruction directly, avoiding generic peripheral stepping that MD/MM immediately performs through its own SIM and interrupt wiring;
- use cycle-bounded DSP JIT dispatch for MD/MM scheduler slices; and
- advance the DSP56300 pin from `329f5977` to `c7ee5b8e`, which supplies the bounded JIT implementation on the newer core.

The idle-MIDI optimization from the old performance series is already present in the current base through PR #29, so it is deliberately not duplicated here.

Bounded dispatch now ships enabled by default. Set `GEARMULATOR_MDMM_BOUNDED_JIT=0` to select the established dispatcher as an emergency field fallback or exact A/B control. The earlier value `1` continues to select bounded dispatch.

## Dependency history, stated plainly

The DSP56300 pin advances across 63 commits: 56 authored by other upstream contributors and seven authored by Joe Landers. The seven rebase existing MD/MM support, bridge the histories, and add/test bounded JIT dispatch. The parent repository itself changes only three MD/MM source files plus the DSP gitlink.

The controlled `upstream_only` arm below changes only the parent repository's DSP gitlink and does not call the new bounded dispatcher. It measures the practical dependency-pin effect for MD/MM. It is not a literal author-purity build with the seven Joe-authored dependency commits deleted.

## Why the old 10--13% result and the current net result differ

The earlier same-binary toggle experiment kept DSP56300 at `c7ee5b8e` and compared all three of our runtime optimizations disabled versus enabled. Median paired CPU-load reductions were:

| Our change | Machinedrum | Monomachine |
|---|---:|---:|
| Processor-only ColdFire stepping | 1.70% | 2.53% |
| Skip idle MIDI arbitration | 3.04% | 5.53% |
| Cycle-bounded DSP dispatch | 9.06% | 4.31% |
| All three together | 13.21% | 11.29% |

Those figures answer how much our three changes help with the dependency held constant. They do not describe PR #30 versus the public alpha.6 binaries.

A new three-arm Windows real-firmware experiment used six balanced permutations and separately measured the dependency change and PR #30's parent-code changes:

| Model | Old DSP | New dependency, parent changes off | PR #30 enabled | Dependency-pin effect | PR #30 parent-code effect | Net effect |
|---|---:|---:|---:|---:|---:|---:|
| MD 1.63 | 62.0171% | 64.6445% | 61.0410% | -4.23% | +5.60% | +1.56% |
| MM 1.32b | 31.9604% | 32.4677% | 31.1568% | -1.23% | +3.87% | +2.85% |

Positive means less CPU load. Every paired repetition agreed on direction: the dependency update cost performance, our two restored parent changes recovered it, and the fully enabled PR remained faster than the reconstructed release base used by this controlled source comparison.

All 18 measured processes passed, covering 36 model-runs with real MD 1.63 and MM 1.32b firmware, a running sequencer, audio input, all six outputs, MIDI, and randomized 1--2048-sample callbacks. There were no invalid callbacks or asserted queue failures. One MD model-run recorded one deadline miss; the other 35 recorded none.

Diagnostic build runs:

- old dependency: https://github.com/joelanders/gearmulator-md-mm/actions/runs/33767531674
- new dependency, parent changes off: https://github.com/joelanders/gearmulator-md-mm/actions/runs/33768194294
- PR #30 changes enabled: https://github.com/joelanders/gearmulator-md-mm/actions/runs/33768197292

The reusable runner, exact measurements, paired calculations, hashes, and machine identity are committed in the private durable notes repository under `notes/sol-high/2026-09-03_md_mm_upstream_attribution/`.

## Direct comparison with public alpha.6

We also tested the exact published alpha.6 Windows ZIP against the exact package from PR #30's green merge-candidate build. Six balanced-order repetitions loaded the real VST3s and rendered about 30 seconds per case at 44.1 kHz with fixed 512-sample blocks:

| Model | Alpha.6 median render load | PR #30 candidate | Median paired improvement | Paired range |
|---|---:|---:|---:|---:|
| Machinedrum | 97.6598% | 95.5172% | +2.31% | +1.31% to +3.41% |
| Monomachine | 93.7306% | 87.3609% | +6.80% | +6.21% to +8.26% |

All six pairs favored the candidate for both products, and all 24 measured processes exited successfully. Render load here means process wall time divided by rendered audio duration; it is not a DAW CPU meter.

This test does not start the internal sequencer and does not randomize callback sizes, so it does not exercise the same workload as the 10--13% all-optimizations experiment. The evidence supports saying that the candidate is faster than alpha.6 in both tested products, with a workload-dependent gain. It does not support promising every user a 10% improvement.

Exact package SHA-256 values:

```text
alpha.6       389e0d860b9192e0c38b4a2a8dbd03a6820bd49af7ae49d9718269cc73493d80
PR #30 build  c32c453aa458f2fb9d05feed2aaf72146bd259413ca0964faf64a3b9c3c08ebe
```

## Validation

All 11 normal PR checks passed after the default switch, including Windows and macOS artifacts, three-platform headless audio tests, built VST3 tests, release tests, sanitizers, and shared-controller compatibility.

A fresh local macOS build passed `mdLibTests` and `mdAudioQueueTest`. Real MD 1.63 and MM 1.32b randomized scheduler/resampler tests passed both with the new default and with `GEARMULATOR_MDMM_BOUNDED_JIT=0`.

No diagnostic tooling, firmware, generated profiles, or unrelated rollback recovery is included.
