### PR TITLE
Harden binary stream bounds handling

### DIFF
--- a/.github/workflows/mdmm-core.yml
+++ b/.github/workflows/mdmm-core.yml
@@ -142,6 +142,7 @@ jobs:
       - name: Build headless gates
         run: >-
           cmake --build build-mdmm-core --parallel 4 --target
+          baseLibBinaryStreamTest
           mdAutomationMidiTest
           synthLibAudioTest
           mdAudioQueueTest
@@ -167,7 +168,7 @@ jobs:
           ctest --test-dir build-mdmm-core -C Release --output-on-failure
           --no-tests=error
           --tests-regex
-          '^(mdAutomationMidiTest|synthLibAudioTest|mdAudioQueueTest|mdAudioFirmwareTest|mdStateTest|mdFlashTest)$'
+          '^(baseLibBinaryStreamTest|mdAutomationMidiTest|synthLibAudioTest|mdAudioQueueTest|mdAudioFirmwareTest|mdStateTest|mdFlashTest)$'
 
       - name: Run deep JUCE sanitizer gates
         if: matrix.mode == 'asan-ubsan'

--- a/scripts/macos/build_mdmm.sh
+++ b/scripts/macos/build_mdmm.sh
@@ -138,6 +138,7 @@ cmake --build "${build_dir}" --parallel 4 --target \
   mdJucePlugin_Standalone \
   mmJucePlugin_Standalone \
   pluginTester \
+  baseLibBinaryStreamTest \
   synthLibAudioTest \
   mdLibTest \
   mdStateTest \
@@ -167,6 +168,7 @@ if [[ "${require_firmware_tests}" == "1" ]]; then
 fi
 
 for test_name in \
+  baseLibBinaryStreamTest \
   synthLibAudioTest \
   mdLibTests \
   mdStateTest \

--- a/scripts/windows/build_mdmm.ps1
+++ b/scripts/windows/build_mdmm.ps1
@@ -120,7 +120,7 @@ if (-not $TestOnly) {
         'pluginTester'
     )
     if ($WithTests) {
-        $targets += @('synthLibAudioTest', 'mdLibTest', 'mdAudioQueueTest',
+        $targets += @('baseLibBinaryStreamTest', 'synthLibAudioTest', 'mdLibTest', 'mdAudioQueueTest',
             'mdAudioFirmwareTest', 'mdAudioIoLayoutTest', 'mdProjectStateRestoreTest',
             'mdAudioProbePlugin_VST3')
     }
@@ -152,7 +152,7 @@ if ($WithTests) {
         '--test-dir', $BuildDir,
         '-C', $Configuration,
         '--output-on-failure',
-        '--tests-regex', '^(synthLibAudioTest|mdLibTests|mdAudioQueueTest|mdAudioFirmwareTest|mdAudioIoLayoutTest|mdProjectStateRestoreTest|mdAudioProbePluginVST3IdentityTest)$'
+        '--tests-regex', '^(baseLibBinaryStreamTest|synthLibAudioTest|mdLibTests|mdAudioQueueTest|mdAudioFirmwareTest|mdAudioIoLayoutTest|mdProjectStateRestoreTest|mdAudioProbePluginVST3IdentityTest)$'
     )
     Invoke-Native -FilePath $ctest -Arguments @(
         '--test-dir', $BuildDir,

--- a/source/baseLib/CMakeLists.txt
+++ b/source/baseLib/CMakeLists.txt
@@ -29,3 +29,11 @@ endif()
 set_property(TARGET baseLib PROPERTY FOLDER "Gearmulator")
 
 target_include_directories(baseLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+if(BUILD_TESTING)
+	add_executable(baseLibBinaryStreamTest binarystreamTest.cpp)
+	target_link_libraries(baseLibBinaryStreamTest PRIVATE baseLib)
+	add_test(NAME baseLibBinaryStreamTest COMMAND baseLibBinaryStreamTest)
+	set_tests_properties(baseLibBinaryStreamTest PROPERTIES LABELS "UnitTest")
+	set_property(TARGET baseLibBinaryStreamTest PROPERTY FOLDER "Tests")
+endif()

--- a/source/baseLib/binarystream.h
+++ b/source/baseLib/binarystream.h
@@ -3,8 +3,12 @@
 #include <array>
 #include <cassert>
 #include <cstdint>
+#include <exception>
 #include <functional>
+#include <limits>
 #include <sstream>
+#include <stdexcept>
+#include <type_traits>
 #include <vector>
 #include <cstring>
 
@@ -12,6 +16,13 @@ namespace baseLib
 {
 	class StreamBuffer
 	{
+	protected:
+		struct ReadState
+		{
+			size_t position;
+			bool failed;
+		};
+
 	public:
 		StreamBuffer() = default;
 		explicit StreamBuffer(std::vector<uint8_t>&& _buffer) : m_vector(std::move(_buffer))
@@ -24,17 +35,20 @@ namespace baseLib
 		StreamBuffer(uint8_t* _buffer, const size_t _size) : m_buffer(_buffer), m_size(_size), m_fixedSize(true)
 		{
 		}
-		StreamBuffer(StreamBuffer& _parent, const size_t _childSize) : m_buffer(&_parent.buffer()[_parent.tellg()]), m_size(_childSize), m_fixedSize(true)
+		StreamBuffer(StreamBuffer& _parent, const size_t _childSize)
+			: m_size(_childSize), m_fixedSize(true)
 		{
-			// force eof if range is not valid
-			if(_parent.tellg() + _childSize > _parent.size())
+			if(!_parent.canRead(_childSize))
 			{
-				assert(false && "invalid range");
-				m_readPos = _childSize;
+				_parent.m_fail = true;
+				m_fail = true;
+				throw std::range_error("invalid child stream range");
 			}
 
-			// seek parent forward
-			_parent.seekg(_parent.tellg() + _childSize);
+			m_buffer = _parent.buffer();
+			if(_parent.tellg() != 0)
+				m_buffer += _parent.tellg();
+			_parent.m_readPos += _childSize;
 		}
 		StreamBuffer(StreamBuffer&& _source) noexcept
 			: m_buffer(_source.m_buffer)
@@ -50,50 +64,77 @@ namespace baseLib
 
 		StreamBuffer& operator = (StreamBuffer&& _source) noexcept
 		{
+			if(this == &_source)
+				return *this;
+
 			m_buffer = _source.m_buffer;
 			m_size = _source.m_size;
 			m_fixedSize = _source.m_fixedSize;
 			m_readPos = _source.m_readPos;
 			m_writePos = _source.m_writePos;
 			m_vector = std::move(_source.m_vector);
+			m_fail = _source.m_fail;
 
 			_source.destroy();
 
 			return *this;
 		}
 
-		void seekg(const size_t _pos)		{ m_readPos = _pos; }
+		void seekg(const size_t _pos)
+		{
+			if(_pos > size())
+			{
+				m_fail = true;
+				return;
+			}
+			m_readPos = _pos;
+		}
 		size_t tellg() const				{ return m_readPos; }
-		void seekp(const size_t _pos)		{ m_writePos = _pos; }
+		void seekp(const size_t _pos)
+		{
+			if(_pos > size())
+			{
+				m_fail = true;
+				return;
+			}
+			m_writePos = _pos;
+		}
 		size_t tellp() const				{ return m_writePos; }
 		bool eof() const					{ return tellg() >= size(); }
 		bool fail() const					{ return m_fail; }
 
 		bool read(uint8_t* _dst, size_t _size)
 		{
-			const auto remaining = size() - tellg();
-			if(remaining < _size)
+			if(!canRead(_size))
 			{
 				m_fail = true;
 				return false;
 			}
-			::memcpy(_dst, &buffer()[m_readPos], _size);
+			if(_size)
+				::memcpy(_dst, buffer() + m_readPos, _size);
 			m_readPos += _size;
 			return true;
 		}
 		bool write(const uint8_t* _src, size_t _size)
 		{
-			const auto remaining = size() - tellp();
-			if(remaining < _size)
+			if(tellp() > size() || _size > std::numeric_limits<size_t>::max() - tellp())
+			{
+				m_fail = true;
+				return false;
+			}
+
+			const auto requiredSize = tellp() + _size;
+			if(requiredSize > size())
 			{
 				if(m_fixedSize)
 				{
 					m_fail = true;
 					return false;
 				}
-				m_vector.resize(tellp() + _size);
+				m_vector.resize(requiredSize);
 			}
-			::memcpy(&buffer()[m_writePos], _src, _size);
+			if(_size)
+				::memcpy(buffer() + m_writePos, _src, _size);
 			m_writePos += _size;
 			return true;
 		}
@@ -104,6 +145,28 @@ namespace baseLib
 		}
 
 		auto& getVector() { return m_vector; }
+
+	protected:
+		bool canRead(const size_t _size) const
+		{
+			return !m_fail && tellg() <= size() && _size <= size() - tellg();
+		}
+
+		void markFailed()
+		{
+			m_fail = true;
+		}
+
+		ReadState getReadState() const
+		{
+			return {m_readPos, m_fail};
+		}
+
+		void restoreReadState(const ReadState& _state)
+		{
+			m_readPos = _state.position;
+			m_fail = _state.failed;
+		}
 
 	private:
 		size_t size() const					{ return m_fixedSize ? m_size : m_vector.size(); }
@@ -157,7 +220,9 @@ namespace baseLib
 
 		template<typename T> explicit BinaryStream(const std::vector<T>& _data)
 		{
-			Base::write(reinterpret_cast<const uint8_t*>(_data.data()), _data.size() * sizeof(T));
+			const auto bytes = checkedByteSize<T>(_data.size());
+			Base::write(reinterpret_cast<const uint8_t*>(_data.data()), bytes);
+			checkFail();
 			seekg(0);
 		}
 
@@ -181,6 +246,8 @@ namespace baseLib
 			if(_append)
 			{
 				const auto currentSize = _buffer.size();
+				if(currentSize > std::numeric_limits<size_t>::max() - size)
+					throw std::length_error("binary stream output size overflow");
 				_buffer.resize(currentSize + size);
 				Base::read(&_buffer[currentSize], size);
 			}
@@ -189,32 +256,41 @@ namespace baseLib
 				_buffer.resize(size);
 				Base::read(_buffer.data(), size);
 			}
+			checkFail();
 		}
 
 		bool checkString(const std::string& _str)
 		{
-			const auto pos = tellg();
-			
-			const auto size = read<SizeType>();
-			if (size != _str.size())
+			const auto state = getReadState();
+			try
 			{
-				seekg(pos);
+				const auto size = read<SizeType>();
+				if(size != _str.size())
+				{
+					restoreReadState(state);
+					return false;
+				}
+				std::string s;
+				requireReadable(size);
+				s.resize(size);
+				Base::read(reinterpret_cast<uint8_t*>(s.data()), size);
+				const auto result = _str == s;
+				restoreReadState(state);
+				return result;
+			}
+			catch(const std::range_error&)
+			{
+				restoreReadState(state);
 				return false;
 			}
-			std::string s;
-			s.resize(size);
-			Base::read(reinterpret_cast<uint8_t*>(s.data()), size);
-			const auto result = _str == s;
-			seekg(pos);
-			return result;
 		}
 
 		uint32_t getWritePos() const			{ return static_cast<uint32_t>(tellp()); }
 		uint32_t getReadPos() const				{ return static_cast<uint32_t>(tellg()); }
 		bool endOfStream() const				{ return eof(); }
 
-		void setWritePos(const uint32_t _pos)	{ seekp(_pos); }
-		void setReadPos(const uint32_t _pos)	{ seekg(_pos); }
+		void setWritePos(const uint32_t _pos)	{ seekp(_pos); checkFail(); }
+		void setReadPos(const uint32_t _pos)	{ seekg(_pos); checkFail(); }
 		
 		using StreamBuffer::getVector;
 
@@ -225,28 +301,38 @@ namespace baseLib
 		template<typename T, typename = std::enable_if_t<std::is_trivially_copyable_v<T>>> void write(const T& _value)
 		{
 			Base::write(reinterpret_cast<const uint8_t*>(&_value), sizeof(_value));
+			checkFail();
 		}
 
 		template<typename T, typename = std::enable_if_t<std::is_trivially_copyable_v<T>>> void write(const T* _data, const size_t _size)
 		{
 			if(!_size)
 				return;
-			Base::write(reinterpret_cast<const uint8_t*>(_data), sizeof(T) * _size);
+			Base::write(reinterpret_cast<const uint8_t*>(_data), checkedByteSize<T>(_size));
+			checkFail();
 		}
 
 		template<typename T, typename Alloc, typename = std::enable_if_t<std::is_trivially_copyable_v<T>>> void write(const std::vector<T, Alloc>& _vector)
 		{
+			if(_vector.size() > std::numeric_limits<SizeType>::max())
+				throw std::length_error("binary stream vector is too large");
 			const auto size = static_cast<SizeType>(_vector.size());
 			write(size);
 			if(size)
-				Base::write(reinterpret_cast<const uint8_t*>(_vector.data()), sizeof(T) * size);
+			{
+				Base::write(reinterpret_cast<const uint8_t*>(_vector.data()), checkedByteSize<T>(size));
+				checkFail();
+			}
 		}
 
 		void write(const std::string& _string)
 		{
+			if(_string.size() > std::numeric_limits<SizeType>::max())
+				throw std::length_error("binary stream string is too large");
 			const auto s = static_cast<SizeType>(_string.size());
 			write(s);
 			Base::write(reinterpret_cast<const uint8_t*>(_string.c_str()), s);
+			checkFail();
 		}
 
 		void write(const char* const _value)
@@ -286,7 +372,11 @@ namespace baseLib
 		template<typename T, typename = std::enable_if_t<std::is_trivially_copyable_v<T>>> void read(T* _out, const size_t _size)
 		{
 			if(_size)
-				Base::read(reinterpret_cast<uint8_t*>(_out), sizeof(T) * _size);
+			{
+				const auto bytes = requireReadableElements<T>(_size);
+				Base::read(reinterpret_cast<uint8_t*>(_out), bytes);
+			}
+			checkFail();
 		}
 
 		template<typename T, typename Alloc, typename = std::enable_if_t<std::is_trivially_copyable_v<T>>> void read(std::vector<T, Alloc>& _vector)
@@ -298,14 +388,16 @@ namespace baseLib
 				_vector.clear();
 				return;
 			}
+			const auto bytes = requireReadableElements<T>(size);
 			_vector.resize(size);
-			Base::read(reinterpret_cast<uint8_t*>(_vector.data()), sizeof(T) * size);
+			Base::read(reinterpret_cast<uint8_t*>(_vector.data()), bytes);
 			checkFail();
 		}
 
 		std::string readString()
 		{
 			const auto size = read<SizeType>();
+			requireReadable(size);
 			std::string s;
 			s.resize(size);
 			Base::read(reinterpret_cast<uint8_t*>(s.data()), size);
@@ -368,6 +460,43 @@ namespace baseLib
 		//
 
 	private:
+		template<typename T>
+		static size_t checkedByteSize(const size_t _count)
+		{
+			if(_count > std::numeric_limits<size_t>::max() / sizeof(T))
+				throw std::range_error("binary stream size overflow");
+			return sizeof(T) * _count;
+		}
+
+		void requireReadable(const size_t _size)
+		{
+			if(!canRead(_size))
+			{
+				markFailed();
+				throw std::range_error("end-of-stream");
+			}
+		}
+
+		template<typename T>
+		size_t requireReadableElements(const size_t _count)
+		{
+			if(_count > std::numeric_limits<size_t>::max() / sizeof(T))
+			{
+				markFailed();
+				throw std::range_error("binary stream size overflow");
+			}
+			const auto bytes = sizeof(T) * _count;
+			requireReadable(bytes);
+			return bytes;
+		}
+
+		using ReadState = StreamBuffer::ReadState;
+		ReadState readState() const { return getReadState(); }
+		void restore(const ReadState& _state) { restoreReadState(_state); }
+
+		friend class ChunkReader;
+		friend class ChunkWriter;
+
 		void checkFail() const
 		{
 			if(fail())
@@ -400,11 +529,13 @@ namespace baseLib
 		using SizeType = BinaryStream::SizeType;
 
 		template<size_t N, std::enable_if_t<N == 5, void*> = nullptr>
-		ChunkWriter(BinaryStream& _stream, char const(&_4Cc)[N], const uint32_t _version = 1) : m_stream(_stream)
+		ChunkWriter(BinaryStream& _stream, char const(&_4Cc)[N], const uint32_t _version = 1)
+			: m_stream(_stream)
+			, m_uncaughtExceptions(std::uncaught_exceptions())
 		{
 			m_stream.write4CC(_4Cc);
 			m_stream.write(_version);
-			m_lengthWritePos = m_stream.getWritePos();
+			m_lengthWritePos = m_stream.tellp();
 			m_stream.write<SizeType>(0);
 		}
 
@@ -414,18 +545,70 @@ namespace baseLib
 		ChunkWriter& operator = (ChunkWriter&&) = delete;
 		ChunkWriter& operator = (const ChunkWriter&) = delete;
 
-		~ChunkWriter()
+		~ChunkWriter() noexcept
 		{
-			const auto currentWritePos = m_stream.getWritePos();
-			const SizeType chunkDataLength = currentWritePos - m_lengthWritePos - sizeof(SizeType);
-			m_stream.setWritePos(m_lengthWritePos);
-			m_stream.write(chunkDataLength);
-			m_stream.setWritePos(currentWritePos);
+			try
+			{
+				// A payload write may reject its arguments or fail an allocation before
+				// StreamBuffer can set its fail bit. Never turn that exceptional exit
+				// into an apparently valid partial chunk.
+				if(std::uncaught_exceptions() > m_uncaughtExceptions)
+				{
+					m_stream.markFailed();
+					return;
+				}
+
+				if(m_stream.fail())
+					return;
+
+				const size_t currentWritePos = m_stream.tellp();
+				SizeType chunkDataLength = 0;
+				if(!validateFinalizationPositions(m_lengthWritePos, currentWritePos, chunkDataLength))
+				{
+					m_stream.markFailed();
+					return;
+				}
+
+				m_stream.seekp(m_lengthWritePos);
+				m_stream.checkFail();
+				m_stream.write(chunkDataLength);
+				m_stream.seekp(currentWritePos);
+				m_stream.checkFail();
+			}
+			catch(...)
+			{
+				m_stream.markFailed();
+				// Destruction must never replace an active exception or terminate unwinding.
+			}
 		}
 
 	private:
+		static bool validateFinalizationPositions(const size_t _lengthWritePos,
+			const size_t _currentWritePos, SizeType& _chunkDataLength) noexcept
+		{
+			_chunkDataLength = 0;
+			constexpr auto maxPosition = static_cast<size_t>(std::numeric_limits<SizeType>::max());
+			if(_lengthWritePos > maxPosition || _currentWritePos > maxPosition)
+				return false;
+			if(_currentWritePos < _lengthWritePos)
+				return false;
+
+			const auto lengthAndPayload = _currentWritePos - _lengthWritePos;
+			if(lengthAndPayload < sizeof(SizeType))
+				return false;
+			const auto payloadLength = lengthAndPayload - sizeof(SizeType);
+			if(payloadLength > std::numeric_limits<SizeType>::max())
+				return false;
+
+			_chunkDataLength = static_cast<SizeType>(payloadLength);
+			return true;
+		}
+
+		friend struct ChunkWriterTestAccess;
+
 		BinaryStream& m_stream;
-		SizeType m_lengthWritePos = 0;
+		size_t m_lengthWritePos = 0;
+		int m_uncaughtExceptions = 0;
 	};
 
 	class ChunkReader
@@ -457,6 +640,7 @@ namespace baseLib
 
 		void read(const uint32_t _count = 0)
 		{
+			m_stream.checkFail();
 			uint32_t count = 0;
 
 			while(!m_stream.endOfStream() && (!_count || ++count <= _count))
@@ -481,18 +665,35 @@ namespace baseLib
 			}
 		}
 
+		// Chunk framing is validated before callbacks run. Stream state and internal
+		// counters are transactional, but external side effects made by a callback
+		// cannot be rolled back if that callback rejects its payload. Non-range
+		// exceptions are rethrown after internal state has been restored.
 		bool tryRead(const uint32_t _count = 0)
 		{
-			const auto pos = m_stream.getReadPos();
+			const auto state = m_stream.readState();
+			const auto numRead = m_numRead;
+			const auto numChunks = m_numChunks;
 			try
 			{
+				preflight(_count);
+				m_stream.restore(state);
 				read(_count);
 				return true;
 			}
-			catch(std::range_error&)
+			catch(const std::range_error&)
 			{
-				m_stream.setReadPos(pos);
+				m_stream.restore(state);
+				m_numRead = numRead;
+				m_numChunks = numChunks;
 				return false;
+			}
+			catch(...)
+			{
+				m_stream.restore(state);
+				m_numRead = numRead;
+				m_numChunks = numChunks;
+				throw;
 			}
 		}
 
@@ -507,6 +708,17 @@ namespace baseLib
 		}
 
 	private:
+		void preflight(const uint32_t _count)
+		{
+			m_stream.checkFail();
+			uint32_t count = 0;
+			while(!m_stream.endOfStream() && (!_count || ++count <= _count))
+			{
+				Chunk chunk;
+				chunk.read(m_stream);
+			}
+		}
+
 		BinaryStream& m_stream;
 		std::vector<ChunkCallbackData> supportedChunks;
 		uint32_t m_numRead = 0;

--- a/source/baseLib/binarystreamTest.cpp
+++ b/source/baseLib/binarystreamTest.cpp
@@ -1,0 +1,396 @@
+#include "binarystream.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace baseLib
+{
+	struct ChunkWriterTestAccess
+	{
+		static bool validateChunkWriterPositions(const size_t _lengthWritePos,
+			const size_t _currentWritePos, BinaryStream::SizeType& _chunkDataLength)
+		{
+			return ChunkWriter::validateFinalizationPositions(
+				_lengthWritePos, _currentWritePos, _chunkDataLength);
+		}
+	};
+}
+
+namespace
+{
+	static_assert(std::is_nothrow_destructible_v<baseLib::ChunkWriter>,
+		"ChunkWriter destruction must be non-throwing");
+
+	void require(const bool _condition, const std::string& _message)
+	{
+		if(_condition)
+			return;
+		std::cerr << "baseLibBinaryStreamTest: " << _message << '\n';
+		std::exit(1);
+	}
+
+	template<typename Callback>
+	void requireRangeError(Callback&& _callback, const std::string& _message)
+	{
+		try
+		{
+			_callback();
+		}
+		catch(const std::range_error&)
+		{
+			return;
+		}
+		require(false, _message);
+	}
+
+	void verifyGoldenRoundTrip()
+	{
+		baseLib::BinaryStream stream;
+		{
+			baseLib::ChunkWriter chunk(stream, "TEST", 1);
+			stream.write<uint8_t>(0x7f);
+			stream.write(std::string("ok"));
+			stream.write(std::vector<uint8_t>{0xaa, 0xbb});
+			stream.write<uint8_t>(0xee);
+		}
+
+		std::vector<uint8_t> bytes;
+		stream.toVector(bytes);
+		const std::vector<uint8_t> expected{
+			'T', 'E', 'S', 'T',
+			0x01, 0x00, 0x00, 0x00,
+			0x0e, 0x00, 0x00, 0x00,
+			0x7f,
+			0x02, 0x00, 0x00, 0x00, 'o', 'k',
+			0x02, 0x00, 0x00, 0x00, 0xaa, 0xbb,
+			0xee};
+		require(bytes == expected, "wire-format golden bytes changed");
+
+		baseLib::BinaryStream input(bytes);
+		auto [payload, version] = input.tryReadChunk("TEST", 1, 2);
+		require(version == 1, "round-trip changed the chunk version");
+		require(payload.read<uint8_t>() == 0x7f, "round-trip changed the scalar");
+		require(payload.readString() == "ok", "round-trip changed the string");
+		std::vector<uint8_t> vector;
+		payload.read(vector);
+		require(vector == std::vector<uint8_t>({0xaa, 0xbb}),
+			"round-trip changed the vector");
+		// Readers may intentionally leave fields for a newer schema revision.
+		require(payload.read<uint8_t>() == 0xee, "round-trip changed trailing data");
+		require(payload.endOfStream(), "round-trip left unexpected bytes");
+	}
+
+	void verifyBoundedReads()
+	{
+		baseLib::BinaryStream truncated(std::vector<uint8_t>{1, 2, 3});
+		requireRangeError([&] { (void)truncated.read<uint32_t>(); },
+			"truncated scalar did not fail");
+
+		baseLib::BinaryStream raw(std::vector<uint8_t>{1, 2});
+		uint8_t rawBytes[4]{};
+		requireRangeError([&] { raw.read(rawBytes, 4); },
+			"truncated raw array did not fail immediately");
+
+		baseLib::BinaryStream multiplied;
+		uint64_t value = 0;
+		requireRangeError([&]
+		{
+			multiplied.read(&value, std::numeric_limits<size_t>::max());
+		}, "element-count multiplication overflow was accepted");
+
+		baseLib::BinaryStream hugeVector;
+		hugeVector.write(std::numeric_limits<baseLib::BinaryStream::SizeType>::max());
+		hugeVector.write<uint8_t>(0x55);
+		hugeVector.setReadPos(0);
+		std::vector<uint64_t> vector;
+		requireRangeError([&] { hugeVector.read(vector); },
+			"oversized vector length was allocated or accepted");
+		require(vector.empty(), "failed vector read modified its destination");
+		require(hugeVector.getReadPos() == sizeof(baseLib::BinaryStream::SizeType),
+			"failed vector read moved beyond its length prefix");
+		requireRangeError([&] { (void)hugeVector.read<uint8_t>(); },
+			"failed vector read did not poison the stream");
+
+		baseLib::BinaryStream hugeString;
+		hugeString.write(std::numeric_limits<baseLib::BinaryStream::SizeType>::max());
+		hugeString.write<uint8_t>(0x66);
+		hugeString.setReadPos(0);
+		requireRangeError([&] { (void)hugeString.readString(); },
+			"oversized string length was allocated or accepted");
+		require(hugeString.getReadPos() == sizeof(baseLib::BinaryStream::SizeType),
+			"failed string read moved beyond its length prefix");
+		requireRangeError([&] { (void)hugeString.read<uint8_t>(); },
+			"failed string read did not poison the stream");
+
+		baseLib::BinaryStream checkedString;
+		checkedString.write<baseLib::BinaryStream::SizeType>(5);
+		checkedString.setReadPos(0);
+		require(!checkedString.checkString("hello"),
+			"truncated checkString input was accepted");
+		require(checkedString.getReadPos() == 0,
+			"checkString did not restore the cursor");
+		require(checkedString.read<baseLib::BinaryStream::SizeType>() == 5,
+			"checkString left the stream failed");
+	}
+
+	void verifyChunkWriterUnwinding()
+	{
+		bool caught = false;
+		try
+		{
+			baseLib::BinaryStream stream;
+			baseLib::ChunkWriter chunk(stream, "FAIL", 1);
+			stream.setWritePos(std::numeric_limits<uint32_t>::max());
+		}
+		catch(const std::range_error&)
+		{
+			caught = true;
+		}
+		require(caught,
+			"failed stream did not unwind safely through ChunkWriter destruction");
+
+		baseLib::BinaryStream rejectedPayload;
+		caught = false;
+		try
+		{
+			baseLib::ChunkWriter chunk(rejectedPayload, "SIZE", 1);
+			const uint64_t value = 0;
+			rejectedPayload.write(&value, std::numeric_limits<size_t>::max());
+		}
+		catch(const std::range_error&)
+		{
+			caught = true;
+		}
+		require(caught, "oversized payload write was not rejected");
+		requireRangeError([&]
+		{
+			std::vector<uint8_t> output;
+			rejectedPayload.toVector(output);
+		}, "exceptional payload write finalized an apparently valid partial chunk");
+
+		baseLib::BinaryStream invalidOrder;
+		{
+			baseLib::ChunkWriter chunk(invalidOrder, "BACK", 1);
+			invalidOrder.setWritePos(0);
+		}
+		requireRangeError([&] { invalidOrder.setWritePos(0); },
+			"invalid ChunkWriter finalization did not poison the stream");
+	}
+
+	void verifyChunkWriterPositionValidation()
+	{
+		using SizeType = baseLib::BinaryStream::SizeType;
+		const auto validate = [](const size_t _lengthPos, const size_t _currentPos,
+			SizeType& _payloadLength)
+		{
+			return baseLib::ChunkWriterTestAccess::validateChunkWriterPositions(
+				_lengthPos, _currentPos, _payloadLength);
+		};
+
+		SizeType payloadLength = 99;
+		require(validate(8, 12, payloadLength) && payloadLength == 0,
+			"zero-length chunk positions were rejected");
+		const auto maxPosition = static_cast<size_t>(std::numeric_limits<SizeType>::max());
+		require(validate(0, maxPosition, payloadLength) &&
+			payloadLength == std::numeric_limits<SizeType>::max() - sizeof(SizeType),
+			"maximum representable total position was rejected");
+		require(!validate(8, 7, payloadLength),
+			"reversed chunk positions were accepted");
+		require(!validate(8, 11, payloadLength),
+			"position before the complete length field was accepted");
+		if constexpr(sizeof(size_t) > sizeof(SizeType))
+		{
+			require(!validate(0, maxPosition + 1, payloadLength),
+				"total position beyond the public 32-bit contract was accepted");
+			require(!validate(maxPosition + 1, maxPosition + 1, payloadLength),
+				"length position beyond the public 32-bit contract was accepted");
+		}
+	}
+
+	void verifyInvalidRanges()
+	{
+		baseLib::BinaryStream readSeek(std::vector<uint8_t>{1});
+		requireRangeError([&] { readSeek.setReadPos(2); },
+			"invalid read seek was accepted");
+
+		baseLib::BinaryStream writeSeek;
+		writeSeek.write<uint8_t>(1);
+		requireRangeError([&] { writeSeek.setWritePos(2); },
+			"invalid write seek was accepted");
+
+		baseLib::BinaryStream parent(std::vector<uint8_t>{1});
+		requireRangeError([&]
+		{
+			baseLib::BinaryStream child(parent, 2);
+			(void)child;
+		}, "invalid child stream length was accepted");
+		require(parent.getReadPos() == 0,
+			"invalid child stream advanced its parent");
+	}
+
+	void verifyChunkCompatibility()
+	{
+		baseLib::BinaryStream stream;
+		{
+			baseLib::ChunkWriter zero(stream, "ZERO", 1);
+		}
+		{
+			baseLib::ChunkWriter unknown(stream, "UNKN", 9);
+			stream.write<uint8_t>(0x11);
+		}
+		{
+			baseLib::ChunkWriter old(stream, "OLD!", 1);
+			stream.write<uint8_t>(0x22);
+			stream.write<uint8_t>(0x23);
+		}
+		{
+			baseLib::ChunkWriter future(stream, "NEW!", 3);
+			stream.write<uint8_t>(0x33);
+		}
+		stream.setReadPos(0);
+
+		baseLib::ChunkReader reader(stream);
+		bool sawZero = false;
+		bool sawOld = false;
+		bool sawFuture = false;
+		reader.add("ZERO", 1, [&](baseLib::BinaryStream& _data, uint32_t)
+		{
+			sawZero = true;
+			require(_data.endOfStream(), "zero-length chunk was not empty");
+		});
+		reader.add("OLD!", 2, [&](baseLib::BinaryStream& _data, const uint32_t _version)
+		{
+			sawOld = true;
+			require(_version == 1, "older chunk version changed");
+			require(_data.read<uint8_t>() == 0x22, "older chunk payload changed");
+			// Deliberately leave 0x23 unread to preserve trailing-field tolerance.
+		});
+		reader.add("NEW!", 2, [&](baseLib::BinaryStream&, uint32_t)
+		{
+			sawFuture = true;
+		});
+		reader.read();
+
+		require(sawZero, "zero-length chunk callback was not invoked");
+		require(sawOld, "older supported chunk version was not accepted");
+		require(!sawFuture, "too-new chunk version was accepted");
+		require(reader.numChunks() == 4, "unknown/versioned chunks were not counted");
+		require(reader.numRead() == 2, "unknown/versioned chunks changed read count");
+	}
+
+	void verifyTryReadRollback()
+	{
+		baseLib::BinaryStream stream;
+		{
+			baseLib::ChunkWriter good(stream, "GOOD", 1);
+			stream.write<uint8_t>(0x44);
+		}
+		stream.write<uint8_t>(0xde);
+		stream.write<uint8_t>(0xad);
+		stream.write<uint8_t>(0xbe);
+		stream.setReadPos(0);
+
+		baseLib::ChunkReader reader(stream);
+		uint32_t callbacks = 0;
+		reader.add("GOOD", 1, [&](baseLib::BinaryStream& _data, uint32_t)
+		{
+			++callbacks;
+			require(_data.read<uint8_t>() == 0x44, "rollback test payload changed");
+		});
+
+		require(!reader.tryRead(), "truncated chunk header was accepted");
+		require(callbacks == 0,
+			"framing preflight invoked a callback before detecting truncation");
+		require(stream.getReadPos() == 0, "tryRead did not restore its cursor");
+		require(reader.numChunks() == 0 && reader.numRead() == 0,
+			"tryRead did not restore its counters");
+		require(reader.tryRead(1), "stream remained failed after rollback");
+		require(reader.numChunks() == 1 && reader.numRead() == 1,
+			"bounded retry counters are wrong");
+		require(callbacks == 1,
+			"rollback unexpectedly suppressed or duplicated a callback");
+		require(!reader.tryRead(), "trailing malformed header was accepted");
+		require(reader.numChunks() == 1 && reader.numRead() == 1,
+			"failed trailing retry changed counters");
+
+		baseLib::BinaryStream oversized;
+		oversized.write4CC("HUGE");
+		oversized.write<uint32_t>(1);
+		oversized.write(std::numeric_limits<baseLib::BinaryStream::SizeType>::max());
+		oversized.setReadPos(0);
+		baseLib::ChunkReader oversizedReader(oversized);
+		require(!oversizedReader.tryRead(), "oversized child chunk was accepted");
+		require(oversized.getReadPos() == 0,
+			"oversized child rollback did not restore its cursor");
+		require(oversizedReader.numChunks() == 0 && oversizedReader.numRead() == 0,
+			"oversized child rollback changed counters");
+
+		baseLib::BinaryStream malformedPayload;
+		{
+			baseLib::ChunkWriter chunk(malformedPayload, "BAD!", 1);
+			malformedPayload.write<uint8_t>(0x77);
+		}
+		malformedPayload.setReadPos(0);
+		baseLib::ChunkReader malformedReader(malformedPayload);
+		uint32_t malformedCallbacks = 0;
+		malformedReader.add("BAD!", 1, [&](baseLib::BinaryStream& _data, uint32_t)
+		{
+			++malformedCallbacks;
+			(void)_data.read<uint32_t>();
+		});
+		require(!malformedReader.tryRead(), "malformed callback payload was accepted");
+		require(malformedPayload.getReadPos() == 0 && malformedReader.numChunks() == 0 &&
+			malformedReader.numRead() == 0,
+			"callback payload failure did not restore stream state and counters");
+		require(malformedCallbacks == 1,
+			"tryRead unexpectedly rolled back an external callback side effect");
+
+		baseLib::BinaryStream exceptionalPayload;
+		{
+			baseLib::ChunkWriter chunk(exceptionalPayload, "ERR!", 1);
+			exceptionalPayload.write<uint8_t>(0x88);
+		}
+		exceptionalPayload.setReadPos(0);
+		baseLib::ChunkReader exceptionalReader(exceptionalPayload);
+		uint32_t exceptionalCallbacks = 0;
+		exceptionalReader.add("ERR!", 1, [&](baseLib::BinaryStream& _data, uint32_t)
+		{
+			++exceptionalCallbacks;
+			require(_data.read<uint8_t>() == 0x88, "exception callback payload changed");
+			throw std::runtime_error("callback failure");
+		});
+		bool rethrown = false;
+		try
+		{
+			(void)exceptionalReader.tryRead();
+		}
+		catch(const std::runtime_error&)
+		{
+			rethrown = true;
+		}
+		require(rethrown, "non-range callback exception was not rethrown");
+		require(exceptionalPayload.getReadPos() == 0 && exceptionalReader.numChunks() == 0 &&
+			exceptionalReader.numRead() == 0,
+			"non-range callback exception did not restore internal state");
+		require(exceptionalCallbacks == 1,
+			"tryRead unexpectedly rolled back a throwing callback side effect");
+	}
+}
+
+int main()
+{
+	verifyGoldenRoundTrip();
+	verifyBoundedReads();
+	verifyInvalidRanges();
+	verifyChunkWriterUnwinding();
+	verifyChunkWriterPositionValidation();
+	verifyChunkCompatibility();
+	verifyTryReadRollback();
+	std::cout << "baseLibBinaryStreamTest: PASS\n";
+	return 0;
+}


### PR DESCRIPTION
## Summary

- Reject out-of-range seeks, child streams, raw reads, and overflowing length-prefixed vector/string sizes before allocation or memory access.
- Preflight chunk framing before callbacks and restore reader state on failed reads.
- Make ChunkWriter finalization non-throwing, use full-width position arithmetic, and poison streams that exceed the 32-bit format contract.
- Preserve existing wire bytes, older chunk versions, unknown chunks, and trailing-field compatibility.

## Validation

- Direct C++17 ASan/UBSan regression executable: PASS.
- Focused CMake baseLibBinaryStreamTest: PASS.
- Golden wire-format and malformed-input regressions: PASS.
- YAML, shell syntax, and git diff checks: PASS.