### PR TITLE
Make MD/MM test gates report honestly

### DIFF
--- a/.github/workflows/mdmm-audio-io.yml
+++ b/.github/workflows/mdmm-audio-io.yml
@@ -58,11 +58,12 @@ jobs:
         run: >-
           cmake --build build --config Release --parallel 3
           --target synthLibAudioTest mdAudioQueueTest mdAudioFirmwareTest
+          mdUwFirmwareTest
 
       - name: Run headless audio tests
         run: >-
           ctest --test-dir build -C Release --output-on-failure
-          --tests-regex "^(synthLibAudioTest|mdAudioQueueTest|mdAudioFirmwareTest)$"
+          --tests-regex "^(synthLibAudioTest|mdAudioQueueTest|mdAudioFirmwareTest|mdUwFirmwareTest)$"
 
   juce-layout:
     name: JUCE and built VST3 (${{ matrix.os }})

--- a/.github/workflows/mdmm-core.yml
+++ b/.github/workflows/mdmm-core.yml
@@ -67,6 +67,9 @@ jobs:
           mdAutomationMidiTest
           mdAutomationParameterTest
           mdAutomationRobustnessTest
+          mdStateTest
+          mdFlashTest
+          mdFrontPanelPresentationTest
           mdAudioIoLayoutTest
 
       - name: Run fixture-free gates
@@ -77,7 +80,7 @@ jobs:
           ctest --test-dir build-mdmm-core -C Release --output-on-failure
           --no-tests=error
           --tests-regex
-          '^(midiOutputDispatcherTest|mdAutomationMidiTest|mdAutomationParameterTest|mdAutomationArchitectureTest|mdAudioIoLayoutTest)$'
+          '^(midiOutputDispatcherTest|mdAutomationMidiTest|mdAutomationParameterTest|mdAutomationArchitectureTest|mdStateTest|mdFlashTest|mdFrontPanelPresentationTests|mdAudioIoLayoutTest)$'
 
   shared-controller-compatibility:
     name: shared controller compatibility

--- a/scripts/macos/build_mdmm.sh
+++ b/scripts/macos/build_mdmm.sh
@@ -140,11 +140,15 @@ cmake --build "${build_dir}" --parallel 4 --target \
   pluginTester \
   synthLibAudioTest \
   mdLibTest \
+  mdStateTest \
+  mdFlashTest \
+  mdUwFirmwareTest \
   mdAudioQueueTest \
   mdAudioFirmwareTest \
   mdAudioIoLayoutTest \
   mdProjectStateRestoreTest \
   mdAudioProbePlugin_VST3 \
+  mdFrontPanelPresentationTest \
   mdFirmwareImageTest \
   mc68kColdFireDivideTest
 
@@ -165,6 +169,9 @@ fi
 for test_name in \
   synthLibAudioTest \
   mdLibTests \
+  mdStateTest \
+  mdFlashTest \
+  mdFrontPanelPresentationTests \
   mdAudioQueueTest \
   mdAudioIoLayoutTest \
   mdAudioProbePluginVST3IdentityTest \
@@ -180,6 +187,11 @@ for test_name in \
 done
 
 if [[ "${require_firmware_tests}" == "1" ]]; then
+  HOME="${build_runtime_home}" GEARMULATOR_DATA_ROOT="${build_runtime_data}" \
+    GEARMULATOR_MD_FIRMWARE_BIN="${md_firmware_bin}" \
+    GEARMULATOR_REQUIRE_FIRMWARE_TESTS=1 \
+    ctest --test-dir "${build_dir}" -C Release --output-on-failure \
+      --no-tests=error --tests-regex '^mdUwFirmwareTest$'
   GEARMULATOR_MD_FIRMWARE_BIN="${md_firmware_bin}" \
     GEARMULATOR_MM_FIRMWARE_BIN="${mm_firmware_bin}" \
     ctest --test-dir "${build_dir}" -C Release --output-on-failure \
@@ -197,7 +209,8 @@ if [[ "${require_firmware_tests}" == "1" ]]; then
 else
   HOME="${build_runtime_home}" GEARMULATOR_DATA_ROOT="${build_runtime_data}" \
     ctest --test-dir "${build_dir}" -C Release --output-on-failure \
-      --no-tests=error --tests-regex '^mdAudioFirmwareTest$'
+      --no-tests=error \
+      --tests-regex '^(mdUwFirmwareTest|mdAudioFirmwareTest)$'
 fi
 
 # Private fixtures are no longer needed after the firmware-backed executables

--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -151,13 +151,15 @@ if(BUILD_TESTING)
 	add_md_automation_firmware_test(mdAutomationFirmwareTest
 		mdAutomationFirmwareTest.cpp)
 	add_test(NAME mdAutomationFirmwareTest COMMAND mdAutomationFirmwareTest)
-	set_tests_properties(mdAutomationFirmwareTest PROPERTIES LABELS "Integration")
+	set_tests_properties(mdAutomationFirmwareTest PROPERTIES
+		LABELS "Integration;FirmwareTest"
+		SKIP_RETURN_CODE 77)
 
 	add_md_automation_firmware_test(mdAutomationRobustnessTest
 		mdAutomationRobustnessTest.cpp)
 	add_test(NAME mdAutomationRobustnessTest COMMAND mdAutomationRobustnessTest)
 	set_tests_properties(mdAutomationRobustnessTest PROPERTIES
-		LABELS "Integration" TIMEOUT 300)
+		LABELS "Integration;FirmwareTest" SKIP_RETURN_CODE 77 TIMEOUT 300)
 	add_test(NAME mdAutomationArchitectureTest COMMAND mdAutomationRobustnessTest
 		--architecture-only)
 	set_tests_properties(mdAutomationArchitectureTest PROPERTIES
@@ -168,7 +170,7 @@ if(BUILD_TESTING)
 	add_test(NAME mdAutomationSoakTest COMMAND mdAutomationSoakTest
 		--soak-writes=256 --multi-writes=128)
 	set_tests_properties(mdAutomationSoakTest PROPERTIES
-		LABELS "Integration" TIMEOUT 300)
+		LABELS "Integration;FirmwareTest" SKIP_RETURN_CODE 77 TIMEOUT 300)
 
 	option(MD_AUTOMATION_REGISTER_FULL_SOAK_TEST
 		"Register the full MD/MM automation soak with CTest" OFF)
@@ -176,7 +178,8 @@ if(BUILD_TESTING)
 		add_test(NAME mdAutomationFullSoakTest COMMAND mdAutomationSoakTest
 			--soak-writes=8192 --multi-writes=2048)
 		set_tests_properties(mdAutomationFullSoakTest PROPERTIES
-			LABELS "Integration;Soak" TIMEOUT 900)
+			LABELS "Integration;FirmwareTest;Soak"
+			SKIP_RETURN_CODE 77 TIMEOUT 900)
 	endif()
 
 	add_executable(mdProjectStateRestoreTest mdProjectStateRestoreTest.cpp)

--- a/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationFirmwareTest.cpp
@@ -14,14 +14,11 @@ namespace
 		return *result;
 	}
 
-	void verifyModel(const md::MachineModel _model)
+	bool verifyModel(const md::MachineModel _model)
 	{
 		Harness harness(_model);
 		if(!harness.hasLocalFirmware())
-		{
-			allowMissingFirmware("mdAutomationFirmwareTest", _model);
-			return;
-		}
+			return allowMissingFirmware("mdAutomationFirmwareTest", _model);
 		harness.prepare();
 
 		auto& audioProcessor = harness.audioProcessor;
@@ -149,6 +146,7 @@ namespace
 		std::cout << "mdAutomationFirmwareTest: "
 			<< modelName(_model)
 			<< " PASS\n";
+		return true;
 	}
 }
 
@@ -158,11 +156,14 @@ int main(const int _argc, const char* const* _argv)
 	try
 	{
 		const auto only = _argc > 1 ? std::string(_argv[1]) : std::string();
+		bool ranFirmwareCase = false;
 		if(only != "--mm")
-			verifyModel(md::MachineModel::Machinedrum);
+			ranFirmwareCase = verifyModel(md::MachineModel::Machinedrum)
+				|| ranFirmwareCase;
 		if(only != "--md")
-			verifyModel(md::MachineModel::Monomachine);
-		return 0;
+			ranFirmwareCase = verifyModel(md::MachineModel::Monomachine)
+				|| ranFirmwareCase;
+		return ranFirmwareCase ? 0 : mdAutomationTest::SkipReturnCode;
 	}
 	catch(const std::exception& error)
 	{

--- a/source/elektron/md/mdJucePlugin/mdAutomationRobustnessTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationRobustnessTest.cpp
@@ -997,14 +997,11 @@ namespace
 			"randomized lifecycle overflowed firmware MIDI RX");
 	}
 
-	void verifyModel(const md::MachineModel _model)
+	bool verifyModel(const md::MachineModel _model)
 	{
 		Harness harness(_model);
 		if(!harness.hasLocalFirmware())
-		{
-			allowMissingFirmware("mdAutomationRobustnessTest", _model);
-			return;
-		}
+			return allowMissingFirmware("mdAutomationRobustnessTest", _model);
 		verifyQueuedPreBootWrites(harness);
 		verifyExternalNotifications(harness);
 		verifyCorrelatedDumpsAndStrictStatus(harness);
@@ -1014,6 +1011,7 @@ namespace
 		verifyRandomizedLifecycle(harness);
 		std::cout << "mdAutomationRobustnessTest: " << modelName(_model)
 			<< " PASS\n";
+		return true;
 	}
 
 	void verifyArchitecture(const md::MachineModel _model)
@@ -1060,11 +1058,14 @@ int main(const int _argc, const char* const* _argv)
 				verifyArchitecture(md::MachineModel::Monomachine);
 			return 0;
 		}
+		bool ranFirmwareCase = false;
 		if(!mmOnly)
-			verifyModel(md::MachineModel::Machinedrum);
+			ranFirmwareCase = verifyModel(md::MachineModel::Machinedrum)
+				|| ranFirmwareCase;
 		if(!mdOnly)
-			verifyModel(md::MachineModel::Monomachine);
-		return 0;
+			ranFirmwareCase = verifyModel(md::MachineModel::Monomachine)
+				|| ranFirmwareCase;
+		return ranFirmwareCase ? 0 : mdAutomationTest::SkipReturnCode;
 	}
 	catch(const std::exception& error)
 	{

--- a/source/elektron/md/mdJucePlugin/mdAutomationSoakTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAutomationSoakTest.cpp
@@ -96,14 +96,11 @@ namespace
 			"soak dropped firmware output at controller queue capacity");
 	}
 
-	void verifyModel(const md::MachineModel _model, const size_t _writeCount)
+	bool verifyModel(const md::MachineModel _model, const size_t _writeCount)
 	{
 		Harness harness(_model);
 		if(!harness.hasLocalFirmware())
-		{
-			allowMissingFirmware("mdAutomationSoakTest", _model);
-			return;
-		}
+			return allowMissingFirmware("mdAutomationSoakTest", _model);
 		harness.prepare();
 		require(harness.synchronize(), "soak firmware synchronization timed out");
 		// Synchronization completes once the authoritative dumps are applied, while
@@ -113,9 +110,10 @@ namespace
 		verifyFirmwareSoak(harness, _writeCount);
 		std::cout << "mdAutomationSoakTest: " << modelName(_model)
 			<< " PASS (" << _writeCount << " writes)\n";
+		return true;
 	}
 
-	void verifyConcurrentIsolation(const size_t _writeCount)
+	bool verifyConcurrentIsolation(const size_t _writeCount)
 	{
 		Harness mdHarness(md::MachineModel::Machinedrum);
 		Harness mmHarness(md::MachineModel::Monomachine);
@@ -126,7 +124,7 @@ namespace
 					"mdAutomationSoakTest: both firmware fixtures are required for multi-instance testing");
 			std::cout << "mdAutomationSoakTest: SKIP multi-instance"
 				" (firmware unavailable)\n";
-			return;
+			return false;
 		}
 		mdHarness.prepare();
 		mmHarness.prepare();
@@ -217,6 +215,7 @@ namespace
 			std::rethrow_exception(mmError);
 		std::cout << "mdAutomationSoakTest: concurrent MD/MM PASS ("
 			<< _writeCount << " writes per instance)\n";
+		return true;
 	}
 }
 
@@ -251,16 +250,20 @@ int main(const int _argc, const char* const* _argv)
 		}
 		require(soakWrites > 0 && multiWrites > 0,
 			"write counts must be positive");
+		bool ranFirmwareCase = false;
 		if(!multiOnly)
 		{
 			if(!mmOnly)
-				verifyModel(md::MachineModel::Machinedrum, soakWrites);
+				ranFirmwareCase = verifyModel(
+					md::MachineModel::Machinedrum, soakWrites) || ranFirmwareCase;
 			if(!mdOnly)
-				verifyModel(md::MachineModel::Monomachine, soakWrites);
+				ranFirmwareCase = verifyModel(
+					md::MachineModel::Monomachine, soakWrites) || ranFirmwareCase;
 		}
 		if(!noMulti && !mdOnly && !mmOnly)
-			verifyConcurrentIsolation(multiWrites);
-		return 0;
+			ranFirmwareCase = verifyConcurrentIsolation(multiWrites)
+				|| ranFirmwareCase;
+		return ranFirmwareCase ? 0 : mdAutomationTest::SkipReturnCode;
 	}
 	catch(const std::exception& error)
 	{

--- a/source/elektron/md/mdJucePlugin/mdAutomationTestSupport.h
+++ b/source/elektron/md/mdJucePlugin/mdAutomationTestSupport.h
@@ -20,6 +20,7 @@
 namespace mdAutomationTest
 {
 	constexpr int BlockSize = 128;
+	constexpr int SkipReturnCode = 77;
 
 	inline void require(const bool _condition, const std::string& _message)
 	{
@@ -47,7 +48,7 @@ namespace mdAutomationTest
 				+ modelName(_model) + " firmware fixture is unavailable");
 		std::cout << _suite << ": SKIP " << modelName(_model)
 			<< " (firmware unavailable)\n";
-		return true;
+		return false;
 	}
 
 	struct MidiTelemetry

--- a/source/elektron/md/mdLibTest/CMakeLists.txt
+++ b/source/elektron/md/mdLibTest/CMakeLists.txt
@@ -24,6 +24,11 @@ set_property(TARGET mdAutomationMidiTest PROPERTY FOLDER "Elektron")
 
 add_executable(mdUwFirmwareTest mdUwFirmwareTest.cpp)
 target_link_libraries(mdUwFirmwareTest PRIVATE mdLib)
+add_test(NAME mdUwFirmwareTest COMMAND mdUwFirmwareTest)
+set_tests_properties(mdUwFirmwareTest PROPERTIES
+	LABELS "Integration;FirmwareTest;Uw"
+	SKIP_RETURN_CODE 77
+	TIMEOUT 900)
 set_property(TARGET mdUwFirmwareTest PROPERTY FOLDER "Elektron")
 
 add_executable(mdFlashTest mdFlashTest.cpp)

--- a/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
+++ b/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
@@ -146,27 +146,8 @@ namespace
 	}
 }
 
-int main(const int argc, const char* const* argv)
+static int runFirmwareTest(const char* const firmwarePath)
 {
-	if(argc > 2)
-	{
-		std::cerr << "usage: mdUwFirmwareTest [elektron_sps1-1uw_os1.63.bin]\n";
-		return 2;
-	}
-	const char* firmwarePath = argc == 2 ? argv[1]
-		: std::getenv("GEARMULATOR_MD_FIRMWARE_BIN");
-	if(!firmwarePath || !*firmwarePath)
-	{
-		const auto* const required =
-			std::getenv("GEARMULATOR_REQUIRE_FIRMWARE_TESTS");
-		if(required && std::string(required) == "1")
-		{
-			std::cerr << "mdUwFirmwareTest: required MD firmware fixture is unavailable\n";
-			return 1;
-		}
-		std::cout << "mdUwFirmwareTest: SKIP (pinned MD firmware not supplied)\n";
-		return 77;
-	}
 	std::ifstream input(firmwarePath, std::ios::binary);
 	const std::vector<uint8_t> rom{
 		std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
@@ -381,7 +362,7 @@ int main(const int argc, const char* const* argv)
 		|| device.projectStateRestoreError().empty())
 		return fail("wrong-factory UW state replaced the healthy live machine");
 
-	md::Hardware hardware(rom, argv[1], md::MachineModel::Machinedrum,
+	md::Hardware hardware(rom, firmwarePath, md::MachineModel::Machinedrum,
 		{}, {}, initializedFlash, factoryCache);
 	advance(hardware, md::g_samplerate * 20);
 
@@ -521,4 +502,32 @@ int main(const int argc, const char* const* argv)
 	std::cout << "Machinedrum UW ROM/RAM firmware test passed; ROM peak="
 		<< peak << ", RAM peak=" << ramPeak << '\n';
 	return 0;
+}
+
+int main(const int argc, const char* const* argv)
+{
+	if(argc > 2)
+	{
+		std::cerr << "usage: mdUwFirmwareTest [elektron_sps1-1uw_os1.63.bin]\n";
+		return 2;
+	}
+	const char* const firmwarePath = argc == 2 ? argv[1]
+		: std::getenv("GEARMULATOR_MD_FIRMWARE_BIN");
+	if(!firmwarePath || !*firmwarePath)
+	{
+		const auto* const required =
+			std::getenv("GEARMULATOR_REQUIRE_FIRMWARE_TESTS");
+		if(required && std::string(required) == "1")
+		{
+			std::cerr << "mdUwFirmwareTest: required MD firmware fixture is unavailable\n";
+			return 1;
+		}
+		std::cout << "mdUwFirmwareTest: SKIP (pinned MD firmware not supplied)\n";
+		return 77;
+	}
+
+	// Keep the firmware-heavy test in a separate stack frame. md::Hardware is
+	// large enough that MSVC otherwise overflows the stack before this skip path
+	// can run on fixture-free Windows CI hosts.
+	return runFirmwareTest(firmwarePath);
 }

--- a/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
+++ b/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
@@ -15,6 +15,7 @@
 #include <functional>
 #include <iostream>
 #include <iterator>
+#include <memory>
 #include <vector>
 
 namespace md
@@ -362,8 +363,10 @@ static int runFirmwareTest(const char* const firmwarePath)
 		|| device.projectStateRestoreError().empty())
 		return fail("wrong-factory UW state replaced the healthy live machine");
 
-	md::Hardware hardware(rom, firmwarePath, md::MachineModel::Machinedrum,
-		{}, {}, initializedFlash, factoryCache);
+	auto hardwareStorage = std::make_unique<md::Hardware>(rom, firmwarePath,
+		md::MachineModel::Machinedrum, std::vector<uint8_t>{},
+		std::shared_ptr<md::FrontPanelPublisher>{}, initializedFlash, factoryCache);
+	auto& hardware = *hardwareStorage;
 	advance(hardware, md::g_samplerate * 20);
 
 	if(!tap(hardware, md::PanelControl::Kit)

--- a/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
+++ b/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
@@ -9,6 +9,7 @@
 #include <array>
 #include <chrono>
 #include <cmath>
+#include <cstdlib>
 #include <cstdint>
 #include <fstream>
 #include <functional>
@@ -147,18 +148,31 @@ namespace
 
 int main(const int argc, const char* const* argv)
 {
-	if(argc != 2)
+	if(argc > 2)
 	{
-		std::cerr << "usage: mdUwFirmwareTest <elektron_sps1-1uw_os1.63.bin>\n";
+		std::cerr << "usage: mdUwFirmwareTest [elektron_sps1-1uw_os1.63.bin]\n";
 		return 2;
 	}
-
-	std::ifstream input(argv[1], std::ios::binary);
+	const char* firmwarePath = argc == 2 ? argv[1]
+		: std::getenv("GEARMULATOR_MD_FIRMWARE_BIN");
+	if(!firmwarePath || !*firmwarePath)
+	{
+		const auto* const required =
+			std::getenv("GEARMULATOR_REQUIRE_FIRMWARE_TESTS");
+		if(required && std::string(required) == "1")
+		{
+			std::cerr << "mdUwFirmwareTest: required MD firmware fixture is unavailable\n";
+			return 1;
+		}
+		std::cout << "mdUwFirmwareTest: SKIP (pinned MD firmware not supplied)\n";
+		return 77;
+	}
+	std::ifstream input(firmwarePath, std::ios::binary);
 	const std::vector<uint8_t> rom{
 		std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
 	synthLib::DeviceCreateParams deviceParams;
 	deviceParams.romData = rom;
-	deviceParams.romName = argv[1];
+	deviceParams.romName = firmwarePath;
 	deviceParams.customData = md::deviceCustomData(md::MachineModel::Machinedrum);
 	md::Device device(deviceParams);
 	auto& initializer = device.getHardware();


### PR DESCRIPTION
## Summary

- register the previously unregistered Machinedrum UW firmware test with CTest
- include the MD/MM state, flash, front-panel, and UW tests in the focused/release gates that should run them
- report unavailable private firmware as a real CTest skip instead of a successful test
- preserve per-product execution when only one firmware image is available
- keep required-fixture mode strict so missing firmware fails release verification

This changes test and release verification behavior only; it does not change production runtime behavior.

## Validation

- `mdStateTest`: passed
- `mdFlashTest`: passed
- `mdFrontPanelPresentationTests`: passed
- `mdAutomationArchitectureTest`: passed
- UW and automation firmware tests: correctly reported `Skipped` without private fixtures
- required-but-missing UW fixture: correctly failed
- all changed test executables compiled on macOS arm64
- macOS build-script syntax, workflow YAML parsing, and `git diff --check`: passed

The real-firmware test bodies were not run locally because the private firmware fixtures were unavailable. The release path continues to require them explicitly.

## Branching

This is the first of three independent architecture-cleanup PRs. It targets the normalized alpha release line at the exact `mdmm-v0.1.0-alpha.9` commit. The later thread-safety and instrumentation PRs are not stacked on this branch and will be updated after this PR merges.
