### PR TITLE
Fix MIDI Learn subscription lifetime

### DIFF
--- a/.github/workflows/mdmm-audio-io.yml
+++ b/.github/workflows/mdmm-audio-io.yml
@@ -23,6 +23,7 @@ on:
       - "source/jucePluginEditorLib/**"
       - "source/synthLib/**"
       - "source/libresample/**"
+      - "source/midiLearnTest/**"
       - "source/jucePluginLib/**"
       - "source/juceRmlPlugin/**"
       - "source/juceRmlUi/**"
@@ -61,6 +62,7 @@ on:
       - "source/jucePluginEditorLib/**"
       - "source/synthLib/**"
       - "source/libresample/**"
+      - "source/midiLearnTest/**"
       - "source/jucePluginLib/**"
       - "source/juceRmlPlugin/**"
       - "source/juceRmlUi/**"
@@ -200,7 +202,7 @@ jobs:
       - name: Build processor and artifact tests
         run: >-
           cmake --build build --config Release --parallel 4
-          --target midiOutputDispatcherTest mdAutomationParameterTest
+          --target midiLearnTest midiOutputDispatcherTest mdAutomationParameterTest
           mdAutomationRobustnessTest mdAudioIoLayoutTest
           mdFrontPanelPresentationTest pluginTester
           mdJucePlugin_VST3 mmJucePlugin_VST3 mdAudioProbePlugin_VST3
@@ -210,4 +212,4 @@ jobs:
       - name: Run processor and built-plugin tests
         run: >-
           ctest --test-dir build -C Release --output-on-failure
-          --tests-regex "^(midiOutputDispatcherTest|mdAutomationParameterTest|mdAutomationArchitectureTest|mdAudioIoLayoutTest|mdFrontPanelPresentationTests|mdJucePlugin_VST3AudioIoTest|mmJucePlugin_VST3AudioIoTest|mdAudioProbePluginVST3IdentityTest|synthLibAudioTest|mdAudioQueueTest|mdAudioFirmwareTest|mdUwFirmwareTest)$"
+          --tests-regex "^(midiLearnTests|midiOutputDispatcherTest|mdAutomationParameterTest|mdAutomationArchitectureTest|mdAudioIoLayoutTest|mdFrontPanelPresentationTests|mdJucePlugin_VST3AudioIoTest|mmJucePlugin_VST3AudioIoTest|mdAudioProbePluginVST3IdentityTest|synthLibAudioTest|mdAudioQueueTest|mdAudioFirmwareTest|mdUwFirmwareTest)$"

--- a/source/jucePluginLib/midiLearnTranslator.cpp
+++ b/source/jucePluginLib/midiLearnTranslator.cpp
@@ -355,7 +355,7 @@ namespace pluginLib
 	void MidiLearnTranslator::subscribeToParameters()
 	{
 		const auto& mappings = m_preset.getMappings();
-		m_paramListenerIds.reserve(mappings.size());
+		m_paramListeners.reserve(mappings.size());
 
 		for (const auto& mapping : mappings)
 		{
@@ -367,8 +367,9 @@ namespace pluginLib
 			if (!param)
 				continue;
 
-			// Subscribe to parameter changes
-			const auto listenerId = param->onValueChanged.addListener(
+			// Keep the event and its listener ID together so skipped mappings cannot
+			// make teardown remove the ID from a different parameter event.
+			m_paramListeners.emplace_back(param->onValueChanged,
 				[this, paramName = mapping.paramName](Parameter* _param)
 				{
 					const auto origin = _param->getChangeOrigin();
@@ -379,24 +380,12 @@ namespace pluginLib
 
 					onParameterChanged(paramName, _param->getValue(), origin);
 				});
-
-			m_paramListenerIds.push_back(listenerId);
 		}
 	}
 
 	void MidiLearnTranslator::unsubscribeFromParameters()
 	{
-		const auto& mappings = m_preset.getMappings();
-		
-		// Remove listeners
-		for (size_t i = 0; i < m_paramListenerIds.size() && i < mappings.size(); ++i)
-		{
-			auto* param = m_controller.getParameter(mappings[i].paramName, 0);
-			if (param)
-				param->onValueChanged.removeListener(m_paramListenerIds[i]);
-		}
-
-		m_paramListenerIds.clear();
+		m_paramListeners.clear();
 	}
 
 	void MidiLearnTranslator::onParameterChanged(const std::string& _paramName, float _normalizedValue, Parameter::Origin _origin)

--- a/source/jucePluginLib/midiLearnTranslator.h
+++ b/source/jucePluginLib/midiLearnTranslator.h
@@ -83,7 +83,7 @@ namespace pluginLib
 		static constexpr size_t kRequiredUniqueValues = 2; // Need 2 unique values (both directions)
 
 		// Parameter subscriptions for feedback
-		std::vector<baseLib::Event<Parameter*>::ListenerId> m_paramListenerIds;
+		std::vector<baseLib::EventListener<Parameter*>> m_paramListeners;
 
 		// Cache for quick lookup: key = (channel << 8) | controller
 		std::unordered_map<uint32_t, size_t> m_midiToMappingIndex;

--- a/source/midiLearnTest/CMakeLists.txt
+++ b/source/midiLearnTest/CMakeLists.txt
@@ -21,7 +21,12 @@ target_compile_definitions(midiLearnTest PRIVATE
 target_sources(midiLearnTest PRIVATE ${SOURCES})
 source_group("source" FILES ${SOURCES})
 
-target_link_libraries(midiLearnTest PUBLIC jucePluginLib juce::juce_core juce::juce_graphics)
+target_link_libraries(midiLearnTest PUBLIC
+	jucePluginLib
+	juce_plugin_modules
+	juce::juce_core
+	juce::juce_graphics
+)
 
 add_test(NAME midiLearnTests COMMAND midiLearnTest)
 set_tests_properties(midiLearnTests PROPERTIES LABELS "UnitTest")

--- a/source/midiLearnTest/midiLearnTest.cpp
+++ b/source/midiLearnTest/midiLearnTest.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <cassert>
+#include <cstring>
 #include <stdexcept>
 #include <sstream>
 
@@ -14,6 +15,8 @@
 #include "jucePluginLib/midiLearnPreset.h"
 #include "jucePluginLib/midiLearnManager.h"
 #include "jucePluginLib/midiLearnTranslator.h"
+#include "jucePluginLib/controller.h"
+#include "jucePluginLib/processor.h"
 
 #include "synthLib/midiTypes.h"
 
@@ -31,6 +34,111 @@ using namespace pluginLib;
 			throw std::runtime_error(oss.str()); \
 		} \
 	} while (0)
+
+namespace
+{
+	constexpr char g_midiLearnParameterDescriptions[] = R"json(
+{
+	"parameterdescriptiondefaults": {
+		"isPublic": true,
+		"isBipolar": false,
+		"toText": {"format": "%d"},
+		"class": "",
+		"min": 0,
+		"max": 127,
+		"isBool": false,
+		"isDiscrete": true,
+		"page": 0,
+		"step": 0
+	},
+	"valuelists": {},
+	"parameterdescriptions": [
+		{"index": 0, "name": "FeedbackDisabled", "displayName": "Feedback Disabled"},
+		{"index": 1, "name": "FeedbackEnabled", "displayName": "Feedback Enabled"}
+	]
+}
+)json";
+
+	const char* g_midiLearnResourceNames[] = {"midiLearnTestParameters_json"};
+	const char* g_midiLearnOriginalFilenames[] = {"midiLearnTestParameters.json"};
+
+	const char* getMidiLearnTestResource(const char* _resourceName, int& _size)
+	{
+		if(std::strcmp(_resourceName, g_midiLearnResourceNames[0]) != 0)
+		{
+			_size = 0;
+			return nullptr;
+		}
+
+		_size = static_cast<int>(sizeof(g_midiLearnParameterDescriptions) - 1);
+		return g_midiLearnParameterDescriptions;
+	}
+
+	pluginLib::Processor::Properties createMidiLearnTestProperties()
+	{
+		return {
+			"MIDI Learn subscription test", "The Usual Suspects", true, true,
+			false, false, "Mlts", "urn:gearmulator:test:midi-learn-subscription",
+			{1, g_midiLearnOriginalFilenames, g_midiLearnResourceNames,
+				getMidiLearnTestResource},
+			"MidiLearnSubscriptionTest"
+		};
+	}
+
+	class MidiLearnTestController final : public pluginLib::Controller
+	{
+	public:
+		explicit MidiLearnTestController(pluginLib::Processor& _processor)
+			: Controller(_processor, "midiLearnTestParameters.json")
+		{
+			TEST_ASSERT(getParameterDescriptions().isValid());
+			registerParams(_processor);
+		}
+
+		void sendParameterChange(const pluginLib::Parameter&, pluginLib::ParamValue,
+			pluginLib::Parameter::Origin) override {}
+		bool parseSysexMessage(const pluginLib::SysEx&,
+			synthLib::MidiEventSource) override { return false; }
+		void onStateLoaded() override {}
+		uint8_t getPartCount() const override { return 1; }
+	};
+
+	class MidiLearnTestProcessor final : public pluginLib::Processor
+	{
+	public:
+		MidiLearnTestProcessor()
+			: Processor(BusesProperties(), createMidiLearnTestProperties()) {}
+
+		synthLib::Device* createDevice() override { return nullptr; }
+		juce::AudioProcessorEditor* createEditor() override { return nullptr; }
+		bool hasEditor() const override { return false; }
+
+	private:
+		pluginLib::Controller* createController() override
+		{
+			return new MidiLearnTestController(*this);
+		}
+	};
+
+	MidiLearnMapping createFeedbackMapping(const std::string& _paramName,
+		const bool _feedbackEnabled)
+	{
+		MidiLearnMapping mapping;
+		mapping.paramName = _paramName;
+		mapping.setFeedbackEnabled(synthLib::MidiEventSource::Editor,
+			_feedbackEnabled);
+		return mapping;
+	}
+
+	MidiLearnPreset createPresetWithSkippedMappings()
+	{
+		MidiLearnPreset preset("Skipped mappings");
+		preset.addMapping(createFeedbackMapping("FeedbackDisabled", false));
+		preset.addMapping(createFeedbackMapping("MissingParameter", true));
+		preset.addMapping(createFeedbackMapping("FeedbackEnabled", true));
+		return preset;
+	}
+}
 
 void testMidiLearnMapping()
 {
@@ -263,6 +371,73 @@ void testMidiLearnTranslatorBasics()
 	std::cout << "    - Learned mappings OVERRIDE default mappings (checked first)" << std::endl;
 	std::cout << "    - Return true = consumed (don't forward to device)" << std::endl;
 	std::cout << "    - Return false = not consumed (forward to device)" << std::endl;
+}
+
+void testMidiLearnSubscriptionLifetime()
+{
+	std::cout << "Testing MIDI Learn parameter subscription lifetime..." << std::endl;
+
+	MidiLearnTestProcessor processor;
+	MidiLearnTestController controller(processor);
+	MidiLearnTranslator translator(controller,
+		controller.getParameterDescriptions().getControllerMap());
+	auto* const feedbackDisabled = controller.getParameter("FeedbackDisabled", 0);
+	auto* const feedbackEnabled = controller.getParameter("FeedbackEnabled", 0);
+	TEST_ASSERT(feedbackDisabled != nullptr);
+	TEST_ASSERT(feedbackEnabled != nullptr);
+
+	// Both Event instances allocate listener ID zero independently. A bare vector
+	// of IDs therefore cannot identify which parameter event owns an ID after a
+	// feedback-disabled or missing mapping was skipped.
+	int unrelatedCalls = 0;
+	const auto unrelatedListenerId = feedbackDisabled->onValueChanged.addListener(
+		[&unrelatedCalls](Parameter*) { ++unrelatedCalls; });
+	TEST_ASSERT(unrelatedListenerId == 0);
+
+	int feedbackCalls = 0;
+	translator.onSendMidiOutput = [&feedbackCalls](synthLib::MidiEventSource,
+		const synthLib::SMidiEvent&) { ++feedbackCalls; };
+	translator.setPreset(createPresetWithSkippedMappings());
+
+	feedbackEnabled->onValueChanged(feedbackEnabled);
+	TEST_ASSERT(feedbackCalls == 1);
+
+	MidiLearnPreset replacement("Replacement");
+	replacement.addMapping(createFeedbackMapping("FeedbackEnabled", true));
+	translator.setPreset(replacement);
+
+	feedbackDisabled->onValueChanged(feedbackDisabled);
+	TEST_ASSERT(unrelatedCalls == 1);
+	feedbackEnabled->onValueChanged(feedbackEnabled);
+	TEST_ASSERT(feedbackCalls == 2);
+
+	translator.setPreset(MidiLearnPreset{});
+	const auto replacementProbeId = feedbackEnabled->onValueChanged.addListener(
+		[](Parameter*) {});
+	TEST_ASSERT(replacementProbeId == 0);
+	feedbackEnabled->onValueChanged.removeListener(replacementProbeId);
+	feedbackDisabled->onValueChanged.removeListener(unrelatedListenerId);
+
+	// Destruction must remove the subscription from its actual event even when
+	// earlier mappings did not create subscriptions.
+	const auto destructionUnrelatedId = feedbackDisabled->onValueChanged.addListener(
+		[&unrelatedCalls](Parameter*) { ++unrelatedCalls; });
+	TEST_ASSERT(destructionUnrelatedId == 0);
+	{
+		MidiLearnTranslator scopedTranslator(controller,
+			controller.getParameterDescriptions().getControllerMap());
+		scopedTranslator.setPreset(createPresetWithSkippedMappings());
+	}
+
+	feedbackDisabled->onValueChanged(feedbackDisabled);
+	TEST_ASSERT(unrelatedCalls == 2);
+	const auto destructionProbeId = feedbackEnabled->onValueChanged.addListener(
+		[](Parameter*) {});
+	TEST_ASSERT(destructionProbeId == 0);
+	feedbackEnabled->onValueChanged.removeListener(destructionProbeId);
+	feedbackDisabled->onValueChanged.removeListener(destructionUnrelatedId);
+
+	std::cout << "  MIDI Learn parameter subscription lifetime tests passed!" << std::endl;
 }
 
 void testMidiLearnFeedback()
@@ -890,6 +1065,7 @@ void testMidiLearnMixedTypes()
 
 int main()
 {
+	juce::ScopedJuceInitialiser_GUI juce;
 	try
 	{
 		std::cout << "Running MIDI Learn Unit Tests..." << std::endl;
@@ -900,6 +1076,7 @@ int main()
 		testMidiLearnPreset();
 		testMidiLearnManager();
 		testMidiLearnTranslatorBasics();
+		testMidiLearnSubscriptionLifetime();
 		testMidiLearnFeedback();
 		testMidiLearnRelativeModes();
 		testMidiLearnModeDetection();


### PR DESCRIPTION
## Summary

- Bind each MIDI Learn feedback subscription to the exact parameter event and listener ID with RAII.
- Remove subscriptions safely when mappings are replaced, cleared, or the translator is destroyed.
- Cover skipped disabled and missing mappings, unrelated listeners, preset replacement, and destruction with a focused regression.

## Validation

- Focused MIDI Learn regression: PASS.
- Regression fails against the untouched base implementation.
- CI now explicitly builds and runs midiLearnTest.
- git diff --check: PASS.