### PR TITLE
Shorten MD/MM pull request CI

### DIFF
--- a/.github/workflows/elektron-macos.yml
+++ b/.github/workflows/elektron-macos.yml
@@ -3,7 +3,40 @@ name: Elektron macOS universal artifacts
 on:
   workflow_call:
   workflow_dispatch:
-  pull_request:
+  push:
+    branches:
+      - main
+      - "release/md-mm-*"
+    paths:
+      - ".github/workflows/elektron-macos.yml"
+      - ".gitmodules"
+      - "CMakeLists.txt"
+      - "base.cmake"
+      - "scripts/macos/**"
+      - "source/3rdparty/**"
+      - "source/CMakeLists.txt"
+      - "source/JUCE"
+      - "source/baseLib/**"
+      - "source/bridge/**"
+      - "source/dsp56300"
+      - "source/dsp56300/**"
+      - "source/elektron/CMakeLists.txt"
+      - "source/elektron/md/**"
+      - "source/hardwareLib/**"
+      - "source/jucePluginData/**"
+      - "source/jucePluginEditorLib/**"
+      - "source/jucePluginLib/**"
+      - "source/juceRmlPlugin/**"
+      - "source/juceRmlUi/**"
+      - "source/juceUiLib/**"
+      - "source/libresample/**"
+      - "source/mc68k"
+      - "source/mc68k/**"
+      - "source/mcpServerLib/**"
+      - "source/networkLib/**"
+      - "source/pluginTester/**"
+      - "source/ptypes/**"
+      - "source/synthLib/**"
 
 permissions:
   contents: read

--- a/.github/workflows/elektron-windows.yml
+++ b/.github/workflows/elektron-windows.yml
@@ -3,7 +3,40 @@ name: Elektron Windows artifacts
 on:
   workflow_call:
   workflow_dispatch:
-  pull_request:
+  push:
+    branches:
+      - main
+      - "release/md-mm-*"
+    paths:
+      - ".github/workflows/elektron-windows.yml"
+      - ".gitmodules"
+      - "CMakeLists.txt"
+      - "base.cmake"
+      - "scripts/windows/build_mdmm.ps1"
+      - "source/3rdparty/**"
+      - "source/CMakeLists.txt"
+      - "source/JUCE"
+      - "source/baseLib/**"
+      - "source/bridge/**"
+      - "source/dsp56300"
+      - "source/dsp56300/**"
+      - "source/elektron/CMakeLists.txt"
+      - "source/elektron/md/**"
+      - "source/hardwareLib/**"
+      - "source/jucePluginData/**"
+      - "source/jucePluginEditorLib/**"
+      - "source/jucePluginLib/**"
+      - "source/juceRmlPlugin/**"
+      - "source/juceRmlUi/**"
+      - "source/juceUiLib/**"
+      - "source/libresample/**"
+      - "source/mc68k"
+      - "source/mc68k/**"
+      - "source/mcpServerLib/**"
+      - "source/networkLib/**"
+      - "source/pluginTester/**"
+      - "source/ptypes/**"
+      - "source/synthLib/**"
 
 permissions:
   contents: read
@@ -17,6 +50,10 @@ jobs:
     name: Windows x64 VST3 and Standalone
     runs-on: windows-2022
     timeout-minutes: 120
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_VERSION: "mdmm-v1-windows-x64-msvc"
+      SCCACHE_IDLE_TIMEOUT: "0"
 
     steps:
       - uses: actions/checkout@v4
@@ -24,14 +61,15 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Restore reusable MSVC build tree
-        id: build-cache
-        uses: actions/cache/restore@v4
+      - name: Configure MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
         with:
-          path: ${{ runner.temp }}\gearmulator-elektron-build
-          key: elektron-windows-msvc-v1-${{ github.sha }}
-          restore-keys: |
-            elektron-windows-msvc-v1-
+          arch: x64
+
+      - name: Configure compiler cache
+        uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: v0.16.0
 
       - name: Configure and compile MD/MM
         shell: pwsh
@@ -42,15 +80,10 @@ jobs:
           -OutputDir "${{ github.workspace }}\artifacts\windows-mdmm"
           -Configuration Release
           -Parallel 4
+          -Generator "Ninja Multi-Config"
+          -CompilerLauncher sccache
           -WithTests
           -BuildOnly
-
-      - name: Save compiled MSVC build tree
-        if: steps.build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ runner.temp }}\gearmulator-elektron-build
-          key: elektron-windows-msvc-v1-${{ github.sha }}
 
       - name: Test and package MD/MM
         shell: pwsh

--- a/.github/workflows/mdmm-audio-io.yml
+++ b/.github/workflows/mdmm-audio-io.yml
@@ -4,46 +4,121 @@ on:
   pull_request:
     paths:
       - ".github/workflows/mdmm-audio-io.yml"
+      - ".gitmodules"
+      - "CMakeLists.txt"
+      - "base.cmake"
+      - "xcodeversion.cmake"
+      - "source/CMakeLists.txt"
+      - "source/*.cmake"
+      - "source/3rdparty/**"
+      - "source/JUCE"
+      - "source/baseLib/**"
+      - "source/bridge/**"
+      - "source/dsp56300"
+      - "source/dsp56300/**"
+      - "source/elektron/CMakeLists.txt"
+      - "source/elektron/md/**"
+      - "source/hardwareLib/**"
+      - "source/jucePluginData/**"
+      - "source/jucePluginEditorLib/**"
       - "source/synthLib/**"
       - "source/libresample/**"
       - "source/jucePluginLib/**"
+      - "source/juceRmlPlugin/**"
+      - "source/juceRmlUi/**"
+      - "source/juceUiLib/**"
+      - "source/mcpServerLib/**"
+      - "source/networkLib/**"
       - "source/pluginTester/**"
-      - "source/elektron/md/**"
-      - "source/dsp56300/**"
+      - "source/ptypes/**"
+      - "source/mc68k"
       - "source/mc68k/**"
       - "scripts/macos/build_mdmm.sh"
       - "scripts/macos/verify_mdmm_package.sh"
       - "scripts/windows/build_mdmm.ps1"
+  push:
+    branches:
+      - main
+      - "release/md-mm-*"
+    paths:
+      - ".github/workflows/mdmm-audio-io.yml"
+      - ".gitmodules"
       - "CMakeLists.txt"
       - "base.cmake"
+      - "xcodeversion.cmake"
+      - "source/CMakeLists.txt"
+      - "source/*.cmake"
+      - "source/3rdparty/**"
+      - "source/JUCE"
+      - "source/baseLib/**"
+      - "source/bridge/**"
+      - "source/dsp56300"
+      - "source/dsp56300/**"
+      - "source/elektron/CMakeLists.txt"
+      - "source/elektron/md/**"
+      - "source/hardwareLib/**"
+      - "source/jucePluginData/**"
+      - "source/jucePluginEditorLib/**"
+      - "source/synthLib/**"
+      - "source/libresample/**"
+      - "source/jucePluginLib/**"
+      - "source/juceRmlPlugin/**"
+      - "source/juceRmlUi/**"
+      - "source/juceUiLib/**"
+      - "source/mcpServerLib/**"
+      - "source/networkLib/**"
+      - "source/pluginTester/**"
+      - "source/ptypes/**"
+      - "source/mc68k"
+      - "source/mc68k/**"
+      - "scripts/macos/build_mdmm.sh"
+      - "scripts/macos/verify_mdmm_package.sh"
+      - "scripts/windows/build_mdmm.ps1"
   workflow_dispatch:
 
 permissions:
   contents: read
+
+env:
+  SCCACHE_GHA_ENABLED: "true"
+  SCCACHE_IDLE_TIMEOUT: "0"
 
 concurrency:
   group: mdmm-audio-io-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  lightweight:
-    name: Headless core (${{ matrix.os }})
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-14, windows-2022]
-    runs-on: ${{ matrix.os }}
+  windows-headless:
+    name: Headless core (windows-2022)
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: windows-2022
     timeout-minutes: 45
+    env:
+      SCCACHE_GHA_VERSION: "mdmm-v1-windows-x64-msvc"
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
+      - name: Configure MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Configure compiler cache
+        uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: v0.16.0
+
       - name: Configure audio-only tests
         run: >-
           cmake -S . -B build
+          -G Ninja
           -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_C_COMPILER_LAUNCHER=sccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          -DGEARMULATOR_MSVC_EMBED_DEBUG_INFO=ON
           -DBUILD_TESTING=ON
           -Dgearmulator_BUILD_JUCEPLUGIN=OFF
           -Dgearmulator_SYNTH_ELEKTRON=ON
@@ -56,7 +131,7 @@ jobs:
 
       - name: Build headless audio tests
         run: >-
-          cmake --build build --config Release --parallel 3
+          cmake --build build --config Release --parallel 4
           --target synthLibAudioTest mdAudioQueueTest mdAudioFirmwareTest
           mdUwFirmwareTest
 
@@ -70,9 +145,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, windows-2022]
+        os: ${{ fromJSON(github.event_name == 'workflow_dispatch' && '["ubuntu-latest", "macos-14", "windows-2022"]' || '["macos-14"]') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    env:
+      SCCACHE_GHA_VERSION: ${{ matrix.os == 'ubuntu-latest' && 'mdmm-v1-linux-x64-gcc' || matrix.os == 'macos-14' && 'mdmm-v1-macos-arm64-clang' || 'mdmm-v1-windows-x64-msvc' }}
 
     steps:
       - name: Install JUCE build dependencies
@@ -83,10 +160,25 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Configure MSVC environment
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Configure compiler cache
+        uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: v0.16.0
+
       - name: Configure focused plugin tests
         run: >-
           cmake -S . -B build
+          -G Ninja
           -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_C_COMPILER_LAUNCHER=sccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          -DGEARMULATOR_MSVC_EMBED_DEBUG_INFO=${{ runner.os == 'Windows' && 'ON' || 'OFF' }}
           -DCMAKE_OSX_ARCHITECTURES=arm64
           -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
           -DBUILD_TESTING=ON
@@ -107,11 +199,15 @@ jobs:
 
       - name: Build processor and artifact tests
         run: >-
-          cmake --build build --config Release --parallel 3
-          --target mdAudioIoLayoutTest pluginTester mdJucePlugin_VST3
-          mmJucePlugin_VST3 mdAudioProbePlugin_VST3
+          cmake --build build --config Release --parallel 4
+          --target midiOutputDispatcherTest mdAutomationParameterTest
+          mdAutomationRobustnessTest mdAudioIoLayoutTest
+          mdFrontPanelPresentationTest pluginTester
+          mdJucePlugin_VST3 mmJucePlugin_VST3 mdAudioProbePlugin_VST3
+          synthLibAudioTest mdAudioQueueTest mdAudioFirmwareTest
+          mdUwFirmwareTest
 
       - name: Run processor and built-plugin tests
         run: >-
           ctest --test-dir build -C Release --output-on-failure
-          --tests-regex "^(mdAudioIoLayoutTest|mdJucePlugin_VST3AudioIoTest|mmJucePlugin_VST3AudioIoTest|mdAudioProbePluginVST3IdentityTest)$"
+          --tests-regex "^(midiOutputDispatcherTest|mdAutomationParameterTest|mdAutomationArchitectureTest|mdAudioIoLayoutTest|mdFrontPanelPresentationTests|mdJucePlugin_VST3AudioIoTest|mmJucePlugin_VST3AudioIoTest|mdAudioProbePluginVST3IdentityTest|synthLibAudioTest|mdAudioQueueTest|mdAudioFirmwareTest|mdUwFirmwareTest)$"

--- a/.github/workflows/mdmm-core.yml
+++ b/.github/workflows/mdmm-core.yml
@@ -2,32 +2,103 @@ name: MD/MM automation core
 
 on:
   pull_request:
+    paths:
+      - ".github/workflows/mdmm-core.yml"
+      - ".gitmodules"
+      - "CMakeLists.txt"
+      - "base.cmake"
+      - "xcodeversion.cmake"
+      - "source/CMakeLists.txt"
+      - "source/*.cmake"
+      - "source/3rdparty/**"
+      - "source/JUCE"
+      - "source/baseLib/**"
+      - "source/bridge/**"
+      - "source/dsp56300"
+      - "source/dsp56300/**"
+      - "source/elektron/CMakeLists.txt"
+      - "source/elektron/md/**"
+      - "source/hardwareLib/**"
+      - "source/jucePluginData/**"
+      - "source/jucePluginEditorLib/**"
+      - "source/jucePluginLib/**"
+      - "source/juceRmlPlugin/**"
+      - "source/juceRmlUi/**"
+      - "source/juceUiLib/**"
+      - "source/libresample/**"
+      - "source/mc68k"
+      - "source/mc68k/**"
+      - "source/mcpServerLib/**"
+      - "source/networkLib/**"
+      - "source/pluginTester/**"
+      - "source/ptypes/**"
+      - "source/synthLib/**"
   workflow_dispatch:
   push:
     branches:
       - main
       - "release/md-mm-*"
+    paths:
+      - ".github/workflows/mdmm-core.yml"
+      - ".gitmodules"
+      - "CMakeLists.txt"
+      - "base.cmake"
+      - "xcodeversion.cmake"
+      - "source/CMakeLists.txt"
+      - "source/*.cmake"
+      - "source/3rdparty/**"
+      - "source/JUCE"
+      - "source/baseLib/**"
+      - "source/bridge/**"
+      - "source/dsp56300"
+      - "source/dsp56300/**"
+      - "source/elektron/CMakeLists.txt"
+      - "source/elektron/md/**"
+      - "source/hardwareLib/**"
+      - "source/jucePluginData/**"
+      - "source/jucePluginEditorLib/**"
+      - "source/jucePluginLib/**"
+      - "source/juceRmlPlugin/**"
+      - "source/juceRmlUi/**"
+      - "source/juceUiLib/**"
+      - "source/libresample/**"
+      - "source/mc68k"
+      - "source/mc68k/**"
+      - "source/mcpServerLib/**"
+      - "source/networkLib/**"
+      - "source/pluginTester/**"
+      - "source/ptypes/**"
+      - "source/synthLib/**"
 
 permissions:
   contents: read
+
+concurrency:
+  group: mdmm-core-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   fixture-free:
     name: fixture-free (${{ matrix.mode }})
     runs-on: ubuntu-24.04
     timeout-minutes: 45
-    concurrency:
-      group: mdmm-core-${{ github.workflow }}-${{ github.ref }}-${{ matrix.mode }}
-      cancel-in-progress: true
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_VERSION: "mdmm-v1-linux-x64-gcc"
     strategy:
       fail-fast: false
       matrix:
-        mode: [release, asan-ubsan]
+        mode: ${{ fromJSON(github.event_name == 'pull_request' && '["release"]' || '["release", "asan-ubsan"]') }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Configure compiler cache
+        uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: v0.16.0
 
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y ninja-build libasound2-dev libgl1-mesa-dev libx11-dev libxcomposite-dev libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev libfreetype6-dev
@@ -43,8 +114,10 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_FLAGS="${sanitizer_flags}" \
             -DCMAKE_EXE_LINKER_FLAGS="${sanitizer_flags}" \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
             -DBUILD_TESTING=ON \
-            -Dgearmulator_BUILD_JUCEPLUGIN=ON \
+            -Dgearmulator_BUILD_JUCEPLUGIN=${{ matrix.mode == 'asan-ubsan' && 'ON' || 'OFF' }} \
             -Dgearmulator_BUILD_FX_PLUGIN=OFF \
             -Dgearmulator_BUILD_JUCEPLUGIN_VST2=OFF \
             -Dgearmulator_BUILD_JUCEPLUGIN_VST3=OFF \
@@ -63,16 +136,24 @@ jobs:
       - name: Build headless gates
         run: >-
           cmake --build build-mdmm-core --parallel 4 --target
-          midiOutputDispatcherTest
           mdAutomationMidiTest
-          mdAutomationParameterTest
-          mdAutomationRobustnessTest
+          synthLibAudioTest
+          mdAudioQueueTest
+          mdAudioFirmwareTest
           mdStateTest
           mdFlashTest
+
+      - name: Build deep JUCE sanitizer gates
+        if: matrix.mode == 'asan-ubsan'
+        run: >-
+          cmake --build build-mdmm-core --parallel 4 --target
+          midiOutputDispatcherTest
+          mdAutomationParameterTest
+          mdAutomationRobustnessTest
           mdFrontPanelPresentationTest
           mdAudioIoLayoutTest
 
-      - name: Run fixture-free gates
+      - name: Run headless gates
         env:
           ASAN_OPTIONS: detect_leaks=1:strict_string_checks=1:check_initialization_order=1
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
@@ -80,48 +161,15 @@ jobs:
           ctest --test-dir build-mdmm-core -C Release --output-on-failure
           --no-tests=error
           --tests-regex
-          '^(midiOutputDispatcherTest|mdAutomationMidiTest|mdAutomationParameterTest|mdAutomationArchitectureTest|mdStateTest|mdFlashTest|mdFrontPanelPresentationTests|mdAudioIoLayoutTest)$'
+          '^(mdAutomationMidiTest|synthLibAudioTest|mdAudioQueueTest|mdAudioFirmwareTest|mdStateTest|mdFlashTest)$'
 
-  shared-controller-compatibility:
-    name: shared controller compatibility
-    runs-on: ubuntu-24.04
-    timeout-minutes: 90
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y ninja-build libasound2-dev libjack-jackd2-dev libgl1-mesa-dev xorg-dev libfreetype6-dev
-
-      - name: Configure non-Elektron controllers
+      - name: Run deep JUCE sanitizer gates
+        if: matrix.mode == 'asan-ubsan'
+        env:
+          ASAN_OPTIONS: detect_leaks=1:strict_string_checks=1:check_initialization_order=1
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         run: >-
-          cmake -S . -B build-shared-controllers -G Ninja
-          -DCMAKE_BUILD_TYPE=Release
-          -DBUILD_TESTING=OFF
-          -Dgearmulator_BUILD_JUCEPLUGIN=ON
-          -Dgearmulator_BUILD_FX_PLUGIN=OFF
-          -Dgearmulator_BUILD_JUCEPLUGIN_VST2=OFF
-          -Dgearmulator_BUILD_JUCEPLUGIN_VST3=OFF
-          -Dgearmulator_BUILD_JUCEPLUGIN_CLAP=OFF
-          -Dgearmulator_BUILD_JUCEPLUGIN_LV2=OFF
-          -Dgearmulator_BUILD_JUCEPLUGIN_AU=OFF
-          -Dgearmulator_BUILD_JUCEPLUGIN_Standalone=OFF
-          -Dgearmulator_SYNTH_ELEKTRON=OFF
-          -Dgearmulator_SYNTH_OSIRUS=ON
-          -Dgearmulator_SYNTH_OSTIRUS=ON
-          -Dgearmulator_SYNTH_VAVRA=ON
-          -Dgearmulator_SYNTH_XENIA=ON
-          -Dgearmulator_SYNTH_NODALRED2X=ON
-          -Dgearmulator_SYNTH_JE8086=ON
-
-      - name: Compile every controller against the shared API
-        run: >-
-          cmake --build build-shared-controllers --parallel 4 --target
-          osirusJucePlugin
-          osTIrusJucePlugin
-          mqJucePlugin
-          xtJucePlugin
-          n2xJucePlugin
-          jeJucePlugin
+          ctest --test-dir build-mdmm-core -C Release --output-on-failure
+          --no-tests=error
+          --tests-regex
+          '^(midiOutputDispatcherTest|mdAutomationParameterTest|mdAutomationArchitectureTest|mdAudioIoLayoutTest|mdFrontPanelPresentationTests)$'

--- a/.github/workflows/mdmm-shared-controller.yml
+++ b/.github/workflows/mdmm-shared-controller.yml
@@ -1,0 +1,155 @@
+name: MD/MM shared controller compatibility
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/mdmm-shared-controller.yml"
+      - ".gitmodules"
+      - "CMakeLists.txt"
+      - "base.cmake"
+      - "xcodeversion.cmake"
+      - "source/CMakeLists.txt"
+      - "source/*.cmake"
+      - "source/*.h.in"
+      - "source/3rdparty/**"
+      - "source/JUCE"
+      - "source/JUCE/**"
+      - "source/baseLib/**"
+      - "source/bridge/**"
+      - "source/clap-juce-extensions"
+      - "source/clap-juce-extensions/**"
+      - "source/cpp-terminal"
+      - "source/dsp56300"
+      - "source/dsp56300/**"
+      - "source/hardwareLib/**"
+      - "source/jucePluginData/**"
+      - "source/jucePluginEditorLib/**"
+      - "source/jucePluginLib/**"
+      - "source/juceRmlPlugin/**"
+      - "source/juceRmlUi/**"
+      - "source/juceUiLib/**"
+      - "source/libresample/**"
+      - "source/mcpServerLib/**"
+      - "source/networkLib/**"
+      - "source/mqJucePlugin/**"
+      - "source/mqLib/**"
+      - "source/nord/**"
+      - "source/osTIrusJucePlugin/**"
+      - "source/osirusJucePlugin/**"
+      - "source/ronaldo/**"
+      - "source/ptypes/**"
+      - "source/synthLib/**"
+      - "source/virusJucePlugin/**"
+      - "source/virusLib/**"
+      - "source/wLib/**"
+      - "source/xtJucePlugin/**"
+      - "source/xtLib/**"
+  push:
+    branches:
+      - main
+      - "release/md-mm-*"
+    paths:
+      - ".github/workflows/mdmm-shared-controller.yml"
+      - ".gitmodules"
+      - "CMakeLists.txt"
+      - "base.cmake"
+      - "xcodeversion.cmake"
+      - "source/CMakeLists.txt"
+      - "source/*.cmake"
+      - "source/*.h.in"
+      - "source/3rdparty/**"
+      - "source/JUCE"
+      - "source/JUCE/**"
+      - "source/baseLib/**"
+      - "source/bridge/**"
+      - "source/clap-juce-extensions"
+      - "source/clap-juce-extensions/**"
+      - "source/cpp-terminal"
+      - "source/dsp56300"
+      - "source/dsp56300/**"
+      - "source/hardwareLib/**"
+      - "source/jucePluginData/**"
+      - "source/jucePluginEditorLib/**"
+      - "source/jucePluginLib/**"
+      - "source/juceRmlPlugin/**"
+      - "source/juceRmlUi/**"
+      - "source/juceUiLib/**"
+      - "source/libresample/**"
+      - "source/mcpServerLib/**"
+      - "source/networkLib/**"
+      - "source/mqJucePlugin/**"
+      - "source/mqLib/**"
+      - "source/nord/**"
+      - "source/osTIrusJucePlugin/**"
+      - "source/osirusJucePlugin/**"
+      - "source/ronaldo/**"
+      - "source/ptypes/**"
+      - "source/synthLib/**"
+      - "source/virusJucePlugin/**"
+      - "source/virusLib/**"
+      - "source/wLib/**"
+      - "source/xtJucePlugin/**"
+      - "source/xtLib/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mdmm-shared-controller-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shared-controller-compatibility:
+    name: shared controller compatibility
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_VERSION: "mdmm-v1-linux-x64-gcc"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Configure compiler cache
+        uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y ninja-build libasound2-dev libjack-jackd2-dev libgl1-mesa-dev xorg-dev libfreetype6-dev
+
+      - name: Configure non-Elektron controllers
+        run: >-
+          cmake -S . -B build-shared-controllers -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_C_COMPILER_LAUNCHER=sccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          -DBUILD_TESTING=OFF
+          -Dgearmulator_BUILD_JUCEPLUGIN=ON
+          -Dgearmulator_BUILD_FX_PLUGIN=OFF
+          -Dgearmulator_BUILD_JUCEPLUGIN_VST2=OFF
+          -Dgearmulator_BUILD_JUCEPLUGIN_VST3=OFF
+          -Dgearmulator_BUILD_JUCEPLUGIN_CLAP=OFF
+          -Dgearmulator_BUILD_JUCEPLUGIN_LV2=OFF
+          -Dgearmulator_BUILD_JUCEPLUGIN_AU=OFF
+          -Dgearmulator_BUILD_JUCEPLUGIN_Standalone=OFF
+          -Dgearmulator_SYNTH_ELEKTRON=OFF
+          -Dgearmulator_SYNTH_OSIRUS=ON
+          -Dgearmulator_SYNTH_OSTIRUS=ON
+          -Dgearmulator_SYNTH_VAVRA=ON
+          -Dgearmulator_SYNTH_XENIA=ON
+          -Dgearmulator_SYNTH_NODALRED2X=ON
+          -Dgearmulator_SYNTH_JE8086=ON
+
+      - name: Compile every controller against the shared API
+        run: >-
+          cmake --build build-shared-controllers --parallel 4 --target
+          osirusJucePlugin
+          osTIrusJucePlugin
+          mqJucePlugin
+          xtJucePlugin
+          n2xJucePlugin
+          jeJucePlugin

--- a/base.cmake
+++ b/base.cmake
@@ -19,8 +19,16 @@ if(MSVC)
 	# /permissive- Standards Conformance
 	# /MP Multiprocessor Compilation
 
-	set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /O2 /GS- /fp:fast /Oy /GT /GL /Zi /Oi /Ot")
-	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /O2 /GS- /fp:fast /Oy /GT /GL /Zi /Oi /Ot")
+	option(GEARMULATOR_MSVC_EMBED_DEBUG_INFO
+		"Use /Z7 embedded debug information for cache-friendly MSVC builds" OFF)
+	if(GEARMULATOR_MSVC_EMBED_DEBUG_INFO)
+		set(GEARMULATOR_MSVC_DEBUG_INFO_FLAG "/Z7")
+	else()
+		set(GEARMULATOR_MSVC_DEBUG_INFO_FLAG "/Zi")
+	endif()
+
+	set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /O2 /GS- /fp:fast /Oy /GT /GL ${GEARMULATOR_MSVC_DEBUG_INFO_FLAG} /Oi /Ot")
+	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /O2 /GS- /fp:fast /Oy /GT /GL ${GEARMULATOR_MSVC_DEBUG_INFO_FLAG} /Oi /Ot")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive- /MP")
 
 	set(ARCHITECTURE ${CMAKE_VS_PLATFORM_NAME})

--- a/scripts/windows/build_mdmm.ps1
+++ b/scripts/windows/build_mdmm.ps1
@@ -5,6 +5,9 @@ param(
     [string] $OutputDir = '',
     [string] $Configuration = 'Release',
     [ValidateRange(1, 64)] [int] $Parallel = 4,
+    [ValidateSet('Visual Studio 17 2022', 'Ninja Multi-Config')]
+    [string] $Generator = 'Visual Studio 17 2022',
+    [string] $CompilerLauncher = '',
     [switch] $WithTests,
     [switch] $BuildOnly,
     [switch] $TestOnly
@@ -65,8 +68,7 @@ if (-not $TestOnly) {
     $configureArgs = @(
         '-S', $SourceDir,
         '-B', $BuildDir,
-        '-G', 'Visual Studio 17 2022',
-        '-A', 'x64',
+        '-G', $Generator,
         "-DBUILD_TESTING=$(if ($WithTests) { 'ON' } else { 'OFF' })",
         '-Dgearmulator_BUILD_JUCEPLUGIN=ON',
         '-Dgearmulator_BUILD_FX_PLUGIN=OFF',
@@ -84,7 +86,31 @@ if (-not $TestOnly) {
         '-Dgearmulator_SYNTH_NODALRED2X=OFF',
         '-Dgearmulator_SYNTH_JE8086=OFF'
     )
+    if ($Generator -eq 'Visual Studio 17 2022') {
+        $configureArgs += @('-A', 'x64')
+    } else {
+        $configureArgs += @(
+            '-DCMAKE_C_COMPILER=cl',
+            '-DCMAKE_CXX_COMPILER=cl'
+        )
+    }
+    if ($CompilerLauncher) {
+        $configureArgs += @(
+            "-DCMAKE_C_COMPILER_LAUNCHER=$CompilerLauncher",
+            "-DCMAKE_CXX_COMPILER_LAUNCHER=$CompilerLauncher"
+        )
+        if ($Generator -eq 'Ninja Multi-Config') {
+            # A shared /Zi compiler PDB races under parallel cached builds.
+            # /Z7 keeps equivalent debug data in each object and is cacheable.
+            $configureArgs += '-DGEARMULATOR_MSVC_EMBED_DEBUG_INFO=ON'
+        }
+    }
     Invoke-Native -FilePath $cmake -Arguments $configureArgs
+
+    $nativeBuildArgs = @()
+    if ($Generator -eq 'Visual Studio 17 2022') {
+        $nativeBuildArgs = @('--', '/verbosity:minimal')
+    }
 
     $targets = @(
         'mdJucePlugin_VST3',
@@ -101,7 +127,7 @@ if (-not $TestOnly) {
     Invoke-Native -FilePath $cmake -Arguments (@(
         '--build', $BuildDir,
         '--config', $Configuration,
-        '--target') + $targets + @('--parallel', "$Parallel", '--', '/verbosity:minimal'))
+        '--target') + $targets + @('--parallel', "$Parallel") + $nativeBuildArgs)
 
     if ($WithTests) {
         Invoke-Native -FilePath $cmake -Arguments (@(
@@ -112,7 +138,7 @@ if (-not $TestOnly) {
             'mdAutomationMidiTest',
             'mdAutomationParameterTest',
             'mdAutomationRobustnessTest',
-            '--parallel', "$Parallel", '--', '/verbosity:minimal'))
+            '--parallel', "$Parallel") + $nativeBuildArgs)
     }
 
     if ($BuildOnly) {


### PR DESCRIPTION
## Summary

- keep ordinary pull requests on a small cross-platform gate: JUCE-free Linux core tests, Windows headless tests, and one consolidated macOS VST3/test build
- move full macOS/Windows release artifacts and deep sanitizer coverage off the per-commit PR critical path while retaining them for release-branch pushes and manual runs
- path-gate shared-controller compatibility, broaden dependency filters, and replace the per-SHA Windows build-tree cache with platform-scoped sccache
- preserve the test additions from PR #32, including UW firmware and front-panel presentation coverage in the appropriate jobs

## Measured results

Representative PR #32 jobs ranged from 9m57s for the release core gate to 35m56s for Windows artifacts. The final workflow layout measured:

- Linux core: 2m28s cold, 1m47s warm
- Windows headless: 3m59s cold, 3m24s warm
- consolidated macOS VST3/tests: 10m57s cold, 4m25s warm
- retained ASAN/UBSAN release/manual gate: 25m29s cold, 6m40s warm
- full Windows artifacts, now off ordinary PRs: 27m10s cold versus 35m56s before

The release branch seeds the platform caches before subsequent pull requests. Cold macOS can land just above ten minutes; measured warm PR feedback is under five minutes on all three operating-system gates.

## Validation

- actionlint passes all five affected workflows
- git diff --check passes
- local JUCE-disabled configure/build passes all four available headless tests; firmware-backed checks correctly report skipped without private ROMs
- exact post-PR32 integration tree was rehearsed before merge and revalidated after rebasing
- GitHub Actions benchmark runs passed the core, sanitizer, Windows headless, consolidated macOS, and optional Linux VST3 matrices

The detailed design, cache inventory, run IDs, and timing record are preserved in the durable project notes.
