### PR TITLE
Preserve MD/MM panel releases under queue saturation

### DIFF
--- a/.github/workflows/mdmm-core.yml
+++ b/.github/workflows/mdmm-core.yml
@@ -133,6 +133,12 @@ jobs:
             -Dgearmulator_SYNTH_NODALRED2X=OFF \
             -Dgearmulator_SYNTH_JE8086=OFF
 
+      - name: Build and run panel input delivery regression
+        run: |
+          cmake --build build-mdmm-core --parallel 4 --target mdLibTest
+          ctest --test-dir build-mdmm-core -C Release --output-on-failure \
+            --no-tests=error --tests-regex '^mdLibTests$'
+
       - name: Build headless gates
         run: >-
           cmake --build build-mdmm-core --parallel 4 --target

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -174,8 +174,7 @@ namespace mdJucePlugin
 				auto* const device = dynamic_cast<md::Device*>(_device);
 				if(!device)
 					return false;
-				device->sendPanelEvent(_command, _argument);
-				return true;
+				return device->sendPanelEvent(_command, _argument);
 			});
 	}
 
@@ -528,10 +527,13 @@ namespace mdJucePlugin
 		}
 
 		const auto step = m_panelSteps.front();
-		m_panelSteps.pop_front();
 
 		const auto combined = step.press ? m_panelRows.press(step.packet) : m_panelRows.release(step.packet);
-		(void)sendPanelEvent(combined.row, combined.mask);
+		// Navigation pulses are retryable: do not advance to the matching release
+		// until this row state actually entered the bounded FIFO.
+		if(!sendPanelEvent(combined.row, combined.mask))
+			return;
+		m_panelSteps.pop_front();
 
 		// Give the firmware a complete timer interval to update its LED readback
 		// before deciding whether the pending direct-selection target needs another

--- a/source/elektron/md/mdLib/mddevice.h
+++ b/source/elektron/md/mdLib/mddevice.h
@@ -152,9 +152,13 @@ namespace md
 		}
 		// Panel interaction remains directed at the audible live machine while a
 		// replacement is prepared. It is intentionally ephemeral across the reboot.
-		void sendPanelEvent(uint8_t _command, uint8_t _argument)
+		bool sendPanelEvent(uint8_t _command, uint8_t _argument)
 		{
-			m_hardware->sendPanelEvent(_command, _argument);
+			return m_hardware->trySendPanelEvent(_command, _argument);
+		}
+		PanelInputQueueStatus getPanelInputStatus() const
+		{
+			return m_hardware->getPanelInputStatus();
 		}
 		FrontPanel getFrontPanelSnapshot() const { return m_frontPanelPublisher->read(); }
 		std::shared_ptr<FrontPanelPublisher> getFrontPanelPublisher() const

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -811,6 +811,11 @@ namespace md
 		return m_panelIn.overflowCount();
 	}
 
+	PanelInputQueueStatus Hardware::getPanelInputStatus() const
+	{
+		return m_panelIn.status();
+	}
+
 	void Hardware::processUC()
 	{
 		// Deliver queued panel input to firmware over UART2 RX. The existing

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -185,9 +185,9 @@ namespace md
 			m_uc.readMidiOut(_midiOut);
 		}
 		// Queue a front-panel button/encoder event ([row][mask]). trySendPanelEvent is bounded,
-		// thread-safe, allocation-free, and never waits; false means the complete
-		// packet was rejected and must be retried if it cannot be lost. The void
-		// wrapper retains legacy best-effort behavior, with drops visible via telemetry.
+		// thread-safe, allocation-free, and never waits; false reports that the FIFO
+		// rejected the packet. Row state is retained for recovery, while pulse commands
+		// are best effort and may be retried. Both outcomes are visible via telemetry.
 		bool trySendPanelEvent(uint8_t _cmd, uint8_t _arg);
 		void sendPanelEvent(uint8_t _cmd, uint8_t _arg)
 		{
@@ -195,6 +195,7 @@ namespace md
 		}
 		size_t getPendingPanelInputBytes() const;
 		size_t getPanelInputOverflowCount() const;
+		PanelInputQueueStatus getPanelInputStatus() const;
 
 		const auto& getAudioOutputs() const { return m_audioOutputs; }
 		const std::string& getRomFilename() const { return m_rom.getFilename(); }

--- a/source/elektron/md/mdLib/mdpanel.cpp
+++ b/source/elektron/md/mdLib/mdpanel.cpp
@@ -29,6 +29,27 @@ namespace md
 		{
 			return {_row, _mask};
 		}
+
+		class ScopedInFlightProducer
+		{
+		public:
+			explicit ScopedInFlightProducer(std::atomic<size_t>& _count)
+				: m_count(_count)
+			{
+				m_count.fetch_add(1, std::memory_order_seq_cst);
+			}
+
+			~ScopedInFlightProducer()
+			{
+				m_count.fetch_sub(1, std::memory_order_seq_cst);
+			}
+
+			ScopedInFlightProducer(const ScopedInFlightProducer&) = delete;
+			ScopedInFlightProducer& operator=(const ScopedInFlightProducer&) = delete;
+
+		private:
+			std::atomic<size_t>& m_count;
+		};
 	}
 
 	std::optional<PanelPacket> panelPacket(const MachineModel _model,
@@ -151,9 +172,51 @@ namespace md
 	{
 		for(size_t i = 0; i < m_slots.size(); ++i)
 			m_slots[i].sequence.store(i, std::memory_order_relaxed);
+		for(auto& row : m_recoveryRows)
+			row.store(0, std::memory_order_relaxed);
 	}
 
 	bool PanelInputQueue::tryPush(const uint8_t _command, const uint8_t _argument)
+	{
+		ScopedInFlightProducer inFlight(m_inFlightProducers);
+		const auto rowState = isRowState(_command);
+		if(rowState)
+			m_recoveryRows[_command - g_firstRow].store(
+				_argument, std::memory_order_release);
+
+		// Once a row packet has been rejected, stop admitting newer work ahead of
+		// its recovery snapshot. Row writes coalesce to the latest complete scan
+		// state; encoder pulses are best effort and may be dropped. This guarantees
+		// that the finite FIFO eventually drains to the point where releases can be
+		// replayed without an older queued press following them.
+		if(m_recoveryAdmissionClosed.load(std::memory_order_seq_cst)
+			|| (m_rowRecoveryPublication.load(std::memory_order_acquire)
+				& g_recoveryPending) != 0)
+		{
+			m_rejectedPackets.fetch_add(1, std::memory_order_relaxed);
+			if(rowState)
+			{
+				m_coalescedRowPackets.fetch_add(1, std::memory_order_relaxed);
+				retainRowRecovery();
+			}
+			else
+				m_droppedPulsePackets.fetch_add(1, std::memory_order_relaxed);
+			return false;
+		}
+
+		if(tryPushFifo(_command, _argument))
+			return true;
+
+		m_rejectedPackets.fetch_add(1, std::memory_order_relaxed);
+		if(rowState)
+			retainRowRecovery();
+		else
+			m_droppedPulsePackets.fetch_add(1, std::memory_order_relaxed);
+		return false;
+	}
+
+	bool PanelInputQueue::tryPushFifo(const uint8_t _command,
+		const uint8_t _argument)
 	{
 		auto position = m_enqueuePosition.load(std::memory_order_relaxed);
 		for(;;)
@@ -188,9 +251,23 @@ namespace md
 		}
 	}
 
+	void PanelInputQueue::retainRowRecovery()
+	{
+		auto publication = m_rowRecoveryPublication.load(std::memory_order_relaxed);
+		for(;;)
+		{
+			const auto next = ((publication + 2) | g_recoveryPending);
+			if(m_rowRecoveryPublication.compare_exchange_weak(publication, next,
+				std::memory_order_release, std::memory_order_relaxed))
+				return;
+		}
+	}
+
 	size_t PanelInputQueue::size() const
 	{
-		return pendingPackets() * 2;
+		const auto recovery = (m_rowRecoveryPublication.load(
+			std::memory_order_acquire) & g_recoveryPending) != 0;
+		return (pendingPackets() + (recovery ? g_rowCount : 0)) * 2;
 	}
 
 	size_t PanelInputQueue::pendingPackets() const
@@ -201,6 +278,23 @@ namespace md
 	size_t PanelInputQueue::overflowCount() const
 	{
 		return m_overflowCount.load(std::memory_order_relaxed);
+	}
+
+	PanelInputQueueStatus PanelInputQueue::status() const
+	{
+		PanelInputQueueStatus result;
+		result.pendingPackets = pendingPackets();
+		result.overflowCount = overflowCount();
+		result.rejectedPackets = m_rejectedPackets.load(std::memory_order_relaxed);
+		result.droppedPulsePackets =
+			m_droppedPulsePackets.load(std::memory_order_relaxed);
+		result.coalescedRowPackets =
+			m_coalescedRowPackets.load(std::memory_order_relaxed);
+		result.recoveredRowPackets =
+			m_recoveredRowPackets.load(std::memory_order_relaxed);
+		result.rowRecoveryPending = (m_rowRecoveryPublication.load(
+			std::memory_order_acquire) & g_recoveryPending) != 0;
+		return result;
 	}
 
 	size_t PanelInputQueue::drain(DrainBuffer& _destination,
@@ -220,6 +314,50 @@ namespace md
 				std::memory_order_release);
 			++m_dequeuePosition;
 			m_pendingPackets.fetch_sub(1, std::memory_order_relaxed);
+		}
+
+		// The recovery snapshot must follow every packet accepted before the first
+		// rejection. Close producer admission before checking for active reservations:
+		// an older producer either keeps the count nonzero or completes its pending
+		// publication before its seq_cst departure. Producers arriving after closure
+		// coalesce into recovery instead of entering the FIFO. Six complete scan rows
+		// fit in Hardware's fixed drain batch and are emitted together.
+		if((m_rowRecoveryPublication.load(std::memory_order_acquire)
+			& g_recoveryPending) != 0)
+		{
+			// Keep the gate closed across deferred drain attempts. With seq_cst gate
+			// and producer-count operations, a producer that observed the old open
+			// state necessarily joined the count before this closure.
+			m_recoveryAdmissionClosed.store(true, std::memory_order_seq_cst);
+			if(limit - count >= g_rowCount
+				&& m_inFlightProducers.load(std::memory_order_seq_cst) == 0
+				&& m_pendingPackets.load(std::memory_order_acquire) == 0)
+			{
+				auto publication = m_rowRecoveryPublication.load(
+					std::memory_order_acquire);
+				if((publication & g_recoveryPending) != 0)
+				{
+					for(size_t row = 0; row < g_rowCount; ++row)
+					{
+						_destination[count++] = {
+							static_cast<uint8_t>(g_firstRow + row),
+							m_recoveryRows[row].load(std::memory_order_acquire)};
+					}
+					m_recoveredRowPackets.fetch_add(g_rowCount,
+						std::memory_order_relaxed);
+					const auto recovered = publication & ~g_recoveryPending;
+					(void)m_rowRecoveryPublication.compare_exchange_strong(
+						publication, recovered, std::memory_order_acq_rel,
+						std::memory_order_acquire);
+				}
+			}
+
+			// A producer rejected by the closed gate may have revised recovery while
+			// the snapshot was copied. Leave admission closed when that happened; the
+			// next drain publishes the newer revision before accepting FIFO work.
+			if((m_rowRecoveryPublication.load(std::memory_order_acquire)
+				& g_recoveryPending) == 0)
+				m_recoveryAdmissionClosed.store(false, std::memory_order_seq_cst);
 		}
 		return count;
 	}

--- a/source/elektron/md/mdLib/mdpanel.h
+++ b/source/elektron/md/mdLib/mdpanel.h
@@ -90,6 +90,17 @@ namespace md
 		}
 	};
 
+	struct PanelInputQueueStatus
+	{
+		size_t pendingPackets = 0;
+		size_t overflowCount = 0;
+		size_t rejectedPackets = 0;
+		size_t droppedPulsePackets = 0;
+		size_t coalescedRowPackets = 0;
+		size_t recoveredRowPackets = 0;
+		bool rowRecoveryPending = false;
+	};
+
 	// Returns no packet when a logical control is not yet verified for that
 	// model. Callers must leave it inert rather than substitute another model's
 	// packet.
@@ -120,7 +131,8 @@ namespace md
 	// Cross-thread ingress for complete UART2 panel packets. This is a bounded MPSC
 	// ring: any thread may tryPush(), while exactly one emulation thread drains it.
 	// It neither allocates nor waits. A full queue rejects the complete packet and
-	// increments overflowCount(); callers that cannot lose an event must retry it.
+	// increments overflowCount(); rejected row state is retained for authoritative
+	// recovery, while pulse commands remain best effort.
 	class PanelInputQueue
 	{
 	public:
@@ -137,15 +149,19 @@ namespace md
 		// Advisory counted-work gate for the emulation thread. The producer publishes
 		// the count before the slot sequence, so true may briefly precede a drainable
 		// packet; drain()'s sequence acquire remains the packet-publication authority.
-		// False never consumes a wake: the count stays nonzero until the consumer drains.
+		// False never consumes a wake: FIFO count or retained recovery remains visible
+		// until the consumer drains it.
 		bool hasPending() const
 		{
-			return m_pendingPackets.load(std::memory_order_acquire) != 0;
+			return m_pendingPackets.load(std::memory_order_acquire) != 0
+				|| (m_rowRecoveryPublication.load(std::memory_order_acquire)
+					& g_recoveryPending) != 0;
 		}
 		// Retained byte-count convention for Hardware::getPendingPanelInputBytes().
 		size_t size() const;
 		size_t pendingPackets() const;
 		size_t overflowCount() const;
+		PanelInputQueueStatus status() const;
 		size_t drain(DrainBuffer& _destination,
 			size_t _maximumPackets = g_maxDrainPackets);
 
@@ -156,13 +172,39 @@ namespace md
 			std::atomic<size_t> sequence{0};
 			PanelPacket packet{};
 		};
+		static constexpr uint8_t g_firstRow = 0x20;
+		static constexpr uint8_t g_lastRow = 0x25;
+		static constexpr size_t g_rowCount = g_lastRow - g_firstRow + 1;
+		static constexpr size_t g_recoveryPending = 1;
+
+		static constexpr bool isRowState(const uint8_t _command)
+		{
+			return _command >= g_firstRow && _command <= g_lastRow;
+		}
+		bool tryPushFifo(uint8_t _command, uint8_t _argument);
+		void retainRowRecovery();
 
 		static_assert(std::atomic<size_t>::is_always_lock_free,
 			"PanelInputQueue requires lock-free size_t atomics");
+		static_assert(std::atomic<uint8_t>::is_always_lock_free,
+			"PanelInputQueue requires lock-free byte atomics");
 		std::array<Slot, g_capacityPackets> m_slots{};
 		std::atomic<size_t> m_enqueuePosition{0};
 		size_t m_dequeuePosition = 0; // single-consumer-owned
+		// Producers join before inspecting recovery state. The consumer closes the
+		// admission gate before accepting a recovery snapshot, then waits for this
+		// count to reach zero so no older FIFO reservation can publish afterward.
+		std::atomic<size_t> m_inFlightProducers{0};
+		std::atomic<bool> m_recoveryAdmissionClosed{false};
 		std::atomic<size_t> m_pendingPackets{0};
 		std::atomic<size_t> m_overflowCount{0};
+		std::array<std::atomic<uint8_t>, g_rowCount> m_recoveryRows{};
+		// Low bit means recovery is pending; the remaining bits form a publication
+		// revision so a producer racing the consumer cannot clear newer row state.
+		std::atomic<size_t> m_rowRecoveryPublication{0};
+		std::atomic<size_t> m_rejectedPackets{0};
+		std::atomic<size_t> m_droppedPulsePackets{0};
+		std::atomic<size_t> m_coalescedRowPackets{0};
+		std::atomic<size_t> m_recoveredRowPackets{0};
 	};
 }

--- a/source/elektron/md/mdLibTest/mdRuntimeTest.cpp
+++ b/source/elektron/md/mdLibTest/mdRuntimeTest.cpp
@@ -1,10 +1,56 @@
 #include "mdLib/mdfrontpanel.h"
+#include "mdLib/mdpanel.h"
 #include "mdLib/mdsim.h"
 #include "dsp56kEmu/memory.h"
 
 #include <array>
 #include <cstdint>
 #include <iostream>
+#include <optional>
+#include <thread>
+
+namespace md
+{
+	// Exposes only the split reservation/publication used to exercise the producer
+	// lifetime race deterministically; production has no scheduling hook.
+	struct PanelInputQueueTestAccess
+	{
+		static std::optional<size_t> claimFifoSlot(PanelInputQueue& _queue,
+			const PanelPacket& _packet)
+		{
+			_queue.m_inFlightProducers.fetch_add(1, std::memory_order_seq_cst);
+			if(PanelInputQueue::isRowState(_packet.row))
+				_queue.m_recoveryRows[_packet.row - PanelInputQueue::g_firstRow].store(
+					_packet.mask, std::memory_order_release);
+
+			auto position = _queue.m_enqueuePosition.load(std::memory_order_relaxed);
+			auto& slot = _queue.m_slots[position % _queue.m_slots.size()];
+			if(slot.sequence.load(std::memory_order_acquire) != position
+				|| !_queue.m_enqueuePosition.compare_exchange_strong(position,
+					position + 1, std::memory_order_relaxed))
+			{
+				_queue.m_inFlightProducers.fetch_sub(1, std::memory_order_seq_cst);
+				return std::nullopt;
+			}
+			return position;
+		}
+
+		static void publishFifoSlot(PanelInputQueue& _queue, const size_t _position,
+			const PanelPacket& _packet)
+		{
+			auto& slot = _queue.m_slots[_position % _queue.m_slots.size()];
+			_queue.m_pendingPackets.fetch_add(1, std::memory_order_release);
+			slot.packet = _packet;
+			slot.sequence.store(_position + 1, std::memory_order_release);
+			_queue.m_inFlightProducers.fetch_sub(1, std::memory_order_seq_cst);
+		}
+
+		static size_t inFlightProducers(const PanelInputQueue& _queue)
+		{
+			return _queue.m_inFlightProducers.load(std::memory_order_seq_cst);
+		}
+	};
+}
 
 namespace
 {
@@ -211,13 +257,175 @@ namespace
 			&& check(publisher.getLedTransitionStatus().dropped == 0,
 				"LED transition reset retained drop telemetry");
 	}
+
+	bool testPanelInputReleaseRecovery()
+	{
+		md::PanelInputQueue queue;
+		const auto held = md::PanelPacket{0x24, 0x02};
+		if(!check(queue.tryPush(held.row, held.mask),
+			"panel queue rejected the initial held state"))
+			return false;
+
+		// Model restore-paused draining: the accepted press and coalescible encoder
+		// pulses fill the finite queue while the emulation consumer is stopped.
+		for(size_t i = 1; i < md::PanelInputQueue::g_capacityPackets; ++i)
+			if(!check(queue.tryPush(0x30, 0x01),
+				"panel queue filled before its documented capacity"))
+				return false;
+
+		// The release cannot enter the FIFO, but it must survive as authoritative
+		// row state even if the producer (the Editor during destruction) goes away.
+		if(!check(!queue.tryPush(held.row, 0),
+			"saturated panel queue reported accepting the release")
+			|| !check(!queue.tryPush(0x23, 0),
+				"row state bypassed pending row recovery")
+			|| !check(!queue.tryPush(0x31, 0xff),
+				"encoder pulse bypassed pending row recovery"))
+			return false;
+
+		auto status = queue.status();
+		if(!check(status.rowRecoveryPending,
+			"rejected release did not arm row recovery")
+			|| !check(status.overflowCount == 1 && status.rejectedPackets == 3,
+				"panel rejection telemetry is wrong")
+			|| !check(status.droppedPulsePackets == 1,
+				"coalescible encoder drop telemetry is wrong")
+			|| !check(status.coalescedRowPackets == 1,
+				"authoritative row coalescing telemetry is wrong")
+			|| !check(queue.size()
+				== (md::PanelInputQueue::g_capacityPackets + 6) * 2,
+				"retained row recovery was absent from pending byte telemetry"))
+			return false;
+
+		md::PanelInputQueue::DrainBuffer batch;
+		bool sawPress = false;
+		bool sawReleaseAfterPress = false;
+		for(size_t pass = 0; pass < 4; ++pass)
+		{
+			const auto count = queue.drain(batch);
+			for(size_t i = 0; i < count; ++i)
+			{
+				if(batch[i] == held)
+					sawPress = true;
+				if(sawPress && batch[i].row == held.row && batch[i].mask == 0)
+					sawReleaseAfterPress = true;
+			}
+		}
+		if(!check(queue.pendingPackets() == 0 && queue.hasPending(),
+			"row recovery lost its emulation-thread wake after FIFO drain"))
+			return false;
+
+		// At this point the simulated Editor/producer is gone. Recovery lives in the
+		// queue, so the next post-restore consumer pass still emits every row.
+		const auto recoveryCount = queue.drain(batch);
+		if(!check(recoveryCount == 6,
+			"panel recovery did not publish one complete row snapshot"))
+			return false;
+		for(size_t i = 0; i < recoveryCount; ++i)
+			if(sawPress && batch[i].row == held.row && batch[i].mask == 0)
+				sawReleaseAfterPress = true;
+
+		status = queue.status();
+		return check(sawPress && sawReleaseAfterPress,
+			"authoritative release did not follow the accepted press")
+			&& check(!status.rowRecoveryPending && queue.size() == 0,
+				"panel release recovery did not quiesce")
+			&& check(status.recoveredRowPackets == 6,
+				"panel recovery telemetry did not report the row snapshot");
+	}
+
+	bool testPanelInputRecoveryWaitsForClaimedProducer()
+	{
+		md::PanelInputQueue queue;
+		for(size_t i = 0; i + 1 < md::PanelInputQueue::g_capacityPackets; ++i)
+			if(!check(queue.tryPush(0x30, 0x01),
+				"panel queue filled before the final FIFO slot"))
+				return false;
+
+		const md::PanelPacket held{0x24, 0x02};
+		const auto claimed = md::PanelInputQueueTestAccess::claimFifoSlot(queue,
+			held);
+		if(!check(claimed.has_value(), "failed to reserve the final FIFO slot")
+			|| !check(md::PanelInputQueueTestAccess::inFlightProducers(queue) == 1,
+				"stalled panel producer was not tracked in flight"))
+			return false;
+
+		bool releaseAccepted = true;
+		std::thread releaseProducer([&queue, &held, &releaseAccepted]
+		{
+			releaseAccepted = queue.tryPush(held.row, 0);
+		});
+		releaseProducer.join();
+		if(!check(!releaseAccepted,
+			"release unexpectedly entered a FIFO with its final slot reserved")
+			|| !check(queue.status().rowRecoveryPending,
+				"rejected release did not arm recovery behind the reservation"))
+			return false;
+
+		md::PanelInputQueue::DrainBuffer batch;
+		size_t drained = 0;
+		for(size_t pass = 0; pass < 4; ++pass)
+		{
+			const auto count = queue.drain(batch);
+			drained += count;
+			for(size_t i = 0; i < count; ++i)
+				if(!check(batch[i] == md::PanelPacket{0x30, 0x01},
+					"recovery overtook the stalled FIFO reservation"))
+					return false;
+		}
+		if(!check(drained == md::PanelInputQueue::g_capacityPackets - 1,
+			"did not drain every published packet ahead of the reservation")
+			|| !check(queue.pendingPackets() == 0 && queue.hasPending(),
+				"stalled reservation lost its retained recovery wake"))
+			return false;
+
+		// With FIFO accounting alone this empty-looking pass would emit the release
+		// snapshot before the already-claimed press can publish.
+		if(!check(queue.drain(batch) == 0,
+			"recovery overtook an in-flight producer's claimed FIFO slot")
+			|| !check(queue.status().rowRecoveryPending,
+				"blocked recovery was cleared while a producer remained in flight"))
+			return false;
+		const md::PanelPacket gatedRow{0x25, 0x08};
+		if(!check(!queue.tryPush(gatedRow.row, gatedRow.mask),
+			"closed recovery gate admitted a newer FIFO packet"))
+			return false;
+
+		md::PanelInputQueueTestAccess::publishFifoSlot(queue, *claimed, held);
+		const auto count = queue.drain(batch);
+		if(!check(count == 7 && batch[0] == held,
+			"claimed press was not delivered before its recovery snapshot"))
+			return false;
+		bool sawRelease = false;
+		bool sawGatedRow = false;
+		for(size_t i = 1; i < count; ++i)
+		{
+			if(batch[i].row == held.row && batch[i].mask == 0)
+				sawRelease = true;
+			if(batch[i] == gatedRow)
+				sawGatedRow = true;
+		}
+
+		return check(sawRelease,
+			"authoritative release did not follow the claimed press")
+			&& check(sawGatedRow,
+				"row state rejected by the closed gate was not recovered")
+			&& check(md::PanelInputQueueTestAccess::inFlightProducers(queue) == 0,
+				"published producer remained marked in flight")
+			&& check(!queue.hasPending() && queue.size() == 0,
+				"claimed-producer recovery did not quiesce")
+			&& check(queue.tryPush(0x30, 0x01),
+				"FIFO admission did not reopen after recovery cleared");
+	}
 }
 
 int main()
 {
 	if(!testDspMemoryFallback() || !testMk2PortAInvertedLoopback()
 		|| !testFrontPanelStepLeds() || !testMachinedrumPanelLedBanks()
-		|| !testFrontPanelTransitionPublication())
+		|| !testFrontPanelTransitionPublication()
+		|| !testPanelInputReleaseRecovery()
+		|| !testPanelInputRecoveryWaitsForClaimedProducer())
 		return 1;
 	std::cout << "mdLib tests passed\n";
 	return 0;


### PR DESCRIPTION
## Summary

- Propagate panel-input acceptance from Hardware through Device to the editor, allowing navigation steps to retry.
- Retain the latest authoritative MD/MM row state when the bounded FIFO is saturated, while keeping encoder pulses best effort and observable through telemetry.
- Prevent recovery from overtaking a claimed but unpublished FIFO packet with an admission gate and in-flight producer tracking.
- Add deterministic saturation and claimed-slot regressions plus a focused CI gate.

## Validation

- mdLibTest build: PASS.
- mdLibTests: PASS, including 100 repeated runs.
- Independent MPSC ordering review: PASS.
- YAML and git diff checks: PASS.