### PR TITLE
Make MD/MM standalone startup and restore robust

### DIFF
--- a/.github/workflows/mdmm-core.yml
+++ b/.github/workflows/mdmm-core.yml
@@ -67,6 +67,7 @@ jobs:
           mdAutomationMidiTest
           mdAutomationParameterTest
           mdAutomationRobustnessTest
+          mdAudioIoLayoutTest
 
       - name: Run fixture-free gates
         env:
@@ -76,7 +77,7 @@ jobs:
           ctest --test-dir build-mdmm-core -C Release --output-on-failure
           --no-tests=error
           --tests-regex
-          '^(midiOutputDispatcherTest|mdAutomationMidiTest|mdAutomationParameterTest|mdAutomationArchitectureTest)$'
+          '^(midiOutputDispatcherTest|mdAutomationMidiTest|mdAutomationParameterTest|mdAutomationArchitectureTest|mdAudioIoLayoutTest)$'
 
   shared-controller-compatibility:
     name: shared controller compatibility

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/joelanders/dsp56300-md-mm.git
 [submodule "source/JUCE"]
 	path = source/JUCE
-	url = https://github.com/juce-framework/JUCE.git
+	url = https://github.com/joelanders/JUCE-md-mm.git
 [submodule "source/cpp-terminal"]
 	path = source/cpp-terminal
 	url = https://github.com/dsp56300/cpp-terminal

--- a/scripts/macos/build_mdmm.sh
+++ b/scripts/macos/build_mdmm.sh
@@ -143,6 +143,7 @@ cmake --build "${build_dir}" --parallel 4 --target \
   mdAudioQueueTest \
   mdAudioFirmwareTest \
   mdAudioIoLayoutTest \
+  mdProjectStateRestoreTest \
   mdAudioProbePlugin_VST3 \
   mdFirmwareImageTest \
   mc68kColdFireDivideTest
@@ -183,6 +184,11 @@ if [[ "${require_firmware_tests}" == "1" ]]; then
     GEARMULATOR_MM_FIRMWARE_BIN="${mm_firmware_bin}" \
     ctest --test-dir "${build_dir}" -C Release --output-on-failure \
       --no-tests=error --tests-regex '^mdAudioFirmwareTest$'
+  HOME="${build_runtime_home}" GEARMULATOR_DATA_ROOT="${build_runtime_data}" \
+    GEARMULATOR_MD_FIRMWARE_BIN="${md_firmware_bin}" \
+    GEARMULATOR_MM_FIRMWARE_BIN="${mm_firmware_bin}" \
+    ctest --test-dir "${build_dir}" -C Release --output-on-failure \
+      --no-tests=error --tests-regex '^mdProjectStateRestoreTest$'
   HOME="${build_runtime_home}" GEARMULATOR_DATA_ROOT="${build_runtime_data}" \
     MD_AUTOMATION_REQUIRE_FIRMWARE=1 \
     ctest --test-dir "${build_dir}" -C Release --output-on-failure \

--- a/scripts/windows/build_mdmm.ps1
+++ b/scripts/windows/build_mdmm.ps1
@@ -95,7 +95,8 @@ if (-not $TestOnly) {
     )
     if ($WithTests) {
         $targets += @('synthLibAudioTest', 'mdLibTest', 'mdAudioQueueTest',
-            'mdAudioFirmwareTest', 'mdAudioIoLayoutTest', 'mdAudioProbePlugin_VST3')
+            'mdAudioFirmwareTest', 'mdAudioIoLayoutTest', 'mdProjectStateRestoreTest',
+            'mdAudioProbePlugin_VST3')
     }
     Invoke-Native -FilePath $cmake -Arguments (@(
         '--build', $BuildDir,
@@ -125,7 +126,7 @@ if ($WithTests) {
         '--test-dir', $BuildDir,
         '-C', $Configuration,
         '--output-on-failure',
-        '--tests-regex', '^(synthLibAudioTest|mdLibTests|mdAudioQueueTest|mdAudioFirmwareTest|mdAudioIoLayoutTest|mdAudioProbePluginVST3IdentityTest)$'
+        '--tests-regex', '^(synthLibAudioTest|mdLibTests|mdAudioQueueTest|mdAudioFirmwareTest|mdAudioIoLayoutTest|mdProjectStateRestoreTest|mdAudioProbePluginVST3IdentityTest)$'
     )
     Invoke-Native -FilePath $ctest -Arguments @(
         '--test-dir', $BuildDir,

--- a/source/elektron/md/mdJucePlugin/mdAudioIoLayoutTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAudioIoLayoutTest.cpp
@@ -1,8 +1,11 @@
 #include "mdPluginProcessor.h"
 
+#include "juce_audio_utils/juce_audio_utils.h"
 #include "juce_events/juce_events.h"
 #include "jucePluginLib/controller.h"
 #include "jucePluginLib/processor.h"
+#include "jucePluginLib/tools.h"
+#include "baseLib/filesystem.h"
 #include "synthLib/device.h"
 #include "synthLib/plugin.h"
 #include "synthLib/syntheticAudioTestDevice.h"
@@ -11,6 +14,7 @@
 #include <array>
 #include <atomic>
 #include <cmath>
+#include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
@@ -27,6 +31,84 @@ namespace
 	}
 
 	using SyntheticAudioDevice = synthLib::test::SyntheticAudioDevice;
+
+	void setDataRootEnvironment(const char* const _value)
+	{
+#if defined(_WIN32)
+		_putenv_s("GEARMULATOR_DATA_ROOT", _value ? _value : "");
+#else
+		if(_value)
+			setenv("GEARMULATOR_DATA_ROOT", _value, 1);
+		else
+			unsetenv("GEARMULATOR_DATA_ROOT");
+#endif
+	}
+
+	void verifyIsolatedDataRoot()
+	{
+		const auto* const previousValue = std::getenv("GEARMULATOR_DATA_ROOT");
+		const std::string previous = previousValue ? previousValue : "";
+		const bool previouslySet = previousValue != nullptr;
+		setDataRootEnvironment("/tmp/gearmulator-data-root-test");
+		const auto actual = pluginLib::Tools::getPublicDataFolder(
+			"Test Vendor", "Test Product");
+		const auto expected = baseLib::filesystem::validatePath(
+			"/tmp/gearmulator-data-root-test/Test Vendor/Test Product/");
+		require(actual == expected,
+			"release-test data root was ignored");
+		setDataRootEnvironment(previouslySet ? previous.c_str() : nullptr);
+	}
+
+	class SparseCallbackAudioDevice final : public juce::AudioIODevice
+	{
+	public:
+		SparseCallbackAudioDevice() : AudioIODevice("Sparse test device", "Test") {}
+		void configure(const double _sampleRate, const int _bufferSize,
+			const int _inputs, const int _outputs)
+		{
+			sampleRate = _sampleRate;
+			bufferSize = _bufferSize;
+			inputs = _inputs;
+			outputs = _outputs;
+		}
+
+		juce::StringArray getOutputChannelNames() override { return {"Out 1", "Out 2"}; }
+		juce::StringArray getInputChannelNames() override { return {"In 1", "In 2"}; }
+		juce::Array<double> getAvailableSampleRates() override { return {sampleRate}; }
+		juce::Array<int> getAvailableBufferSizes() override { return {bufferSize}; }
+		int getDefaultBufferSize() override { return bufferSize; }
+		juce::String open(const juce::BigInteger&, const juce::BigInteger&,
+			double, int) override { return {}; }
+		void close() override {}
+		bool isOpen() override { return true; }
+		void start(juce::AudioIODeviceCallback*) override {}
+		void stop() override {}
+		bool isPlaying() override { return true; }
+		juce::String getLastError() override { return {}; }
+		int getCurrentBufferSizeSamples() override { return bufferSize; }
+		double getCurrentSampleRate() override { return sampleRate; }
+		int getCurrentBitDepth() override { return 32; }
+		juce::BigInteger getActiveOutputChannels() const override
+		{
+			juce::BigInteger result;
+			result.setRange(0, outputs, true);
+			return result;
+		}
+		juce::BigInteger getActiveInputChannels() const override
+		{
+			juce::BigInteger result;
+			result.setRange(0, inputs, true);
+			return result;
+		}
+		int getOutputLatencyInSamples() override { return 0; }
+		int getInputLatencyInSamples() override { return 0; }
+
+	private:
+		double sampleRate = 48000.0;
+		int bufferSize = 64;
+		int inputs = 2;
+		int outputs = 2;
+	};
 
 	class SyntheticController final : public pluginLib::Controller
 	{
@@ -224,24 +306,81 @@ namespace
 		require(processor->wrapperType
 			== juce::AudioProcessor::wrapperType_Standalone,
 			"processor did not retain the Standalone wrapper type");
-		require(processor->getBusCount(false) == 1
-			&& processor->getTotalNumOutputChannels() == 6,
-			"Standalone did not expose one six-channel physical-output bus");
+		require(processor->getBusCount(false) == 3
+			&& processor->getTotalNumOutputChannels() == 2,
+			"Standalone construction changed the shared three-bus topology");
 		processor->disableNonMainBuses();
-		require(processor->getTotalNumOutputChannels() == 6,
-			"JUCE Standalone bus filtering hid auxiliary outputs");
+		require(processor->getTotalNumOutputChannels() == 2
+			&& !processor->getBus(false, 1)->isEnabled()
+			&& !processor->getBus(false, 2)->isEnabled(),
+			"JUCE Standalone did not retain a stereo main-only layout");
 
-		for(const int channelCount : {2, 4, 6})
-		{
-			auto layout = processor->getBusesLayout();
-			layout.outputBuses.set(0,
-				juce::AudioChannelSet::canonicalChannelSet(channelCount));
-			require(processor->checkBusesLayoutSupported(layout),
-				"Standalone rejected a supported physical-output count");
-			require(processor->setBusesLayout(layout)
-				&& processor->getTotalNumOutputChannels() == channelCount,
-				"Standalone could not apply a supported physical-output count");
-		}
+		auto invalid = processor->getBusesLayout();
+		invalid.outputBuses.set(0, juce::AudioChannelSet::quadraphonic());
+		require(!processor->checkBusesLayoutSupported(invalid),
+			"Standalone accepted a non-stereo main bus");
+	}
+
+	void verifySparseDeviceCallbacks()
+	{
+		std::array<float, 32> offsetProbe{};
+		require(juce::detail::addAudioCallbackChannelOffset(
+			static_cast<float*>(nullptr), 17) == nullptr,
+			"standalone callback splitter manufactured an address from null");
+		require(juce::detail::addAudioCallbackChannelOffset(
+			offsetProbe.data(), 17) == offsetProbe.data() + 17,
+			"standalone callback splitter applied the wrong channel offset");
+
+		constexpr int samples = 64;
+		SparseCallbackAudioDevice device;
+		juce::AudioProcessorPlayer player;
+		player.audioDeviceAboutToStart(&device);
+
+		std::array<float, samples> input{};
+		std::array<float, samples> output{};
+		input.fill(0.5f);
+		output.fill(1.0f);
+		const float* inputs[] = {nullptr, input.data()};
+		float* outputs[] = {output.data(), nullptr};
+
+		// JUCE starts the device callback before attaching the processor. A sparse
+		// channel must remain a null sentinel and every real output must be silenced.
+		player.audioDeviceIOCallbackWithContext(inputs, 2, outputs, 2, samples, {});
+		require(std::all_of(output.begin(), output.end(),
+			[](const float value) { return value == 0.0f; }),
+			"processor-free sparse callback did not clear the real output");
+
+		SyntheticProcessor processor;
+		player.setProcessor(&processor);
+		player.audioDeviceIOCallbackWithContext(inputs, 2, outputs, 2, samples, {});
+		require(std::all_of(output.begin(), output.end(),
+			[](const float value) { return std::isfinite(value); }),
+			"sparse input/output callback produced invalid audio");
+		player.setProcessor(nullptr);
+		player.audioDeviceStopped();
+
+		// Model a transition to a Bluetooth-like device and separate I/O with a
+		// single input, stereo output, and a much larger callback. Re-preparation
+		// must resize all silence/discard storage before the next callback.
+		device.configure(44100.0, 512, 1, 2);
+		player.audioDeviceAboutToStart(&device);
+		player.setProcessor(&processor);
+		std::array<float, 512> bluetoothInput{};
+		std::array<float, 512> bluetoothLeft{};
+		bluetoothInput.fill(0.25f);
+		const float* changedInputs[] = {bluetoothInput.data()};
+		float* changedOutputs[] = {bluetoothLeft.data(), nullptr};
+		player.audioDeviceIOCallbackWithContext(changedInputs, 1,
+			changedOutputs, 2, 512, {});
+		require(std::all_of(bluetoothLeft.begin(), bluetoothLeft.end(),
+			[](const float value) { return std::isfinite(value); }),
+			"device-change callback produced invalid audio");
+
+		// A disappearing device may deliver no backing output array while its
+		// stop notification is in flight. This defensive path must remain silent.
+		player.setProcessor(nullptr);
+		player.audioDeviceIOCallbackWithContext(nullptr, 0, nullptr, 2, 512, {});
+		player.audioDeviceStopped();
 	}
 
 	void verifyReplacementLatencyNotificationIsAsync()
@@ -463,10 +602,12 @@ int main()
 		verifyModel(md::MachineModel::Monomachine);
 		verifyStandaloneLayout(md::MachineModel::Machinedrum);
 		verifyStandaloneLayout(md::MachineModel::Monomachine);
+		verifySparseDeviceCallbacks();
 		verifyProcessorAudioRouting();
 		verifyLatencyTracksLayoutRateAndOfflineMode();
 		verifyInvalidDeviceRecoveryIsDeferred();
 		verifyReplacementLatencyNotificationIsAsync();
+		verifyIsolatedDataRoot();
 		std::cout << "mdAudioIoLayoutTest: PASS\n";
 		return 0;
 	}

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
@@ -334,18 +334,12 @@ namespace mdJucePlugin
 
 	juce::AudioProcessor::BusesProperties AudioPluginAudioProcessor::createBusesProperties()
 	{
-		auto buses = BusesProperties()
-			.withInput("Input A/B", juce::AudioChannelSet::stereo(), true);
-
-		// JUCE's Standalone wrapper disables every non-main bus after construction.
-		// Use one adaptive physical-output bus there so its audio-device dialog can
-		// expose all six outputs. Plug-in wrappers retain named stereo buses.
-		if(juce::PluginHostType::getPluginLoadedAs()
-			== juce::AudioProcessor::wrapperType_Standalone)
-			return buses.withOutput("Outputs A-F",
-				juce::AudioChannelSet::discreteChannels(6), true);
-
-		return buses
+		// Match the established Gearmulator bus model: plug-in hosts may enable the
+		// two auxiliary stereo buses, while JUCE Standalone deliberately disables
+		// non-main buses and opens the physical device as stereo. Keeping one stable
+		// topology also removes wrapper-dependent construction from the processor.
+		return BusesProperties()
+			.withInput("Input A/B", juce::AudioChannelSet::stereo(), true)
 			.withOutput("Main A/B", juce::AudioChannelSet::stereo(), true)
 			.withOutput("Out C/D", juce::AudioChannelSet::stereo(), false)
 			.withOutput("Out E/F", juce::AudioChannelSet::stereo(), false);
@@ -366,12 +360,6 @@ namespace mdJucePlugin
 		if(input != juce::AudioChannelSet::disabled()
 			&& input != juce::AudioChannelSet::stereo())
 			return false;
-
-		if(_layout.outputBuses.size() == 1)
-		{
-			const auto channels = _layout.getMainOutputChannelSet().size();
-			return channels == 2 || channels == 4 || channels == 6;
-		}
 
 		if(_layout.outputBuses.size() != 3
 			|| _layout.getMainOutputChannelSet() != juce::AudioChannelSet::stereo())

--- a/source/elektron/md/mdJucePlugin/mdProjectStateRestoreTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdProjectStateRestoreTest.cpp
@@ -7,6 +7,7 @@
 #include "mdLib/mdtypes.h"
 
 #include "baseLib/binarystream.h"
+#include "juce_audio_utils/juce_audio_utils.h"
 #include "synthLib/romLoader.h"
 
 #include <algorithm>
@@ -31,6 +32,14 @@ namespace md
 		{
 			return _device.m_deferredPreparedState
 				? _device.m_deferredPreparedState->m_hardware.get() : nullptr;
+		}
+		static FrontPanelPublisher* publisher(Hardware& _hardware)
+		{
+			return _hardware.m_frontPanelPublisher.get();
+		}
+		static FrontPanelPublisher* livePublisher(Device& _device)
+		{
+			return _device.m_frontPanelPublisher.get();
 		}
 	};
 }
@@ -73,7 +82,7 @@ namespace
 		return _hardware.isFactoryFlashReadyForReboot();
 	}
 
-	std::vector<uint8_t> pluginState(const std::vector<uint8_t>& _patch,
+	std::vector<uint8_t> mdPluginState(const std::vector<uint8_t>& _patch,
 		const std::vector<uint8_t>& _flash,
 		const std::vector<uint8_t>& _factory,
 		const std::vector<uint8_t>& _rom)
@@ -82,6 +91,29 @@ namespace
 		require(md::encodeStateWithFactoryBaseline(state, _patch, _flash, _factory,
 			_rom, md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
 			"could not encode processor restore fixture");
+		std::vector<uint8_t> result{1, synthLib::StateTypeGlobal};
+		result.insert(result.end(), state.begin(), state.end());
+		return result;
+	}
+
+	std::vector<uint8_t> mmPluginState(const std::vector<uint8_t>& _patch)
+	{
+		std::vector<uint8_t> state;
+		require(md::encodeState(state, _patch, md::MachineModel::Monomachine,
+			synthLib::StateTypeGlobal),
+			"could not encode Monomachine processor restore fixture");
+		std::vector<uint8_t> result{1, synthLib::StateTypeGlobal};
+		result.insert(result.end(), state.begin(), state.end());
+		return result;
+	}
+
+	std::vector<uint8_t> mdCompletePluginState(const std::vector<uint8_t>& _patch,
+		const std::vector<uint8_t>& _flash, const std::vector<uint8_t>& _rom)
+	{
+		std::vector<uint8_t> state;
+		require(md::encodeState(state, _patch, _flash, _rom, _rom,
+			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+			"could not encode complete Machinedrum cold-start fixture");
 		std::vector<uint8_t> result{1, synthLib::StateTypeGlobal};
 		result.insert(result.end(), state.begin(), state.end());
 		return result;
@@ -149,22 +181,26 @@ namespace
 		RestoreStatus status = RestoreStatus::Failed;
 		uint64_t generation = 0;
 		md::Hardware* liveHardware = nullptr;
+		uint64_t hardwareEpoch = 0;
 		bool candidateReady = false;
 	};
 
 	class Harness
 	{
 	public:
-		Harness()
-			: processor(md::MachineModel::Machinedrum, isolatedConfig(), false)
+		explicit Harness(const md::MachineModel _model = md::MachineModel::Machinedrum,
+			const bool _prepareAudio = true)
+			: processor(_model, isolatedConfig(), false)
 			, audioProcessor(processor), audio(2, blockSize)
 		{
-			audioProcessor.prepareToPlay(48000.0, blockSize);
+			if(_prepareAudio)
+				prepareAudio();
 		}
 
 		~Harness()
 		{
-			audioProcessor.releaseResources();
+			if(audioPrepared)
+				audioProcessor.releaseResources();
 		}
 
 		static mdJucePlugin::AudioPluginAudioProcessor::EphemeralConfig isolatedConfig()
@@ -176,6 +212,7 @@ namespace
 
 		void process(const uint32_t _blocks)
 		{
+			require(audioPrepared, "audio callback ran before processor preparation");
 			for(uint32_t block = 0; block < _blocks; ++block)
 			{
 				audio.clear();
@@ -184,6 +221,13 @@ namespace
 				if((block & 31u) == 0)
 					std::this_thread::sleep_for(250us);
 			}
+		}
+
+		void prepareAudio()
+		{
+			require(!audioPrepared, "processor audio was prepared twice");
+			audioProcessor.prepareToPlay(48000.0, blockSize);
+			audioPrepared = true;
 		}
 
 		double benchmark(const uint32_t _blocks)
@@ -202,10 +246,11 @@ namespace
 				{
 					RestoreSnapshot result;
 					auto* const device = dynamic_cast<md::Device*>(_device);
-					require(device != nullptr, "processor did not own a local MD device");
+					require(device != nullptr, "processor did not own a local MD/MM device");
 					result.status = device->projectStateRestoreStatus();
 					result.generation = device->deferredStateGeneration();
 					result.liveHardware = &device->getHardware();
+					result.hardwareEpoch = device->hardwareEpoch();
 					auto* const candidate =
 						md::DevicePreparedStateTestAccess::deferredHardware(*device);
 					result.candidateReady = candidate
@@ -236,6 +281,7 @@ namespace
 		static constexpr int blockSize = 128;
 		juce::AudioBuffer<float> audio;
 		juce::MidiBuffer midi;
+		bool audioPrepared = false;
 	};
 
 	void setHostState(Harness& _harness, const std::vector<uint8_t>& _state)
@@ -243,6 +289,99 @@ namespace
 		const auto hostState = processorState(_state);
 		_harness.audioProcessor.setStateInformation(hostState.data(),
 			static_cast<int>(hostState.size()));
+	}
+
+	class HeadlessLifecycleAudioDevice final : public juce::AudioIODevice
+	{
+	public:
+		HeadlessLifecycleAudioDevice() : AudioIODevice("Lifecycle device", "Test") {}
+		void configure(const double _sampleRate, const int _bufferSize,
+			const int _inputs, const int _outputs)
+		{
+			sampleRate = _sampleRate;
+			bufferSize = _bufferSize;
+			inputs = _inputs;
+			outputs = _outputs;
+		}
+		juce::StringArray getOutputChannelNames() override { return {"L", "R"}; }
+		juce::StringArray getInputChannelNames() override { return {"L", "R"}; }
+		juce::Array<double> getAvailableSampleRates() override { return {sampleRate}; }
+		juce::Array<int> getAvailableBufferSizes() override { return {bufferSize}; }
+		int getDefaultBufferSize() override { return bufferSize; }
+		juce::String open(const juce::BigInteger&, const juce::BigInteger&,
+			double, int) override { return {}; }
+		void close() override {}
+		bool isOpen() override { return true; }
+		void start(juce::AudioIODeviceCallback*) override {}
+		void stop() override {}
+		bool isPlaying() override { return true; }
+		juce::String getLastError() override { return {}; }
+		int getCurrentBufferSizeSamples() override { return bufferSize; }
+		double getCurrentSampleRate() override { return sampleRate; }
+		int getCurrentBitDepth() override { return 32; }
+		juce::BigInteger getActiveOutputChannels() const override
+		{
+			juce::BigInteger result;
+			result.setRange(0, outputs, true);
+			return result;
+		}
+		juce::BigInteger getActiveInputChannels() const override
+		{
+			juce::BigInteger result;
+			result.setRange(0, inputs, true);
+			return result;
+		}
+		int getOutputLatencyInSamples() override { return 0; }
+		int getInputLatencyInSamples() override { return 0; }
+
+	private:
+		double sampleRate = 48000.0;
+		int bufferSize = 128;
+		int inputs = 2;
+		int outputs = 2;
+	};
+
+	void verifyHeadlessStandaloneLifecycle(const md::MachineModel _model,
+		const std::vector<uint8_t>& _state)
+	{
+		Harness harness(_model, false);
+		const auto before = harness.snapshot();
+		setHostState(harness, _state);
+		const auto restored = harness.snapshot();
+		require(restored.status == RestoreStatus::Idle
+			&& restored.hardwareEpoch == before.hardwareEpoch + 1
+			&& restored.liveHardware != before.liveHardware,
+			"standalone-order cold restore did not commit before audio startup");
+
+		HeadlessLifecycleAudioDevice device;
+		juce::AudioProcessorPlayer player;
+		player.audioDeviceAboutToStart(&device);
+		player.setProcessor(&harness.processor);
+		std::array<float, 128> input{};
+		std::array<float, 128> output{};
+		input.fill(0.125f);
+		const float* inputs[] = {nullptr, input.data()};
+		float* outputs[] = {output.data(), nullptr};
+		for(uint32_t block = 0; block < 32; ++block)
+			player.audioDeviceIOCallbackWithContext(inputs, 2, outputs, 2, 128, {});
+		require(std::all_of(output.begin(), output.end(),
+			[](const float value) { return std::isfinite(value); }),
+			"standalone-order sparse callback produced invalid audio");
+
+		player.audioDeviceStopped();
+		device.configure(44100.0, 512, 1, 2);
+		player.audioDeviceAboutToStart(&device);
+		std::array<float, 512> bluetoothInput{};
+		std::array<float, 512> bluetoothOutput{};
+		const float* bluetoothInputs[] = {bluetoothInput.data()};
+		float* bluetoothOutputs[] = {bluetoothOutput.data(), nullptr};
+		player.audioDeviceIOCallbackWithContext(bluetoothInputs, 1,
+			bluetoothOutputs, 2, 512, {});
+		require(std::all_of(bluetoothOutput.begin(), bluetoothOutput.end(),
+			[](const float value) { return std::isfinite(value); }),
+			"standalone-order device-change callback produced invalid audio");
+		player.setProcessor(nullptr);
+		player.audioDeviceStopped();
 	}
 
 	struct StartGate
@@ -274,9 +413,10 @@ namespace
 int main()
 {
 	const auto* const firmwarePath = std::getenv("GEARMULATOR_MD_FIRMWARE_BIN");
-	if(!firmwarePath || !*firmwarePath)
+	const auto* const mmFirmwarePath = std::getenv("GEARMULATOR_MM_FIRMWARE_BIN");
+	if(!firmwarePath || !*firmwarePath || !mmFirmwarePath || !*mmFirmwarePath)
 	{
-		std::cout << "mdProjectStateRestoreTest: SKIP (pinned MD firmware not supplied)\n";
+		std::cout << "mdProjectStateRestoreTest: SKIP (pinned MD/MM firmware not supplied)\n";
 		return 77;
 	}
 
@@ -288,8 +428,15 @@ int main()
 			std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
 		require(md::RomLoader::isRomForModel(rom, md::MachineModel::Machinedrum),
 			"firmware is not the supported Machinedrum OS 1.63 image");
+		std::ifstream mmInput(mmFirmwarePath, std::ios::binary);
+		const std::vector<uint8_t> mmRom{
+			std::istreambuf_iterator<char>(mmInput), std::istreambuf_iterator<char>()};
+		require(md::RomLoader::isRomForModel(mmRom, md::MachineModel::Monomachine),
+			"firmware is not the supported Monomachine OS 1.32b image");
 		synthLib::RomLoader::addSearchPath(
 			juce::File(firmwarePath).getParentDirectory().getFullPathName().toStdString());
+		synthLib::RomLoader::addSearchPath(
+			juce::File(mmFirmwarePath).getParentDirectory().getFullPathName().toStdString());
 
 		md::Hardware factory(rom, firmwarePath, md::MachineModel::Machinedrum);
 		require(factory.isValid() && initializeUwFlash(factory),
@@ -301,19 +448,23 @@ int main()
 		auto patchA = factoryPatch;
 		flashA[6 * md::g_uwFlashSectorSize + 111] ^= 0x21;
 		patchA.front() ^= 0x31;
-		const auto stateA = pluginState(patchA, flashA, factoryFlash, rom);
+		const auto stateA = mdPluginState(patchA, flashA, factoryFlash, rom);
+		const auto completeStateA = mdCompletePluginState(patchA, flashA, rom);
 
 		auto flashB = factoryFlash;
 		auto patchB = factoryPatch;
 		flashB[10 * md::g_uwFlashSectorSize + 222] ^= 0x42;
 		patchB.back() ^= 0x52;
-		const auto stateB = pluginState(patchB, flashB, factoryFlash, rom);
+		const auto stateB = mdPluginState(patchB, flashB, factoryFlash, rom);
 
 		auto flashC = factoryFlash;
 		auto patchC = factoryPatch;
 		flashC[12 * md::g_uwFlashSectorSize + 333] ^= 0x63;
 		patchC[patchC.size() / 2] ^= 0x73;
-		const auto stateC = pluginState(patchC, flashC, factoryFlash, rom);
+		const auto stateC = mdPluginState(patchC, flashC, factoryFlash, rom);
+
+		verifyHeadlessStandaloneLifecycle(
+			md::MachineModel::Machinedrum, completeStateA);
 
 		Harness successful;
 		successful.process(64);
@@ -337,6 +488,11 @@ int main()
 					md::DevicePreparedStateTestAccess::deferredHardware(*device);
 				require(candidate != nullptr,
 					"pending restore did not retain an isolated candidate");
+				require(md::DevicePreparedStateTestAccess::publisher(live)
+					== md::DevicePreparedStateTestAccess::livePublisher(*device)
+					&& md::DevicePreparedStateTestAccess::publisher(*candidate)
+					!= md::DevicePreparedStateTestAccess::livePublisher(*device),
+					"prepared and live machines shared the SPSC front-panel publisher");
 				const auto livePanelBytes = live.getPendingPanelInputBytes();
 				const auto candidatePanelBytes = candidate->getPendingPanelInputBytes();
 				device->sendPanelEvent(0x24, 0x02); // MD Function press.
@@ -391,9 +547,27 @@ int main()
 			gate.arriveAndWait();
 			resultC = successful.processor.getPlugin().setState(stateC);
 		});
+		std::atomic<bool> keepProcessing{true};
+		std::atomic<bool> audioStarted{false};
+		std::atomic<uint32_t> concurrentAudioBlocks{0};
+		std::thread audioThread([&]
+		{
+			audioStarted.store(true, std::memory_order_release);
+			while(keepProcessing.load(std::memory_order_acquire))
+			{
+				successful.process(1);
+				concurrentAudioBlocks.fetch_add(1, std::memory_order_relaxed);
+			}
+		});
+		while(!audioStarted.load(std::memory_order_acquire))
+			std::this_thread::yield();
 		gate.release();
 		threadB.join();
 		threadC.join();
+		keepProcessing.store(false, std::memory_order_release);
+		audioThread.join();
+		require(concurrentAudioBlocks.load(std::memory_order_relaxed) > 0,
+			"audio did not run during concurrent replacement construction");
 		require(resultB || resultC, "all concurrent processor restore requests failed");
 
 		std::vector<uint8_t> currentState;
@@ -448,13 +622,28 @@ int main()
 				require(device && device->getHardware().copyFlashData() == expectedFlash
 					&& device->getHardware().getUC().copyPatchRam() == expectedPatch,
 					"processor committed the wrong concurrent restore generation");
+				require(md::DevicePreparedStateTestAccess::publisher(device->getHardware())
+					== md::DevicePreparedStateTestAccess::livePublisher(*device),
+					"committed machine was not rebound to the live front-panel publisher");
 			});
+
+		// A malformed cold-start payload must fail deterministically and identify the
+		// layer that rejected it, rather than collapsing every failure into the same
+		// generic standalone alert.
+		auto malformed = stateA;
+		malformed.resize(17);
+		setHostState(successful, malformed);
+		require(successful.snapshot().status == RestoreStatus::Failed,
+			"malformed state did not enter the failed restore state");
+		require(successful.processor.getProjectStateRestoreError().find("payload")
+			!= std::string::npos,
+			"malformed state failure did not retain an actionable diagnostic");
 
 		auto wrongFactory = factoryFlash;
 		wrongFactory[2 * md::g_uwFlashSectorSize + 17] ^= 0x41;
 		auto wrongProject = wrongFactory;
 		wrongProject[14 * md::g_uwFlashSectorSize + 91] ^= 0x24;
-		const auto rejectedState = pluginState(factoryPatch, wrongProject,
+		const auto rejectedState = mdPluginState(factoryPatch, wrongProject,
 			wrongFactory, rom);
 		Harness rejected;
 		setHostState(rejected, rejectedState);
@@ -482,7 +671,100 @@ int main()
 		require(serializedPluginState(rejected.processor) != rejectedState,
 			"processor kept advertising a rejected project as authoritative");
 
-		std::cout << "mdProjectStateRestoreTest: PASS\n";
+		// MM does not need the MD factory-flash initialization phase, but it uses
+		// the same unlocked replacement transaction. Exercise its real firmware on
+		// the standalone ordering: restore first, then prepare/start audio.
+		std::vector<uint8_t> mmPatchA(md::g_patchRamStateSize, 0);
+		std::vector<uint8_t> mmPatchB(md::g_patchRamStateSize, 0);
+		std::vector<uint8_t> mmPatchC(md::g_patchRamStateSize, 0);
+		for(size_t offset = 0; offset < mmPatchA.size(); offset += 4093)
+		{
+			mmPatchA[offset] = static_cast<uint8_t>(offset >> 8);
+			mmPatchB[offset] = static_cast<uint8_t>((offset >> 7) ^ 0x5a);
+			mmPatchC[offset] = static_cast<uint8_t>((offset >> 6) ^ 0xa5);
+		}
+		const auto mmStateA = mmPluginState(mmPatchA);
+		const auto mmStateB = mmPluginState(mmPatchB);
+		const auto mmStateC = mmPluginState(mmPatchC);
+		verifyHeadlessStandaloneLifecycle(md::MachineModel::Monomachine, mmStateA);
+
+		Harness mmCold(md::MachineModel::Monomachine, false);
+		const auto mmBefore = mmCold.snapshot();
+		setHostState(mmCold, mmStateA);
+		const auto mmRestoredBeforeAudio = mmCold.snapshot();
+		require(mmRestoredBeforeAudio.status == RestoreStatus::Idle
+			&& mmRestoredBeforeAudio.hardwareEpoch == mmBefore.hardwareEpoch + 1
+			&& mmRestoredBeforeAudio.liveHardware != mmBefore.liveHardware,
+			"Monomachine cold state was not committed before audio startup");
+		require(serializedPluginState(mmCold.processor) == mmStateA,
+			"Monomachine cold-start serialization lost the restored project");
+		mmCold.prepareAudio();
+		mmCold.process(128);
+
+		StartGate mmGate;
+		bool mmResultB = false;
+		bool mmResultC = false;
+		std::thread mmThreadB([&]
+		{
+			mmGate.arriveAndWait();
+			mmResultB = mmCold.processor.getPlugin().setState(mmStateB);
+		});
+		std::thread mmThreadC([&]
+		{
+			mmGate.arriveAndWait();
+			mmResultC = mmCold.processor.getPlugin().setState(mmStateC);
+		});
+		std::atomic<bool> mmKeepProcessing{true};
+		std::atomic<uint32_t> mmAudioBlocks{0};
+		std::thread mmAudioThread([&]
+		{
+			while(mmKeepProcessing.load(std::memory_order_acquire))
+			{
+				mmCold.process(1);
+				mmAudioBlocks.fetch_add(1, std::memory_order_relaxed);
+			}
+		});
+		mmGate.release();
+		mmThreadB.join();
+		mmThreadC.join();
+		mmKeepProcessing.store(false, std::memory_order_release);
+		mmAudioThread.join();
+		require(mmAudioBlocks.load(std::memory_order_relaxed) > 0,
+			"Monomachine audio did not run during replacement construction");
+		require(mmResultB || mmResultC,
+			"all concurrent Monomachine restore requests failed");
+		const auto mmWinningState = serializedPluginState(mmCold.processor);
+		require(mmWinningState.size() > 2 && mmWinningState[0] == 1
+			&& mmWinningState[1] == synthLib::StateTypeGlobal,
+			"concurrent Monomachine restore published an invalid device envelope");
+		std::vector<uint8_t> mmWinningPayload(mmWinningState.begin() + 2,
+			mmWinningState.end());
+		std::vector<uint8_t> mmWinningPatch;
+		require(md::decodeState(mmWinningPatch, mmWinningPayload,
+			md::MachineModel::Monomachine, synthLib::StateTypeGlobal),
+			"concurrent Monomachine restore published a torn or corrupt state");
+		mmCold.processor.getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				require(device && device->getModel() == md::MachineModel::Monomachine
+					&& device->projectStateRestoreStatus() == RestoreStatus::Idle
+					&& device->getHardware().getUC().copyPatchRam() == mmWinningPatch,
+					"Monomachine serialization did not match the committed live machine");
+				require(md::DevicePreparedStateTestAccess::publisher(device->getHardware())
+					== md::DevicePreparedStateTestAccess::livePublisher(*device),
+					"committed Monomachine was not rebound to the live panel publisher");
+			});
+
+		auto malformedMm = mmStateA;
+		malformedMm.resize(23);
+		setHostState(mmCold, malformedMm);
+		require(mmCold.snapshot().status == RestoreStatus::Failed
+			&& mmCold.processor.getProjectStateRestoreError().find("Monomachine")
+				!= std::string::npos,
+			"malformed Monomachine state did not retain a model-specific diagnostic");
+
+		std::cout << "mdProjectStateRestoreTest: MD/MM PASS\n";
 		return 0;
 	}
 	catch(const std::exception& error)

--- a/source/elektron/md/mdJucePlugin/mdProjectStateRestoreTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdProjectStateRestoreTest.cpp
@@ -412,6 +412,10 @@ namespace
 
 int main()
 {
+	// AudioProcessorPlayer pulls in JUCE's platform audio and GUI services. Keep
+	// their lifetime balanced on Windows even when the firmware-backed test skips.
+	juce::ScopedJuceInitialiser_GUI juce;
+
 	const auto* const firmwarePath = std::getenv("GEARMULATOR_MD_FIRMWARE_BIN");
 	const auto* const mmFirmwarePath = std::getenv("GEARMULATOR_MM_FIRMWARE_BIN");
 	if(!firmwarePath || !*firmwarePath || !mmFirmwarePath || !*mmFirmwarePath)
@@ -420,7 +424,6 @@ int main()
 		return 77;
 	}
 
-	juce::ScopedJuceInitialiser_GUI juce;
 	try
 	{
 		std::ifstream input(firmwarePath, std::ios::binary);

--- a/source/elektron/md/mdJucePlugin/mdProjectStateRestoreTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdProjectStateRestoreTest.cpp
@@ -18,6 +18,7 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <string>
@@ -412,10 +413,6 @@ namespace
 
 int main()
 {
-	// AudioProcessorPlayer pulls in JUCE's platform audio and GUI services. Keep
-	// their lifetime balanced on Windows even when the firmware-backed test skips.
-	juce::ScopedJuceInitialiser_GUI juce;
-
 	const auto* const firmwarePath = std::getenv("GEARMULATOR_MD_FIRMWARE_BIN");
 	const auto* const mmFirmwarePath = std::getenv("GEARMULATOR_MM_FIRMWARE_BIN");
 	if(!firmwarePath || !*firmwarePath || !mmFirmwarePath || !*mmFirmwarePath)
@@ -424,6 +421,7 @@ int main()
 		return 77;
 	}
 
+	juce::ScopedJuceInitialiser_GUI juce;
 	try
 	{
 		std::ifstream input(firmwarePath, std::ios::binary);
@@ -441,11 +439,15 @@ int main()
 		synthLib::RomLoader::addSearchPath(
 			juce::File(mmFirmwarePath).getParentDirectory().getFullPathName().toStdString());
 
-		md::Hardware factory(rom, firmwarePath, md::MachineModel::Machinedrum);
-		require(factory.isValid() && initializeUwFlash(factory),
+		// Hardware contains the complete emulated machine and is larger than the
+		// default 1 MiB Windows process stack. Keep it on the heap so both the
+		// fixture-free skip and the real-firmware test can enter main safely.
+		auto factory = std::make_unique<md::Hardware>(
+			rom, firmwarePath, md::MachineModel::Machinedrum);
+		require(factory->isValid() && initializeUwFlash(*factory),
 			"could not establish the OS 1.63 factory flash baseline");
-		const auto factoryFlash = factory.copyFlashData();
-		const auto factoryPatch = factory.getUC().copyPatchRam();
+		const auto factoryFlash = factory->copyFlashData();
+		const auto factoryPatch = factory->getUC().copyPatchRam();
 
 		auto flashA = factoryFlash;
 		auto patchA = factoryPatch;

--- a/source/elektron/md/mdLib/mddevice.cpp
+++ b/source/elektron/md/mdLib/mddevice.cpp
@@ -121,8 +121,7 @@ namespace md
 		: synthLib::Device(_params)
 		, m_model(machineModelFromDeviceCustomData(_params.customData))
 		, m_frontPanelPublisher(std::make_shared<FrontPanelPublisher>())
-		, m_preparationContext(new PreparationContext(_params, m_model,
-			m_frontPanelPublisher))
+		, m_preparationContext(new PreparationContext(_params, m_model))
 		, m_mdFlashCacheFilename(mdFlashCacheFilename(_params, m_model))
 	{
 		auto initialFlash = loadInitialMdFlash(_params, m_model);
@@ -276,7 +275,9 @@ namespace md
 		m_displaced.reset();
 		m_prepared = m_state
 			? Device::prepareState(m_context, *m_state, m_type,
-				m_factoryFlash) : nullptr;
+				m_factoryFlash, &m_error) : nullptr;
+		if(!m_state)
+			m_error = "The project state payload is missing.";
 		return m_prepared != nullptr;
 	}
 
@@ -309,7 +310,9 @@ namespace md
 			return false;
 		if(!transaction->m_prepared)
 		{
-			failProjectStateRestore("The project state could not be prepared.");
+			failProjectStateRestore(transaction->m_error.empty()
+				? "The project state could not be prepared."
+				: transaction->m_error);
 			return false;
 		}
 		if(transaction->m_prepared->m_hardware->isProjectStateRestorePending())
@@ -352,7 +355,7 @@ namespace md
 		auto replacement = std::make_unique<Hardware>(
 			_validated.m_context->m_romData, _validated.m_context->m_romName,
 			_validated.m_context->m_model, _validated.m_hardware->copyPatchRam(),
-			_validated.m_context->m_frontPanelPublisher,
+			std::shared_ptr<FrontPanelPublisher>{},
 			_validated.m_hardware->copyFlashData(), cache);
 		if(!replacement->isValid())
 			return {};
@@ -363,10 +366,18 @@ namespace md
 	std::unique_ptr<Device::PreparedState> Device::prepareState(
 		std::shared_ptr<const PreparationContext> _context,
 		const std::vector<uint8_t>& _state, const synthLib::StateType _type,
-		const FactoryFlashSnapshot& _factoryFlash)
+		const FactoryFlashSnapshot& _factoryFlash, std::string* const _error)
 	{
+		const auto fail = [_error](const char* const _message)
+		{
+			if(_error)
+				*_error = _message;
+			return std::unique_ptr<PreparedState>{};
+		};
+		if(_error)
+			_error->clear();
 		if(!_context)
-			return {};
+			return fail("The project state has no preparation context.");
 
 		std::vector<uint8_t> patchRam;
 		std::vector<uint8_t> initialFlash;
@@ -374,17 +385,17 @@ namespace md
 		if(_context->m_model == MachineModel::Monomachine)
 		{
 			if(!decodeState(patchRam, _state, _context->m_model, _type))
-				return {};
+				return fail("The Monomachine project payload is invalid or incompatible.");
 		}
 		else
 		{
 			auto stateRom = loadStateRom(_context->m_romData, _context->m_romName,
 				_context->m_model);
 			if(!stateRom.isValid())
-				return {};
+				return fail("The Machinedrum firmware needed to restore this project is unavailable or invalid.");
 			DecodedState decoded;
 			if(!decodeState(decoded, _state, stateRom.data(), _context->m_model, _type))
-				return {};
+				return fail("The Machinedrum project payload is corrupt, incompatible, or belongs to different firmware.");
 			patchRam = std::move(decoded.patchRam);
 			containsFlash = decoded.containsFlash;
 			auto factory = loadInitialMdFlash(stateRom,
@@ -393,7 +404,7 @@ namespace md
 			{
 				if(!decodeFactoryFlashCache(factory.flash, _factoryFlash.cache,
 					stateRom.data()))
-					return {};
+					return fail("The captured Machinedrum factory-flash cache is invalid for this firmware.");
 				factory.cache = _factoryFlash.cache;
 			}
 			else if(factory.cache.empty() && !_factoryFlash.baseline.empty())
@@ -401,7 +412,7 @@ namespace md
 				factory.flash = _factoryFlash.baseline;
 				if(!encodeFactoryFlashCache(factory.cache, factory.flash,
 					stateRom.data()))
-					return {};
+					return fail("The Machinedrum factory-flash baseline could not be prepared.");
 			}
 			FlashSectorOverlay pending;
 			if(containsFlash)
@@ -410,7 +421,7 @@ namespace md
 				{
 					if(!applyFlashOverlay(initialFlash, decoded.flashOverlay,
 						factory.flash, stateRom.data()))
-						return {};
+						return fail("The project sample-flash overlay does not match the Machinedrum factory baseline.");
 				}
 				else if(decoded.flashOverlay.sectors.size()
 					== g_romSize / g_uwFlashSectorSize)
@@ -419,7 +430,7 @@ namespace md
 					// the replacement starts so firmware boots from one coherent project.
 					if(!applyFlashOverlay(initialFlash, decoded.flashOverlay,
 						stateRom.data(), stateRom.data()))
-						return {};
+						return fail("The complete project sample-flash image could not be materialized.");
 				}
 				else
 					pending = std::move(decoded.flashOverlay);
@@ -429,11 +440,10 @@ namespace md
 
 			auto replacement = std::make_unique<Hardware>(
 				_context->m_romData, _context->m_romName, _context->m_model, patchRam,
-				pending.valid ? std::shared_ptr<FrontPanelPublisher>{}
-					: _context->m_frontPanelPublisher,
+				std::shared_ptr<FrontPanelPublisher>{},
 				initialFlash, factory.cache, pending);
 			if(!replacement->isValid())
-				return {};
+				return fail("The replacement Machinedrum machine rejected the restored firmware or memory image.");
 			return std::unique_ptr<PreparedState>(
 				new PreparedState(std::move(_context), std::move(replacement),
 					containsFlash));
@@ -441,9 +451,9 @@ namespace md
 
 		auto replacement = std::make_unique<Hardware>(
 			_context->m_romData, _context->m_romName, _context->m_model, patchRam,
-			_context->m_frontPanelPublisher, initialFlash);
+			std::shared_ptr<FrontPanelPublisher>{}, initialFlash);
 		if(!replacement->isValid())
-			return {};
+			return fail("The replacement Monomachine rejected the restored firmware or memory image.");
 		return std::unique_ptr<PreparedState>(
 			new PreparedState(std::move(_context), std::move(replacement),
 				containsFlash));
@@ -469,6 +479,7 @@ namespace md
 		}
 
 		m_frontPanelPublisher->reset();
+		_prepared.m_hardware->setFrontPanelPublisher(m_frontPanelPublisher);
 		m_hardware.swap(_prepared.m_hardware);
 		++m_hardwareEpoch;
 		_prepared.m_committed = true;

--- a/source/elektron/md/mdLib/mddevice.h
+++ b/source/elektron/md/mdLib/mddevice.h
@@ -36,12 +36,11 @@ namespace md
 			friend struct DevicePreparedStateTestAccess;
 
 			PreparationContext(const synthLib::DeviceCreateParams& _params,
-				MachineModel _model, std::shared_ptr<FrontPanelPublisher> _frontPanelPublisher)
+				MachineModel _model)
 				: m_romData(_params.romData)
 				, m_romName(_params.romName)
 				, m_homePath(_params.homePath)
 				, m_model(_model)
-				, m_frontPanelPublisher(std::move(_frontPanelPublisher))
 			{
 			}
 
@@ -55,7 +54,6 @@ namespace md
 			const std::string m_romName;
 			const std::string m_homePath;
 			const MachineModel m_model;
-			const std::shared_ptr<FrontPanelPublisher> m_frontPanelPublisher;
 		};
 
 		class PreparedState
@@ -103,7 +101,8 @@ namespace md
 		static std::unique_ptr<PreparedState> prepareState(
 			std::shared_ptr<const PreparationContext> _context,
 			const std::vector<uint8_t>& _state, synthLib::StateType _type,
-			const FactoryFlashSnapshot& _factoryFlash = {});
+			const FactoryFlashSnapshot& _factoryFlash = {},
+			std::string* _error = nullptr);
 		// A sparse UW state cannot be validated without its matching factory
 		// baseline. Keep the live Hardware authoritative while an isolated candidate
 		// performs first-run initialization, then cold-boot the validated images.
@@ -213,6 +212,7 @@ namespace md
 			uint64_t m_generation;
 			std::unique_ptr<PreparedState> m_displaced;
 			std::unique_ptr<PreparedState> m_prepared;
+			std::string m_error;
 		};
 
 		void clearProjectStateRestore();

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -129,14 +129,7 @@ namespace md
 
 		// Feed the OS's host->panel UART2 stream into the front-panel LCD/LED decoder.
 		m_uc.setFrontPanel(&m_frontPanel);
-		const auto panelPublisher = m_frontPanelPublisher;
-		m_uc.setPanelLedTransitionCallback(
-			[panelPublisher](const uint8_t _command, const uint8_t _value,
-				const uint64_t _emulationCycles)
-			{
-				(void)panelPublisher->tryPushLedTransition(
-					_command, _value, _emulationCycles);
-			});
+		setFrontPanelPublisher(m_frontPanelPublisher);
 
 		// Inter-DSP ESSI0 ring. Each DSP's
 		// ESSI0 TX pushes its frame into the OTHER DSP's ESSI0 audio-INPUT ring (blocking
@@ -482,6 +475,23 @@ namespace md
 		m_uc.reset();
 		m_uc.exec();	// prefetch warm-up (retires nothing; matches the synchronous harness)
 
+	}
+
+	void Hardware::setFrontPanelPublisher(
+		std::shared_ptr<FrontPanelPublisher> _publisher)
+	{
+		if(!_publisher)
+			_publisher = std::make_shared<FrontPanelPublisher>();
+		m_frontPanelPublisher = std::move(_publisher);
+		const auto panelPublisher = m_frontPanelPublisher;
+		m_uc.setPanelLedTransitionCallback(
+			[panelPublisher](const uint8_t _command, const uint8_t _value,
+				const uint64_t _emulationCycles)
+			{
+				(void)panelPublisher->tryPushLedTransition(
+					_command, _value, _emulationCycles);
+			});
+		(void)m_frontPanelPublisher->tryPublish(m_frontPanel);
 	}
 
 	Hardware::~Hardware() = default;

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -209,9 +209,14 @@ namespace md
 
 	private:
 		friend class Device;
+		friend struct DevicePreparedStateTestAccess;
 		// Transfer the live sample-flash image and its factory-capture bookkeeping
 		// into a prepared cold-boot machine without copying their backing stores.
 		bool exchangePersistentFlashState(Hardware& _other);
+		// Prepared machines publish into a private queue while they boot. Rebinding
+		// happens only while Device is exclusively locked, immediately before commit,
+		// so the live SPSC publisher always has exactly one producer.
+		void setFrontPanelPublisher(std::shared_ptr<FrontPanelPublisher> _publisher);
 
 		void ensureBufferSize(uint32_t _frames);
 		void setHostAudioInputLatency(uint32_t _latency);

--- a/source/jucePluginLib/tools.cpp
+++ b/source/jucePluginLib/tools.cpp
@@ -5,6 +5,8 @@
 #include "juce_audio_processors/juce_audio_processors.h"
 #include "juce_gui_basics/juce_gui_basics.h"
 
+#include <cstdlib>
+
 namespace pluginLib
 {
 	bool Tools::isHeadless()
@@ -23,6 +25,16 @@ namespace pluginLib
 
 	std::string Tools::getPublicDataFolder(const std::string& _vendorName, const std::string& _productName)
 	{
-		return baseLib::filesystem::validatePath(baseLib::filesystem::getSpecialFolderPath(baseLib::filesystem::SpecialFolderType::UserDocuments) + _vendorName + '/' + _productName + '/');
+		// Package verification and standalone lifecycle tests must not read or
+		// modify a developer's real Documents folder. The release scripts already
+		// provide this override; honour it here so those tests exercise a real
+		// firmware-backed device instead of silently falling back to DummyDevice.
+		const auto* const dataRoot = std::getenv("GEARMULATOR_DATA_ROOT");
+		const auto root = dataRoot != nullptr && *dataRoot != '\0'
+			? baseLib::filesystem::validatePath(dataRoot)
+			: baseLib::filesystem::getSpecialFolderPath(
+				baseLib::filesystem::SpecialFolderType::UserDocuments);
+		return baseLib::filesystem::validatePath(
+			root + _vendorName + '/' + _productName + '/');
 	}
 }


### PR DESCRIPTION
Fixes the standalone startup/state-restore race and sparse CoreAudio channel handling at their architectural boundaries. Keeps the MD/MM processor bus topology stable, isolates candidate machine publishers until commit, restores saved state before audio-device startup, and adds deterministic headless coverage for sparse channels, device transitions, cold restore, concurrent audio/restore, firmware-backed MD/MM restore, and failure diagnostics.\n\nJUCE fixes are published at joelanders/JUCE-md-mm commit dc438ed540.\n\nValidated locally with ASan-only mdAudioIoLayoutTest and firmware-backed mdProjectStateRestoreTest; normal release builds of both tests, pluginTester, MD/MM VST3, and MD/MM Standalone; and 10 isolated firmware-backed cold-start processes for each synth.