### PR TITLE
Restore Shift-click panel holds and trig chording

### DIFF
--- a/.github/workflows/mdmm-core.yml
+++ b/.github/workflows/mdmm-core.yml
@@ -182,7 +182,6 @@ jobs:
           '^(midiOutputDispatcherTest|mdAutomationParameterTest|mdAutomationArchitectureTest|mdAudioIoLayoutTest|mdFrontPanelPresentationTests)$'
 
       - name: Build and run Shift panel chording regression
-        if: matrix.mode == 'asan-ubsan'
         run: |
           cmake --build build-mdmm-core --parallel 4 --target mdShiftPanelLatchTest
           ctest --test-dir build-mdmm-core -C Release --output-on-failure \

--- a/.github/workflows/mdmm-core.yml
+++ b/.github/workflows/mdmm-core.yml
@@ -180,3 +180,10 @@ jobs:
           --no-tests=error
           --tests-regex
           '^(midiOutputDispatcherTest|mdAutomationParameterTest|mdAutomationArchitectureTest|mdAudioIoLayoutTest|mdFrontPanelPresentationTests)$'
+
+      - name: Build and run Shift panel chording regression
+        if: matrix.mode == 'asan-ubsan'
+        run: |
+          cmake --build build-mdmm-core --parallel 4 --target mdShiftPanelLatchTest
+          ctest --test-dir build-mdmm-core -C Release --output-on-failure \
+            --no-tests=error --tests-regex '^mdShiftPanelLatchTest$'

--- a/source/elektron/md/CMakeLists.txt
+++ b/source/elektron/md/CMakeLists.txt
@@ -4,6 +4,16 @@ add_subdirectory(mdLib)
 
 if(BUILD_TESTING)
 	add_subdirectory(mdLibTest)
+
+	# This policy test deliberately stays independent of JUCE so pull requests
+	# exercise it in the fast headless configuration as well as release builds.
+	add_executable(mdShiftPanelLatchTest
+		mdJucePlugin/mdShiftPanelLatchTest.cpp)
+	target_link_libraries(mdShiftPanelLatchTest PRIVATE mdLib)
+	target_include_directories(mdShiftPanelLatchTest PRIVATE mdJucePlugin)
+	add_test(NAME mdShiftPanelLatchTest COMMAND mdShiftPanelLatchTest)
+	set_tests_properties(mdShiftPanelLatchTest PROPERTIES LABELS "UnitTest;Panel")
+	set_property(TARGET mdShiftPanelLatchTest PROPERTY FOLDER "Elektron/test")
 endif()
 
 if(${CMAKE_PROJECT_NAME}_BUILD_JUCEPLUGIN)

--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -127,12 +127,6 @@ if(BUILD_TESTING)
 	set_tests_properties(mdFrontPanelPresentationTests PROPERTIES LABELS "UnitTest")
 	set_property(TARGET mdFrontPanelPresentationTest PROPERTY FOLDER "Elektron")
 
-	add_executable(mdShiftPanelLatchTest mdShiftPanelLatchTest.cpp)
-	target_link_libraries(mdShiftPanelLatchTest PRIVATE mdLib)
-	add_test(NAME mdShiftPanelLatchTest COMMAND mdShiftPanelLatchTest)
-	set_tests_properties(mdShiftPanelLatchTest PROPERTIES LABELS "UnitTest;Panel")
-	set_property(TARGET mdShiftPanelLatchTest PROPERTY FOLDER "Elektron/test")
-
 	add_executable(mdAutomationParameterTest mdAutomationParameterTest.cpp)
 	target_link_libraries(mdAutomationParameterTest PRIVATE
 		jucePluginLib mdLib juce_plugin_modules)

--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -127,6 +127,12 @@ if(BUILD_TESTING)
 	set_tests_properties(mdFrontPanelPresentationTests PROPERTIES LABELS "UnitTest")
 	set_property(TARGET mdFrontPanelPresentationTest PROPERTY FOLDER "Elektron")
 
+	add_executable(mdShiftPanelLatchTest mdShiftPanelLatchTest.cpp)
+	target_link_libraries(mdShiftPanelLatchTest PRIVATE mdLib)
+	add_test(NAME mdShiftPanelLatchTest COMMAND mdShiftPanelLatchTest)
+	set_tests_properties(mdShiftPanelLatchTest PROPERTIES LABELS "UnitTest;Panel")
+	set_property(TARGET mdShiftPanelLatchTest PROPERTY FOLDER "Elektron/test")
+
 	add_executable(mdAutomationParameterTest mdAutomationParameterTest.cpp)
 	target_link_libraries(mdAutomationParameterTest PRIVATE
 		jucePluginLib mdLib juce_plugin_modules)

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -27,9 +27,11 @@
 #include "juceRmlUi/rmlElemComboBox.h"
 #include "juceRmlUi/rmlElemKnob.h"
 #include "juceRmlUi/rmlEventListener.h"
+#include "juceRmlUi/rmlHelper.h"
 #include "juceRmlUi/juceRmlComponent.h"
 
 #include "RmlUi/Core/Element.h"
+#include "RmlUi/Core/ElementDocument.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -143,14 +145,14 @@ namespace mdJucePlugin
 		, m_controller(dynamic_cast<Controller&>(_processor.getController()))
 		, m_model(dynamic_cast<const AudioPluginAudioProcessor&>(_processor).getModel())
 	{
+		juce::Desktop::getInstance().addFocusChangeListener(this);
 	}
 
 	Editor::~Editor()
 	{
+		juce::Desktop::getInstance().removeFocusChangeListener(this);
 		m_panelSteps.clear();
-		endPanelGesture();
-		releasePatternBankLatch();
-		releaseAllPanelInputs();
+		cancelPanelInputGestures();
 		stopTimer(g_presentationTimerId);
 		stopTimer(g_panelTimerId);
 	}
@@ -303,6 +305,8 @@ namespace mdJucePlugin
 
 	void Editor::createButtons()
 	{
+		releaseActivePanelButtons();
+		releaseShiftHeldPanelControls();
 		releasePatternBankLatch();
 		m_panelRows.reset();
 		const auto model = getModel();
@@ -321,40 +325,134 @@ namespace mdJucePlugin
 			}
 
 			// On the hardware, A/E through D/H are held while a trig key chooses the
-			// pattern number. A mouse cannot hold one momentary button while clicking
-			// another, so an MM bank click latches until the next trig.
+			// pattern number. A normal MM bank click therefore keeps its existing latch.
+			// When another Shift-held control is active, the bank acts as an ordinary
+			// momentary target so chords such as FUNCTION + BANK remain exact.
 			if(model == md::MachineModel::Monomachine && isPatternBank(pb.control))
 			{
-				juceRmlUi::EventListener::Add(b, Rml::EventId::Click, [this, b, packet](Rml::Event&)
+				b->SetAttribute("title",
+					"Click to hold this bank; choose a trig to release it");
+				juceRmlUi::EventListener::Add(b, Rml::EventId::Mousedown,
+					[this, b, packet, control = pb.control](Rml::Event& _event)
 				{
-					togglePatternBankLatch(b, *packet);
+					const bool shiftDown = _event.GetParameter<int>("shift_key", 0) != 0;
+					if(!shiftDown && !m_shiftPanelLatch.empty())
+						releaseShiftHeldPanelControls();
+					if(m_shiftPanelLatch.empty())
+						togglePatternBankLatch(b, *packet);
+					else
+						pressPanelButton(b, control, *packet, shiftDown);
 				});
+				const auto release = [this, b, packet, control = pb.control](Rml::Event&)
+				{
+					releasePanelButton(b, control, *packet);
+				};
+				juceRmlUi::EventListener::Add(b, Rml::EventId::Mouseup, release);
+				juceRmlUi::EventListener::Add(b, Rml::EventId::Mouseout, release);
 				continue;
 			}
 
+			if(isTrigger(pb.control))
+				b->SetAttribute("title",
+					"Shift-click to hold this trig; release Shift to let go");
+			else
+				b->SetAttribute("title",
+					"Shift-click to hold; use another control; release Shift to let go");
+
 			juceRmlUi::EventListener::Add(b, Rml::EventId::Mousedown,
-				[this, b, packet, model, control = pb.control](Rml::Event&)
+				[this, b, packet, control = pb.control](Rml::Event& _event)
 			{
-				if(model == md::MachineModel::Monomachine && !isTrigger(control))
-					releasePatternBankLatch();
-				juceRmlUi::ElemButton::setChecked(b, true);
-				const auto combined = m_panelRows.press(*packet);
-				(void)sendPanelEvent(combined.row, combined.mask);
+				pressPanelButton(b, control, *packet,
+					_event.GetParameter<int>("shift_key", 0) != 0);
 			});
 
 			// Mouseout releases too, otherwise dragging off a button leaves it held.
-			const auto release = [this, b, packet, model, control = pb.control](Rml::Event&)
+			const auto release = [this, b, packet, control = pb.control](Rml::Event&)
 			{
-				if(!b->isChecked())
-					return;
-				juceRmlUi::ElemButton::setChecked(b, false);
-				const auto combined = m_panelRows.release(*packet);
-				(void)sendPanelEvent(combined.row, combined.mask);
-				if(model == md::MachineModel::Monomachine && isTrigger(control))
-					releasePatternBankLatch();
+				releasePanelButton(b, control, *packet);
 			};
 			juceRmlUi::EventListener::Add(b, Rml::EventId::Mouseup, release);
 			juceRmlUi::EventListener::Add(b, Rml::EventId::Mouseout, release);
+		}
+
+		if(auto* const document = getDocument())
+		{
+			juceRmlUi::EventListener::Add(document, Rml::EventId::Keyup,
+				[this](const Rml::Event& _event)
+				{
+					if(_event.GetParameter<int>("shift_key", 0) == 0
+						&& !m_shiftPanelLatch.empty())
+						releaseShiftHeldPanelControls();
+				});
+			juceRmlUi::EventListener::Add(document, Rml::EventId::Keydown,
+				[this](Rml::Event& _event)
+				{
+					if(juceRmlUi::helper::getKeyIdentifier(_event) != Rml::Input::KI_ESCAPE
+						|| (m_shiftPanelLatch.empty() && m_activePanelButtons.empty()
+							&& m_panelGesturePackets.empty() && !m_patternBankPacket))
+						return;
+					_event.StopPropagation();
+					cancelPanelInputGestures();
+				});
+		}
+	}
+
+	void Editor::pressPanelButton(juceRmlUi::ElemButton* const _button,
+		const md::PanelControl _control, const md::PanelPacket& _packet,
+		const bool _shiftDown)
+	{
+		if(!_button || _button->isChecked())
+			return;
+
+		// A missing native key-up must never let an earlier hold leak into a new,
+		// unmodified click before the timer fail-safe gets its next turn.
+		if(!_shiftDown && !m_shiftPanelLatch.empty())
+			releaseShiftHeldPanelControls();
+
+		const auto action = m_shiftPanelLatch.press(_control, _shiftDown);
+		if(action == panelAffordances::ShiftPanelLatch::PressAction::Ignored)
+			return;
+
+		if(getModel() == md::MachineModel::Monomachine && !isTrigger(_control))
+			releasePatternBankLatch();
+
+		juceRmlUi::ElemButton::setChecked(_button, true);
+		if(action == panelAffordances::ShiftPanelLatch::PressAction::Momentary)
+			m_activePanelButtons.push_back({ _button, _packet });
+
+		const auto combined = m_panelRows.press(_packet);
+		(void)sendPanelEvent(combined.row, combined.mask);
+	}
+
+	void Editor::releasePanelButton(juceRmlUi::ElemButton* const _button,
+		const md::PanelControl _control, const md::PanelPacket& _packet)
+	{
+		if(m_shiftPanelLatch.contains(_control))
+			return;
+
+		const auto it = std::find_if(m_activePanelButtons.begin(), m_activePanelButtons.end(),
+			[_button](const ActivePanelButton& _active) { return _active.button == _button; });
+		if(it == m_activePanelButtons.end())
+			return;
+
+		m_activePanelButtons.erase(it);
+		juceRmlUi::ElemButton::setChecked(_button, false);
+		const auto combined = m_panelRows.release(_packet);
+		(void)sendPanelEvent(combined.row, combined.mask);
+		if(getModel() == md::MachineModel::Monomachine && isTrigger(_control))
+			releasePatternBankLatch();
+	}
+
+	void Editor::releaseActivePanelButtons()
+	{
+		while(!m_activePanelButtons.empty())
+		{
+			const auto active = m_activePanelButtons.back();
+			m_activePanelButtons.pop_back();
+			if(active.button)
+				juceRmlUi::ElemButton::setChecked(active.button, false);
+			const auto combined = m_panelRows.release(active.packet);
+			(void)sendPanelEvent(combined.row, combined.mask);
 		}
 	}
 
@@ -372,8 +470,9 @@ namespace mdJucePlugin
 			if(!element)
 				return;
 			element->SetClass(panelAffordances::g_affordanceClass, true);
-			juceRmlUi::EventListener::Add(element, Rml::EventId::Click, [_select](Rml::Event&)
+			juceRmlUi::EventListener::Add(element, Rml::EventId::Click, [this, _select](Rml::Event&)
 			{
+				releaseShiftHeldPanelControls();
 				_select();
 			});
 		};
@@ -457,6 +556,9 @@ namespace mdJucePlugin
 	void Editor::beginPanelGesture(Rml::Element* const _element,
 		const std::initializer_list<md::PanelControl> _controls)
 	{
+		// Direct labels own their complete gesture. Ending an existing Shift hold
+		// avoids duplicate row bits and accidental three-control chords.
+		releaseShiftHeldPanelControls();
 		endPanelGesture();
 		releasePatternBankLatch();
 
@@ -489,6 +591,55 @@ namespace mdJucePlugin
 
 		m_panelGesturePackets.clear();
 		m_panelGestureElement = nullptr;
+	}
+
+	void Editor::releaseShiftHeldPanelControls()
+	{
+		// If Shift is released while an action button is still physically down, end
+		// that action before its held modifier. Later mouse-up is a harmless no-op.
+		releaseActivePanelButtons();
+
+		m_shiftPanelLatch.releaseAll([this](const md::PanelControl _control)
+		{
+			for(const auto& panelButton : g_panelButtons)
+			{
+				if(panelButton.control != _control)
+					continue;
+				if(auto* const button = findChild<juceRmlUi::ElemButton>(panelButton.id, false))
+					juceRmlUi::ElemButton::setChecked(button, false);
+				break;
+			}
+
+			if(const auto packet = md::panelPacket(getModel(), _control))
+			{
+				const auto combined = m_panelRows.release(*packet);
+				(void)sendPanelEvent(combined.row, combined.mask);
+			}
+		});
+
+		// A pattern bank acts as the modifier in the MM bank + trig chord. Let go
+		// of every target trig before releasing that modifier.
+		if(getModel() == md::MachineModel::Monomachine)
+			releasePatternBankLatch();
+	}
+
+	void Editor::cancelPanelInputGestures()
+	{
+		releaseActivePanelButtons();
+		endPanelGesture();
+		releaseShiftHeldPanelControls();
+		releasePatternBankLatch();
+		releaseAllPanelInputs();
+	}
+
+	void Editor::globalFocusChanged(juce::Component* const _focusedComponent)
+	{
+		auto* const panel = getRmlComponent();
+		if(panel && _focusedComponent
+			&& (_focusedComponent == panel || panel->isParentOf(_focusedComponent)))
+			return;
+
+		cancelPanelInputGestures();
 	}
 
 	void Editor::releaseAllPanelInputs()
@@ -985,6 +1136,9 @@ namespace mdJucePlugin
 		if(!_knob)
 			return;
 
+		// Shift belongs to the MD/MM panel-hold gesture. Keep normal drag speed
+		// while it is down; Command/Ctrl remains the fine-adjustment modifier.
+		_knob->SetAttribute("speedScaleShift", 1.0f);
 		_knob->setMinValue(0.0f);
 		_knob->setMaxValue(g_encoderRange);
 		_knob->setEndless(true);
@@ -1239,6 +1393,12 @@ namespace mdJucePlugin
 			return;
 
 		const auto nowMilliseconds = juce::Time::getMillisecondCounterHiRes();
+		// Some plugin hosts can lose the modifier key-up when focus changes. Poll
+		// native state as a fail-safe so no panel row remains held indefinitely.
+		if(!m_shiftPanelLatch.empty()
+			&& !juce::ModifierKeys::getCurrentModifiersRealtime().isShiftDown())
+			releaseShiftHeldPanelControls();
+
 		m_frontPanelSnapshotValid = refreshFrontPanelState(nowMilliseconds);
 
 		if(m_lcdCanvas && m_lcdChanged)

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -76,12 +76,6 @@ namespace mdJucePlugin
 			return false;
 		}
 
-		constexpr bool isPatternBank(const md::PanelControl _control)
-		{
-			return _control == md::PanelControl::BankA || _control == md::PanelControl::BankB
-				|| _control == md::PanelControl::BankC || _control == md::PanelControl::BankD;
-		}
-
 		constexpr bool isTrigger(const md::PanelControl _control)
 		{
 			return _control >= md::PanelControl::Trigger1 && _control <= md::PanelControl::Trigger16;
@@ -305,10 +299,7 @@ namespace mdJucePlugin
 
 	void Editor::createButtons()
 	{
-		releaseActivePanelButtons();
-		releaseShiftHeldPanelControls();
-		releasePatternBankLatch();
-		m_panelRows.reset();
+		cancelPanelInputGestures();
 		const auto model = getModel();
 
 		for (const auto& pb : g_panelButtons)
@@ -328,17 +319,19 @@ namespace mdJucePlugin
 			// pattern number. A normal MM bank click therefore keeps its existing latch.
 			// When another Shift-held control is active, the bank acts as an ordinary
 			// momentary target so chords such as FUNCTION + BANK remain exact.
-			if(model == md::MachineModel::Monomachine && isPatternBank(pb.control))
+			if(model == md::MachineModel::Monomachine
+				&& panelAffordances::isPatternBank(pb.control))
 			{
 				b->SetAttribute("title",
-					"Click to hold this bank; choose a trig to release it");
+					"Click to hold this bank until a trig; Shift uses the same bank latch");
 				juceRmlUi::EventListener::Add(b, Rml::EventId::Mousedown,
 					[this, b, packet, control = pb.control](Rml::Event& _event)
 				{
 					const bool shiftDown = _event.GetParameter<int>("shift_key", 0) != 0;
 					if(!shiftDown && !m_shiftPanelLatch.empty())
-						releaseShiftHeldPanelControls();
-					if(m_shiftPanelLatch.empty())
+						releasePanelButtonGestures();
+					if(panelAffordances::usesPersistentPatternBankLatch(getModel(),
+						control, !m_shiftPanelLatch.empty()))
 						togglePatternBankLatch(b, *packet);
 					else
 						pressPanelButton(b, control, *packet, shiftDown);
@@ -382,7 +375,7 @@ namespace mdJucePlugin
 				{
 					if(_event.GetParameter<int>("shift_key", 0) == 0
 						&& !m_shiftPanelLatch.empty())
-						releaseShiftHeldPanelControls();
+						releasePanelButtonGestures();
 				});
 			juceRmlUi::EventListener::Add(document, Rml::EventId::Keydown,
 				[this](Rml::Event& _event)
@@ -407,7 +400,7 @@ namespace mdJucePlugin
 		// A missing native key-up must never let an earlier hold leak into a new,
 		// unmodified click before the timer fail-safe gets its next turn.
 		if(!_shiftDown && !m_shiftPanelLatch.empty())
-			releaseShiftHeldPanelControls();
+			releasePanelButtonGestures();
 
 		const auto action = m_shiftPanelLatch.press(_control, _shiftDown);
 		if(action == panelAffordances::ShiftPanelLatch::PressAction::Ignored)
@@ -472,7 +465,7 @@ namespace mdJucePlugin
 			element->SetClass(panelAffordances::g_affordanceClass, true);
 			juceRmlUi::EventListener::Add(element, Rml::EventId::Click, [this, _select](Rml::Event&)
 			{
-				releaseShiftHeldPanelControls();
+				releasePanelButtonGestures();
 				_select();
 			});
 		};
@@ -558,9 +551,8 @@ namespace mdJucePlugin
 	{
 		// Direct labels own their complete gesture. Ending an existing Shift hold
 		// avoids duplicate row bits and accidental three-control chords.
-		releaseShiftHeldPanelControls();
+		releasePanelButtonGestures();
 		endPanelGesture();
-		releasePatternBankLatch();
 
 		m_panelGestureElement = _element;
 		m_panelGestureElement->SetClass("active", true);
@@ -593,10 +585,10 @@ namespace mdJucePlugin
 		m_panelGestureElement = nullptr;
 	}
 
-	void Editor::releaseShiftHeldPanelControls()
+	void Editor::releasePanelButtonGestures()
 	{
-		// If Shift is released while an action button is still physically down, end
-		// that action before its held modifier. Later mouse-up is a harmless no-op.
+		// Finish every momentary target before its Shift-held modifier. This also
+		// makes a later mouse-up harmless when key-up or focus loss ends the gesture.
 		releaseActivePanelButtons();
 
 		m_shiftPanelLatch.releaseAll([this](const md::PanelControl _control)
@@ -619,16 +611,13 @@ namespace mdJucePlugin
 
 		// A pattern bank acts as the modifier in the MM bank + trig chord. Let go
 		// of every target trig before releasing that modifier.
-		if(getModel() == md::MachineModel::Monomachine)
-			releasePatternBankLatch();
+		releasePatternBankLatch();
 	}
 
 	void Editor::cancelPanelInputGestures()
 	{
-		releaseActivePanelButtons();
 		endPanelGesture();
-		releaseShiftHeldPanelControls();
-		releasePatternBankLatch();
+		releasePanelButtonGestures();
 		releaseAllPanelInputs();
 	}
 
@@ -1397,7 +1386,7 @@ namespace mdJucePlugin
 		// native state as a fail-safe so no panel row remains held indefinitely.
 		if(!m_shiftPanelLatch.empty()
 			&& !juce::ModifierKeys::getCurrentModifiersRealtime().isShiftDown())
-			releaseShiftHeldPanelControls();
+			releasePanelButtonGestures();
 
 		m_frontPanelSnapshotValid = refreshFrontPanelState(nowMilliseconds);
 

--- a/source/elektron/md/mdJucePlugin/mdEditor.h
+++ b/source/elektron/md/mdJucePlugin/mdEditor.h
@@ -43,7 +43,8 @@ namespace mdJucePlugin
 	class Controller;
 	struct EditorIdentityTestAccess;
 
-	class Editor final : public jucePluginEditorLib::Editor, juce::MultiTimer
+	class Editor final : public jucePluginEditorLib::Editor, juce::MultiTimer,
+		private juce::FocusChangeListener
 	{
 	public:
 		Editor(jucePluginEditorLib::Processor& _processor, const jucePluginEditorLib::Skin& _skin);
@@ -85,10 +86,18 @@ namespace mdJucePlugin
 		void createPanelAffordances();
 		void bindPanelTarget(const char* _id, md::PanelControl _control);
 		void bindPanelChord(const char* _id, md::PanelControl _control);
+		void pressPanelButton(juceRmlUi::ElemButton* _button, md::PanelControl _control,
+			const md::PanelPacket& _packet, bool _shiftDown);
+		void releasePanelButton(juceRmlUi::ElemButton* _button, md::PanelControl _control,
+			const md::PanelPacket& _packet);
+		void releaseActivePanelButtons();
 		void beginPanelGesture(Rml::Element* _element,
 			std::initializer_list<md::PanelControl> _controls);
 		void endPanelGesture();
+		void releaseShiftHeldPanelControls();
+		void cancelPanelInputGestures();
 		void releaseAllPanelInputs();
+		void globalFocusChanged(juce::Component* _focusedComponent) override;
 		void queuePanelPulse(md::PanelControl _control, int _count = 1);
 		void servicePanelQueue();
 		void servicePanelNavigation();
@@ -145,6 +154,14 @@ namespace mdJucePlugin
 		std::optional<md::PanelPacket> m_patternBankPacket;
 		Rml::Element* m_panelGestureElement = nullptr;
 		std::vector<md::PanelPacket> m_panelGesturePackets;
+		panelAffordances::ShiftPanelLatch m_shiftPanelLatch;
+
+		struct ActivePanelButton
+		{
+			juceRmlUi::ElemButton* button = nullptr;
+			md::PanelPacket packet;
+		};
+		std::vector<ActivePanelButton> m_activePanelButtons;
 
 		struct PanelStep
 		{

--- a/source/elektron/md/mdJucePlugin/mdEditor.h
+++ b/source/elektron/md/mdJucePlugin/mdEditor.h
@@ -94,7 +94,7 @@ namespace mdJucePlugin
 		void beginPanelGesture(Rml::Element* _element,
 			std::initializer_list<md::PanelControl> _controls);
 		void endPanelGesture();
-		void releaseShiftHeldPanelControls();
+		void releasePanelButtonGestures();
 		void cancelPanelInputGestures();
 		void releaseAllPanelInputs();
 		void globalFocusChanged(juce::Component* _focusedComponent) override;

--- a/source/elektron/md/mdJucePlugin/mdPanelAffordances.h
+++ b/source/elektron/md/mdJucePlugin/mdPanelAffordances.h
@@ -33,6 +33,24 @@ namespace mdJucePlugin::panelAffordances
 		int count;
 	};
 
+	constexpr bool isPatternBank(const md::PanelControl _control)
+	{
+		return _control == md::PanelControl::BankA
+			|| _control == md::PanelControl::BankB
+			|| _control == md::PanelControl::BankC
+			|| _control == md::PanelControl::BankD;
+	}
+
+	// MM bank buttons already have a persistent click latch for choosing a pattern.
+	// That behavior also wins when the bank is the first Shift-clicked control. A
+	// bank becomes momentary only when it is the target of an existing Shift chord.
+	constexpr bool usesPersistentPatternBankLatch(const md::MachineModel _model,
+		const md::PanelControl _control, const bool _shiftChordActive)
+	{
+		return _model == md::MachineModel::Monomachine
+			&& isPatternBank(_control) && !_shiftChordActive;
+	}
+
 	// Classifies panel presses while Shift is down. The first control is held until
 	// Shift is released; subsequent controls remain ordinary momentary actions. The
 	// one exception preserves the parameter-lock workflow: a gesture that starts

--- a/source/elektron/md/mdJucePlugin/mdPanelAffordances.h
+++ b/source/elektron/md/mdJucePlugin/mdPanelAffordances.h
@@ -33,6 +33,85 @@ namespace mdJucePlugin::panelAffordances
 		int count;
 	};
 
+	// Classifies panel presses while Shift is down. The first control is held until
+	// Shift is released; subsequent controls remain ordinary momentary actions. The
+	// one exception preserves the parameter-lock workflow: a gesture that starts
+	// with a trig may collect more trigs, but never a second non-trig modifier.
+	class ShiftPanelLatch
+	{
+	public:
+		enum class PressAction
+		{
+			Momentary,
+			Latched,
+			Ignored,
+		};
+
+		PressAction press(const md::PanelControl _control, const bool _shiftDown)
+		{
+			const auto index = controlIndex(_control);
+			if(m_held[index])
+				return PressAction::Ignored;
+			if(!_shiftDown)
+				return PressAction::Momentary;
+			if(m_size != 0 && (!m_triggerSet || !isTrigger(_control)))
+				return PressAction::Momentary;
+
+			if(m_size == 0)
+				m_triggerSet = isTrigger(_control);
+			m_held[index] = true;
+			m_order[m_size++] = _control;
+			return PressAction::Latched;
+		}
+
+		bool contains(const md::PanelControl _control) const
+		{
+			return m_held[controlIndex(_control)];
+		}
+
+		bool empty() const
+		{
+			return m_size == 0;
+		}
+
+		size_t size() const
+		{
+			return m_size;
+		}
+
+		template<typename Release>
+		void releaseAll(Release&& _release)
+		{
+			while(m_size != 0)
+			{
+				const auto control = m_order[--m_size];
+				m_held[controlIndex(control)] = false;
+				_release(control);
+			}
+			m_triggerSet = false;
+		}
+
+	private:
+		static constexpr size_t g_controlCount =
+			static_cast<size_t>(md::PanelControl::ClassicExtended) + 1;
+
+		static constexpr bool isTrigger(const md::PanelControl _control)
+		{
+			return _control >= md::PanelControl::Trigger1
+				&& _control <= md::PanelControl::Trigger16;
+		}
+
+		static constexpr size_t controlIndex(const md::PanelControl _control)
+		{
+			return static_cast<size_t>(_control);
+		}
+
+		std::array<bool, g_controlCount> m_held{};
+		std::array<md::PanelControl, g_controlCount> m_order{};
+		size_t m_size = 0;
+		bool m_triggerSet = false;
+	};
+
 	// A direct-selection target is replaced, rather than appended, when the user
 	// clicks again while the firmware is still processing the previous request.
 	// The editor advances one panel pulse at a time and clears the target only

--- a/source/elektron/md/mdJucePlugin/mdShiftPanelLatchTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdShiftPanelLatchTest.cpp
@@ -1,0 +1,159 @@
+#include "mdPanelAffordances.h"
+
+#include <array>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+namespace
+{
+	using mdJucePlugin::panelAffordances::ShiftPanelLatch;
+	using PressAction = ShiftPanelLatch::PressAction;
+
+	void expect(const bool _condition, const char* const _message)
+	{
+		if(_condition)
+			return;
+
+		std::cerr << "mdShiftPanelLatchTest: " << _message << '\n';
+		std::exit(1);
+	}
+
+	void checkTriggerChordPolicy()
+	{
+		ShiftPanelLatch latch;
+		expect(latch.empty(), "new latch is not empty");
+		expect(latch.press(md::PanelControl::Trigger1, true) == PressAction::Latched,
+			"first Shift-trig was not latched");
+		expect(latch.press(md::PanelControl::Trigger1, true) == PressAction::Ignored,
+			"duplicate Shift-trig was accepted");
+		expect(latch.press(md::PanelControl::Trigger8, true) == PressAction::Latched,
+			"second Shift-trig was not latched");
+		expect(latch.press(md::PanelControl::Trigger16, true) == PressAction::Latched,
+			"last Shift-trig was not latched");
+		expect(latch.press(md::PanelControl::Play, true) == PressAction::Momentary,
+			"non-trig after a trig chord was latched");
+		expect(latch.size() == 3, "trigger chord size is wrong");
+
+		std::vector<md::PanelControl> released;
+		latch.releaseAll([&released](const auto control) { released.push_back(control); });
+		const std::vector<md::PanelControl> expected
+		{
+			md::PanelControl::Trigger16,
+			md::PanelControl::Trigger8,
+			md::PanelControl::Trigger1,
+		};
+		expect(released == expected, "held trigs were not released in reverse order");
+		expect(latch.empty(), "trigger chord release left latch state behind");
+	}
+
+	void checkModifierChordPolicy()
+	{
+		ShiftPanelLatch latch;
+		expect(latch.press(md::PanelControl::Function, false) == PressAction::Momentary,
+			"ordinary press was not momentary");
+		expect(latch.empty(), "ordinary press changed latch state");
+		expect(latch.press(md::PanelControl::Function, true) == PressAction::Latched,
+			"Shift-held modifier was not latched");
+		expect(latch.press(md::PanelControl::Tempo, true) == PressAction::Momentary,
+			"target after a held modifier was also latched");
+		expect(latch.press(md::PanelControl::Trigger4, true) == PressAction::Momentary,
+			"trig after a held modifier was also latched");
+		expect(latch.contains(md::PanelControl::Function) && latch.size() == 1,
+			"held modifier state is wrong");
+
+		std::vector<md::PanelControl> released;
+		latch.releaseAll([&released](const auto control) { released.push_back(control); });
+		expect(released == std::vector<md::PanelControl>{md::PanelControl::Function},
+			"modifier release was not exact");
+	}
+
+	void checkChordRows(const md::MachineModel _model,
+		const md::PanelControl _held, const md::PanelControl _target)
+	{
+		ShiftPanelLatch latch;
+		md::PanelRowState rows;
+		const auto heldPacket = md::panelPacket(_model, _held);
+		const auto targetPacket = md::panelPacket(_model, _target);
+		expect(heldPacket && targetPacket, "chord control has no panel packet");
+		expect(latch.press(_held, true) == PressAction::Latched,
+			"chord modifier was not latched");
+		rows.press(*heldPacket);
+		expect(latch.press(_target, true) == PressAction::Momentary,
+			"chord target was not momentary");
+		rows.press(*targetPacket);
+
+		const auto combinedMask = heldPacket->row == targetPacket->row
+			? static_cast<uint8_t>(heldPacket->mask | targetPacket->mask)
+			: heldPacket->mask;
+		expect(rows.mask(heldPacket->row) == combinedMask,
+			"target press did not preserve the held modifier");
+		if(heldPacket->row != targetPacket->row)
+			expect(rows.mask(targetPacket->row) == targetPacket->mask,
+				"target was not present in its panel row");
+
+		// The editor releases the action before its modifier.
+		rows.release(*targetPacket);
+		expect(rows.mask(heldPacket->row) == heldPacket->mask,
+			"target release also released its modifier");
+		latch.releaseAll([&](const auto control)
+		{
+			const auto packet = md::panelPacket(_model, control);
+			expect(packet.has_value(), "held control lost its panel packet");
+			rows.release(*packet);
+		});
+
+		for(uint8_t row = 0x20; row <= 0x25; ++row)
+			expect(rows.mask(row) == 0, "chord release left a panel row held");
+	}
+
+	void checkTriggerRows(const md::MachineModel _model)
+	{
+		ShiftPanelLatch latch;
+		md::PanelRowState rows;
+		constexpr std::array controls
+		{
+			md::PanelControl::Trigger1,
+			md::PanelControl::Trigger6,
+			md::PanelControl::Trigger11,
+			md::PanelControl::Trigger16,
+		};
+
+		for(const auto control : controls)
+		{
+			const auto packet = md::panelPacket(_model, control);
+			expect(packet.has_value(), "trig has no panel packet");
+			expect(latch.press(control, true) == PressAction::Latched,
+				"unique Shift-trig was rejected");
+			rows.press(*packet);
+		}
+
+		latch.releaseAll([&](const auto control)
+		{
+			const auto packet = md::panelPacket(_model, control);
+			expect(packet.has_value(), "latched trig lost its panel packet");
+			rows.release(*packet);
+		});
+		for(uint8_t row = 0x20; row <= 0x25; ++row)
+			expect(rows.mask(row) == 0, "trig release left a panel row held");
+	}
+}
+
+int main()
+{
+	checkTriggerChordPolicy();
+	checkModifierChordPolicy();
+	checkTriggerRows(md::MachineModel::Machinedrum);
+	checkTriggerRows(md::MachineModel::Monomachine);
+	checkChordRows(md::MachineModel::Machinedrum,
+		md::PanelControl::Record, md::PanelControl::Play);
+	checkChordRows(md::MachineModel::Machinedrum,
+		md::PanelControl::Scale, md::PanelControl::Stop);
+	checkChordRows(md::MachineModel::Monomachine,
+		md::PanelControl::Stop, md::PanelControl::Record);
+	checkChordRows(md::MachineModel::Monomachine,
+		md::PanelControl::DataPageBackward, md::PanelControl::DataPageForward);
+
+	std::cout << "mdShiftPanelLatchTest: PASS\n";
+	return 0;
+}

--- a/source/elektron/md/mdJucePlugin/mdShiftPanelLatchTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdShiftPanelLatchTest.cpp
@@ -1,6 +1,5 @@
 #include "mdPanelAffordances.h"
 
-#include <array>
 #include <cstdlib>
 #include <iostream>
 #include <vector>
@@ -66,6 +65,26 @@ namespace
 		latch.releaseAll([&released](const auto control) { released.push_back(control); });
 		expect(released == std::vector<md::PanelControl>{md::PanelControl::Function},
 			"modifier release was not exact");
+		expect(latch.press(md::PanelControl::Trigger2, true) == PressAction::Latched,
+			"released latch could not start a new trigger gesture");
+		latch.releaseAll([](const auto) {});
+	}
+
+	void checkMonomachineBankPolicy()
+	{
+		using mdJucePlugin::panelAffordances::usesPersistentPatternBankLatch;
+		expect(usesPersistentPatternBankLatch(md::MachineModel::Monomachine,
+			md::PanelControl::BankA, false),
+			"first MM bank press did not use its persistent latch");
+		expect(!usesPersistentPatternBankLatch(md::MachineModel::Monomachine,
+			md::PanelControl::BankA, true),
+			"MM bank target inside a Shift chord was not momentary");
+		expect(!usesPersistentPatternBankLatch(md::MachineModel::Machinedrum,
+			md::PanelControl::BankA, false),
+			"MD bank incorrectly used the MM persistent latch");
+		expect(!usesPersistentPatternBankLatch(md::MachineModel::Monomachine,
+			md::PanelControl::Function, false),
+			"non-bank MM control used the persistent bank latch");
 	}
 
 	void checkChordRows(const md::MachineModel _model,
@@ -111,16 +130,10 @@ namespace
 	{
 		ShiftPanelLatch latch;
 		md::PanelRowState rows;
-		constexpr std::array controls
+		for(int trigger = static_cast<int>(md::PanelControl::Trigger1);
+			trigger <= static_cast<int>(md::PanelControl::Trigger16); ++trigger)
 		{
-			md::PanelControl::Trigger1,
-			md::PanelControl::Trigger6,
-			md::PanelControl::Trigger11,
-			md::PanelControl::Trigger16,
-		};
-
-		for(const auto control : controls)
-		{
+			const auto control = static_cast<md::PanelControl>(trigger);
 			const auto packet = md::panelPacket(_model, control);
 			expect(packet.has_value(), "trig has no panel packet");
 			expect(latch.press(control, true) == PressAction::Latched,
@@ -143,6 +156,7 @@ int main()
 {
 	checkTriggerChordPolicy();
 	checkModifierChordPolicy();
+	checkMonomachineBankPolicy();
 	checkTriggerRows(md::MachineModel::Machinedrum);
 	checkTriggerRows(md::MachineModel::Monomachine);
 	checkChordRows(md::MachineModel::Machinedrum,


### PR DESCRIPTION
## What this brings back

- Shift-click an MD/MM panel button to keep it held until Shift is released.
- Shift-click multiple trigger keys to form held trigger chords for parameter-lock workflows.
- When a non-trigger control is held, later controls remain momentary so modifier chords stay exact.
- Reserve Shift for panel holds while Command/Ctrl remains the fine encoder-movement modifier.

## Monomachine bank-button exception

Monomachine A/E through D/H buttons keep their existing persistent click latch: the first click, including Shift-click, holds the bank until a trigger chooses the pattern. A bank acts momentarily only when it is clicked as the target of an already active Shift chord. This exception is intentional, visible in the tooltip, and covered by the policy test.

## Stuck-input protection

Held input is released on Shift-up, Escape, editor focus loss, an ordinary click after a missed Shift-up, or the native modifier-state fail-safe. Momentary targets are released before their held modifiers, and final row releases use the existing reliable panel-input queue recovery.

This is a focused port of the final chording behavior from the old recovery branches. It does not restore the unrelated updater, SysEx, +Drive, LCD inversion, or settings-discovery work from PR #20. Production changes stay inside the MD/MM editor.

## Automated verification

- The focused regression target is available with JUCE plugins disabled and now runs in the fast pull-request CI configuration.
- The test covers all 16 trigger keys on both MD and MM, reverse release order, duplicate suppression, modifier-plus-target row state, latch reuse, and the Monomachine bank exception.
- Full Machinedrum and Monomachine editor translation units compile locally with the project JUCE/RmlUi flags.
- git diff --check passes.

## Manual smoke test before release

- In both MD and MM, Shift-click one trigger, release the mouse, then release Shift.
- Shift-click several triggers and confirm they remain visibly held together until Shift-up.
- Shift-click FUNCTION, click a target, and confirm the target releases before FUNCTION.
- Confirm Escape and moving focus out of the plugin clear held buttons.
- On MM, confirm a first bank click remains latched until a trigger, while a bank used after a Shift-held modifier is momentary.