### PR TITLE
Add MD/MM SysEx file transfers

### DIFF
--- a/doc/elektron_md_mm_sysex.md
+++ b/doc/elektron_md_mm_sysex.md
@@ -1,0 +1,126 @@
+# Machinedrum / Monomachine SysEx files
+
+To send a user-data SysEx file to the emulated Machinedrum or Monomachine,
+right-click anywhere on the instrument UI and choose **Send SysEx File...**.
+The context-menu item shows transfer progress when the menu is reopened and
+becomes **Cancel SysEx Transfer...** while a transfer is active. Cancellation
+terminates any partial SysEx message before releasing the emulated MIDI wire.
+
+The sender accepts one or more complete Elektron user-data dump messages for the
+active machine, up to 8 MiB: globals, kits, patterns, songs, and Monomachine
+DigiPRO waveforms. Framing, 7-bit data, model identity, dump-command identity,
+checksum, and declared length are validated for every message. Files for the
+other machine, MIDI control/request commands, malformed/corrupt streams, and OS
+updates are rejected.
+
+Monomachine firmware accepts data dumps only while the matching receive screen
+says **WAITING**. Before its file picker opens, the plug-in confirms that this is
+already true. Use **GLOBAL > FILE > SYSEX RECV** for kits, patterns, songs,
+globals, and backups. DigiPRO waveform files instead use **GLOBAL > FILE >
+DIGIPRO MGR > RECEIVE**. After a DigiPRO transfer reaches its last waveform,
+press **EXIT/NO** and wait for **WRITING WAVEFORMS** to finish. The Machinedrum
+does not require this preflight step.
+
+Imported Monomachine DigiPRO data is included in newly saved plug-in/project
+state. This adds a fixed 2 MiB user-flash image, with an independent CRC, to the
+existing 1 MiB patch-RAM snapshot. Older version-1 Monomachine states remain
+readable; because they predate user-flash persistence, they restore patch RAM
+only and retain the user flash initialized by the loaded ROM.
+
+The sender negotiates TurboMIDI with the emulated firmware and falls back to
+standard MIDI speed when negotiation is unavailable. Transfer completion means
+the bytes have drained through the emulated MIDI UART; the machine's display is
+authoritative for whether its firmware accepted and imported the data.
+While it owns that serial wire, a MIDI event already in flight is allowed to
+finish; subsequent host notes/controllers and automation-generated MIDI wait
+behind the file. MIDI clock already queued at the ownership boundary crosses
+first, and later clock traffic waits with the other input rather than being
+inserted into the SysEx stream.
+
+The host must keep processing the instrument while a transfer is active. If the
+emulated MIDI port does not advance for five seconds, the UI warns that the
+transfer is paused. Resume audio processing and disable plug-in bypass or host
+suspension; the right-click cancellation command remains available.
+
+The sender retains at most one file buffer, bounded by the 8 MiB input limit.
+Completion leaves that storage available for control-plane retirement rather
+than freeing it on the real-time scheduler. The editor normally retires it on
+the next progress tick; reopening an editor retires a transfer that completed
+while the editor was closed, and starting another transfer also retires an
+unobserved terminal buffer outside the plug-in's process/device lock.
+Cancellation hands the buffer directly to its control-plane caller for the same
+off-lock destruction.
+
+This operation is intentionally not part of the Escape/settings overlay.
+Settings are persistent configuration, while sending a file is an active
+machine operation with progress and a firmware-owned result.
+
+## Verification
+
+Build and run the deterministic transport and project-state regressions with:
+
+```sh
+cmake --build <build-directory> --target mdTurboMidiUnitTest mdStateTest
+ctest --test-dir <build-directory> --output-on-failure \
+  --tests-regex '^(mdTurboMidiUnitTest|mdStateTest)$'
+```
+
+The transport suite covers negotiation fallback, the documented TurboMIDI
+handshake, checksum and message validation, concurrent transfer starts, MIDI
+wire arbitration, suspended processing followed by resume, cancellation,
+terminal payload retirement, and concurrent progress readers.
+
+For firmware-level verification with legally obtained firmware and user-data
+files, build `mdUserSysexFirmwareTest` and run one of:
+
+```sh
+mdUserSysexFirmwareTest md <firmware.bin> <user-data.syx> [first|cancel]
+mdUserSysexFirmwareTest mm <firmware.bin> <1MiB-patch-ram.bin> \
+  <user-data.syx> [first|cancel]
+```
+
+The harness drives the Monomachine receive screens, interleaves clock,
+controller/automation-like traffic, and ordinary MIDI with the transfer, waits
+for the emulated UART to drain, and requires persistent RAM or flash mutation.
+For DigiPRO it also serializes project state and verifies byte-exact user-flash
+restoration in a fresh hardware instance. `first` limits a concatenated file to
+its first message; `cancel` verifies partial-message termination and return to
+an idle transport.
+
+### Verification record
+
+On 2026-09-04, a clean macOS arm64 Release build from the feature commit passed
+`mdTurboMidiUnitTest` and `mdStateTest`. Machinedrum and Monomachine Standalone,
+VST3, and AU targets built successfully; all six bundles passed strict ad-hoc
+signature verification, both AU property lists were valid, and the project
+plug-in tester loaded both VST3s and passed its audio-bus and automation/state
+smoke checks.
+
+The same build completed firmware-backed imports of a 777,212-byte Machinedrum
+backup, a 288,472-byte Monomachine backup, and a 449,728-byte Monomachine
+DigiPRO bank. They respectively changed 178,359 patch-RAM plus 1,025,724 flash
+bytes, 148,267 patch-RAM bytes, and 378,314 user-flash bytes. The DigiPRO run
+also passed project-state serialization and byte-exact restoration into fresh
+hardware. A separate Machinedrum run cancelled after 40 of 777,212 bytes and
+verified a terminal transport with idle MIDI ingress.
+
+This local record does not replace the normal Windows x64, Linux, or macOS
+universal CI jobs. Those remain required before merge because they exercise
+other compilers, sanitizers, CPU architectures, and release packaging.
+
+## Known limitations
+
+- Transfers advance only while the host processes the instrument. Some hosts
+  suspend processing for bypassed, muted, or inaudible plug-ins.
+- UART-drained completion cannot prove firmware acceptance. Follow the
+  instrument display, especially the Monomachine's receive and flash-writing
+  prompts.
+- Import is deliberately limited to complete, checksum-valid user-data dump
+  messages recognized for the active model, with an 8 MiB file-size limit.
+- If a transfer completes with no editor open and no later transfer starts, its
+  bounded file buffer remains owned by the machine until an editor opens or the
+  plug-in instance is destroyed. This avoids an unbounded-time deallocation on
+  the real-time scheduler.
+- Platform and plug-in-format packaging remains the responsibility of the
+  normal project CI matrix; the firmware harness requires user-supplied ROMs
+  and therefore is not suitable for public CI artifacts.

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -277,6 +277,33 @@ namespace mdJucePlugin
 		applyPanelSpeeds();
 		createLeds();
 		createPanelAffordances();
+
+		// A transfer belongs to the emulated machine, not the lifetime of one
+		// editor window. Reattach progress monitoring after a reopen, or reclaim a
+		// file buffer whose terminal transition happened while no editor existed.
+		const auto progress = getUserSysexProgress();
+		if(progress && (progress->state == md::MidiSysexTransferState::Queued
+			|| progress->state == md::MidiSysexTransferState::NegotiatingTurbo
+			|| progress->state == md::MidiSysexTransferState::Sending
+			|| progress->state == md::MidiSysexTransferState::Cancelling))
+		{
+			m_sysexTransferWasActive = true;
+			m_sysexLastState = progress->state;
+			m_sysexLastSent = progress->sent;
+			m_sysexLastAdvanceMilliseconds = juce::Time::getMillisecondCounterHiRes();
+		}
+		else if(progress && (progress->state == md::MidiSysexTransferState::Complete
+			|| progress->state == md::MidiSysexTransferState::Cancelled))
+		{
+			std::vector<uint8_t> retiredPayload;
+			(void)getProcessor().getPlugin().withDeviceLocked(
+				[&](synthLib::Device* const _device)
+				{
+					auto* const device = dynamic_cast<md::Device*>(_device);
+					return device && device->getHardware()
+						.retireMidiSysexTransferPayload(retiredPayload);
+				});
+		}
 	}
 
 	void Editor::createLcd()
@@ -959,6 +986,318 @@ namespace mdJucePlugin
 			_message.toStdString(), getRmlComponent());
 	}
 
+	std::optional<md::MidiSysexTransferProgress> Editor::getUserSysexProgress() const
+	{
+		return getProcessor().getPlugin().withDeviceLocked(
+			[](synthLib::Device* const _device)
+				-> std::optional<md::MidiSysexTransferProgress>
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				if(!device)
+					return std::nullopt;
+				return device->getHardware().getMidiSysexTransferProgress();
+			});
+	}
+
+	bool Editor::isUserSysexTransferActive() const
+	{
+		const auto progress = getUserSysexProgress();
+		if(!progress)
+			return false;
+		return progress->state == md::MidiSysexTransferState::Queued
+			|| progress->state == md::MidiSysexTransferState::NegotiatingTurbo
+			|| progress->state == md::MidiSysexTransferState::Sending
+			|| progress->state == md::MidiSysexTransferState::Cancelling;
+	}
+
+	bool Editor::canCancelUserSysexTransfer() const
+	{
+		const auto progress = getUserSysexProgress();
+		if(!progress)
+			return false;
+		return progress->state == md::MidiSysexTransferState::Queued
+			|| progress->state == md::MidiSysexTransferState::NegotiatingTurbo
+			|| progress->state == md::MidiSysexTransferState::Sending;
+	}
+
+	std::string Editor::getUserSysexMenuText() const
+	{
+		const auto progress = getUserSysexProgress();
+		if(!progress)
+			return "Send SysEx File...";
+		if(progress->state == md::MidiSysexTransferState::Cancelling)
+			return "Cancelling SysEx Transfer...";
+		if(progress->state == md::MidiSysexTransferState::Queued
+			|| progress->state == md::MidiSysexTransferState::NegotiatingTurbo)
+			return "Cancel SysEx Transfer - negotiating TurboMIDI...";
+		if(progress->state == md::MidiSysexTransferState::Sending)
+		{
+			const auto percent = progress->total == 0 ? size_t{0}
+				: std::min<size_t>(100, (progress->sent * 100) / progress->total);
+			return "Cancel SysEx Transfer... " + std::to_string(percent) + "%";
+		}
+		return "Send SysEx File...";
+	}
+
+	void Editor::cancelUserSysexTransfer()
+	{
+		std::vector<uint8_t> retiredPayload;
+		const bool cancelled = getProcessor().getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				return device && device->getHardware().cancelMidiSysexTransfer(
+					retiredPayload);
+			});
+		// retiredPayload is intentionally destroyed here, after withDeviceLocked()
+		// has returned, so cancellation never frees file-sized storage on audio time.
+		if(!cancelled)
+			showUserSysexError("The transfer was no longer active.");
+	}
+
+	void Editor::chooseUserSysexFile()
+	{
+		if(m_sysexChooserOpen)
+		{
+			showUserSysexError("Finish the open SysEx file dialog first.");
+			return;
+		}
+		if(isUserSysexTransferActive())
+		{
+			showUserSysexError("A SysEx file is already being sent.");
+			return;
+		}
+
+		m_sysexChooserOpen = true;
+		if(m_model == md::MachineModel::Monomachine)
+		{
+			const std::weak_ptr<void> lifetime = m_lifetimeToken;
+			genericUI::MessageBox::showYesNo(genericUI::MessageBox::Icon::Info,
+				"Is Monomachine ready to receive?",
+				"The Monomachine only accepts data dumps while its display says WAITING. "
+				"For kits, patterns, songs, globals, or a backup, use GLOBAL > FILE > "
+				"SYSEX RECV. For DigiPRO waveforms, use GLOBAL > FILE > DIGIPRO MGR > "
+				"RECEIVE.\n\n"
+				"Is the appropriate WAITING screen open now?",
+				[lifetime, this](const genericUI::MessageBox::Result _answer)
+				{
+					if(lifetime.expired())
+						return;
+					if(_answer != genericUI::MessageBox::Result::Yes)
+					{
+						m_sysexChooserOpen = false;
+						return;
+					}
+					launchUserSysexFileChooser();
+				});
+			return;
+		}
+		launchUserSysexFileChooser();
+	}
+
+	void Editor::launchUserSysexFileChooser()
+	{
+
+		auto& config = getProcessor().getConfig();
+		juce::File initial(config.getValue("mdMmSysexLastDirectory"));
+		if(!initial.isDirectory())
+			initial = juce::File::getSpecialLocation(juce::File::userDocumentsDirectory);
+
+		m_sysexFileChooser = std::make_unique<juce::FileChooser>(
+			"Send SysEx file to the emulated machine", initial,
+			"*.syx;*.SYX", true);
+		const std::weak_ptr<void> lifetime = m_lifetimeToken;
+		m_sysexFileChooser->launchAsync(
+			juce::FileBrowserComponent::openMode
+				| juce::FileBrowserComponent::canSelectFiles,
+			[lifetime, this](const juce::FileChooser& _chooser)
+			{
+				if(lifetime.expired())
+					return;
+				m_sysexChooserOpen = false;
+				const auto file = _chooser.getResult();
+				if(file.existsAsFile())
+					sendUserSysexFile(file);
+			});
+	}
+
+	void Editor::sendUserSysexFile(const juce::File& _file)
+	{
+		const auto fileSize = _file.getSize();
+		if(fileSize <= 0)
+		{
+			showUserSysexError("The selected file is empty.");
+			return;
+		}
+		if(fileSize > static_cast<juce::int64>(md::g_midiSysexTransferMaxBytes))
+		{
+			showUserSysexError("The selected file is larger than the 8 MiB safety limit.");
+			return;
+		}
+
+		juce::MemoryBlock fileData;
+		if(!_file.loadFileAsData(fileData)
+			|| fileData.getSize() != static_cast<size_t>(fileSize))
+		{
+			showUserSysexError("The selected file could not be read completely.");
+			return;
+		}
+
+		const auto* const begin = static_cast<const uint8_t*>(fileData.getData());
+		std::vector<uint8_t> bytes(begin, begin + fileData.getSize());
+		const auto validation = md::validateMidiSysexStream(bytes, m_model);
+		switch(validation)
+		{
+		case md::MidiSysexStreamValidation::Valid:
+			break;
+		case md::MidiSysexStreamValidation::WrongModel:
+			showUserSysexError("This SysEx file is for the other Elektron machine model.");
+			return;
+		case md::MidiSysexStreamValidation::FirmwareUpdate:
+			showUserSysexError("OS update SysEx files cannot be sent with this user-data command.");
+			return;
+		case md::MidiSysexStreamValidation::TooLarge:
+			showUserSysexError("The selected file is larger than the 8 MiB safety limit.");
+			return;
+		case md::MidiSysexStreamValidation::Empty:
+			showUserSysexError("The selected file is empty.");
+			return;
+		case md::MidiSysexStreamValidation::InvalidFraming:
+			showUserSysexError(
+				"The file is not a complete Machinedrum/Monomachine SysEx stream.");
+			return;
+		case md::MidiSysexStreamValidation::InvalidDataByte:
+			showUserSysexError("The SysEx stream contains an invalid non-7-bit data byte.");
+			return;
+		case md::MidiSysexStreamValidation::ChecksumMismatch:
+			showUserSysexError(
+				"An Elektron data message has an invalid checksum or declared length.");
+			return;
+		case md::MidiSysexStreamValidation::UnsupportedMessage:
+			showUserSysexError(
+				"The file contains a command rather than an importable user-data dump.");
+			return;
+		}
+
+		auto prepared = md::prepareMidiSysexTransfer(std::move(bytes));
+		if(!prepared)
+		{
+			showUserSysexError("The SysEx file could not be prepared.");
+			return;
+		}
+
+		enum class StartResult { Started, NoDevice, Restoring, NotReady, Busy };
+		const auto result = getProcessor().getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				if(!device)
+					return StartResult::NoDevice;
+				if(device->isProjectStateRestorePending())
+					return StartResult::Restoring;
+				auto& hardware = device->getHardware();
+				if(!hardware.isFirmwareMidiReady())
+					return StartResult::NotReady;
+				return hardware.startMidiSysexTransfer(*prepared)
+					? StartResult::Started : StartResult::Busy;
+			});
+
+		if(result != StartResult::Started)
+		{
+			if(result == StartResult::Restoring)
+				showUserSysexError("Wait for project-state restoration to finish, then try again.");
+			else if(result == StartResult::NotReady)
+				showUserSysexError("Wait for the emulated machine to finish booting, then try again.");
+			else if(result == StartResult::Busy)
+				showUserSysexError("A SysEx file is already being sent.");
+			else
+				showUserSysexError("The local emulated machine is not available.");
+			return;
+		}
+
+		m_sysexTransferWasActive = true;
+		m_sysexLastState = md::MidiSysexTransferState::Queued;
+		m_sysexLastSent = 0;
+		m_sysexLastAdvanceMilliseconds = juce::Time::getMillisecondCounterHiRes();
+		m_sysexStallWarningShown = false;
+		auto& config = getProcessor().getConfig();
+		config.setValue("mdMmSysexLastDirectory",
+			_file.getParentDirectory().getFullPathName());
+		config.saveIfNeeded();
+	}
+
+	void Editor::showUserSysexError(const juce::String& _message)
+	{
+		genericUI::MessageBox::showOk(genericUI::MessageBox::Icon::Warning,
+			"SysEx file not sent", _message.toStdString(), getRmlComponent());
+	}
+
+	void Editor::serviceUserSysexProgress()
+	{
+		if(!m_sysexTransferWasActive)
+			return;
+		const auto progress = getUserSysexProgress();
+		if(progress && (progress->state == md::MidiSysexTransferState::Queued
+			|| progress->state == md::MidiSysexTransferState::NegotiatingTurbo
+			|| progress->state == md::MidiSysexTransferState::Sending
+			|| progress->state == md::MidiSysexTransferState::Cancelling))
+		{
+			const auto now = juce::Time::getMillisecondCounterHiRes();
+			if(progress->state != m_sysexLastState || progress->sent != m_sysexLastSent)
+			{
+				m_sysexLastState = progress->state;
+				m_sysexLastSent = progress->sent;
+				m_sysexLastAdvanceMilliseconds = now;
+				m_sysexStallWarningShown = false;
+			}
+			else if(!m_sysexStallWarningShown
+				&& now - m_sysexLastAdvanceMilliseconds >= 5000.0)
+			{
+				m_sysexStallWarningShown = true;
+				genericUI::MessageBox::showOk(genericUI::MessageBox::Icon::Warning,
+					"SysEx transfer paused",
+					"The host has not advanced the emulated MIDI port for five seconds. "
+					"Resume audio processing and disable plug-in bypass/suspension, or "
+					"right-click the instrument to cancel the transfer.",
+					getRmlComponent());
+			}
+			return;
+		}
+
+		m_sysexTransferWasActive = false;
+		std::vector<uint8_t> retiredPayload;
+		(void)getProcessor().getPlugin().withDeviceLocked(
+			[&](synthLib::Device* const _device)
+			{
+				auto* const device = dynamic_cast<md::Device*>(_device);
+				return device && device->getHardware().retireMidiSysexTransferPayload(
+					retiredPayload);
+			});
+		// Destruction remains outside the device lock and therefore outside any
+		// interval in which it can block the real-time process callback.
+		if(progress && progress->state == md::MidiSysexTransferState::Complete)
+		{
+			juce::String message = "Every byte reached the emulated MIDI input. "
+				"Check the machine display for the firmware's import result.";
+			if(progress->fallbackCount != 0)
+				message += "\n\nTurboMIDI was unavailable, so the transfer completed at standard MIDI speed.";
+			genericUI::MessageBox::showOk(genericUI::MessageBox::Icon::Info,
+				"SysEx transfer complete", message.toStdString(), getRmlComponent());
+		}
+		else if(progress && progress->state == md::MidiSysexTransferState::Cancelled)
+		{
+			genericUI::MessageBox::showOk(genericUI::MessageBox::Icon::Info,
+				"SysEx transfer cancelled",
+				"The sender terminated the partial SysEx message before releasing the MIDI wire.",
+				getRmlComponent());
+		}
+		else
+		{
+			showUserSysexError(
+				"The emulated machine changed before the transfer completed. Please try again.");
+		}
+	}
+
 	void Editor::createMasterVolume()
 	{
 		m_masterVolume = findChild<juceRmlUi::ElemKnob>("encMaster", false);
@@ -1240,6 +1579,7 @@ namespace mdJucePlugin
 
 		const auto nowMilliseconds = juce::Time::getMillisecondCounterHiRes();
 		m_frontPanelSnapshotValid = refreshFrontPanelState(nowMilliseconds);
+		serviceUserSysexProgress();
 
 		if(m_lcdCanvas && m_lcdChanged)
 			m_lcdCanvas->repaint();

--- a/source/elektron/md/mdJucePlugin/mdEditor.h
+++ b/source/elektron/md/mdJucePlugin/mdEditor.h
@@ -12,6 +12,7 @@
 #include "mdFrontPanelPresentation.h"
 #include "mdPanelAffordances.h"
 #include "mdLib/mdfrontpanel.h"
+#include "mdLib/mdsysextransfer.h"
 
 #include "juce_gui_basics/juce_gui_basics.h"
 
@@ -68,6 +69,12 @@ namespace mdJucePlugin
 		void chooseStorageImage();
 		void restorePreviousStorage();
 		bool hasStorageRecoveryImage() const;
+		void chooseUserSysexFile();
+		void cancelUserSysexTransfer();
+		std::string getUserSysexMenuText() const;
+		bool isUserSysexTransferActive() const;
+		bool canCancelUserSysexTransfer() const;
+		std::weak_ptr<void> getLifetimeToken() const { return m_lifetimeToken; }
 
 		static constexpr int g_panelSpeedPercents[] = {50, 75, 100, 150, 200, 300};
 
@@ -119,6 +126,11 @@ namespace mdJucePlugin
 		void confirmStorageImage(const juce::File& _file,
 			StorageImageBookmark _bookmark);
 		void showStorageOperationResult(bool _success, const juce::String& _message);
+		std::optional<md::MidiSysexTransferProgress> getUserSysexProgress() const;
+		void sendUserSysexFile(const juce::File& _file);
+		void launchUserSysexFileChooser();
+		void showUserSysexError(const juce::String& _message);
+		void serviceUserSysexProgress();
 
 		enum class StorageImageFlow
 		{
@@ -192,5 +204,14 @@ namespace mdJucePlugin
 		std::array<RawLedElem, 20> m_mmPanelLeds{};
 		std::unique_ptr<juce::FileChooser> m_storageFileChooser;
 		StorageImageFlow m_storageImageFlow = StorageImageFlow::None;
+		std::unique_ptr<juce::FileChooser> m_sysexFileChooser;
+		bool m_sysexChooserOpen = false;
+		bool m_sysexTransferWasActive = false;
+		md::MidiSysexTransferState m_sysexLastState =
+			md::MidiSysexTransferState::Idle;
+		size_t m_sysexLastSent = 0;
+		double m_sysexLastAdvanceMilliseconds = 0.0;
+		bool m_sysexStallWarningShown = false;
+		std::shared_ptr<void> m_lifetimeToken = std::make_shared<int>(0);
 	};
 }

--- a/source/elektron/md/mdJucePlugin/mdPluginEditorState.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPluginEditorState.cpp
@@ -8,6 +8,7 @@
 #include "mdProductSkins.h"
 
 #include "juce_events/juce_events.h"
+#include "juceRmlUi/rmlMenu.h"
 
 namespace mdJucePlugin
 {
@@ -57,5 +58,33 @@ namespace mdJucePlugin
 	jucePluginEditorLib::Editor* PluginEditorState::createEditor(const jucePluginEditorLib::Skin& _skin)
 	{
 		return new Editor(m_processor, _skin);
+	}
+
+	void PluginEditorState::initContextMenu(juceRmlUi::Menu& _menu)
+	{
+		jucePluginEditorLib::PluginEditorState::initContextMenu(_menu);
+		auto* const editor = dynamic_cast<Editor*>(getEditor());
+		if(!editor)
+			return;
+
+		const bool active = editor->isUserSysexTransferActive();
+		const bool cancellable = editor->canCancelUserSysexTransfer();
+		_menu.addEntry(editor->getUserSysexMenuText(),
+			!active || cancellable, false, [this, editor, cancellable]
+			{
+				if(cancellable)
+				{
+					editor->cancelUserSysexTransfer();
+					return;
+				}
+				// Menu actions run before the Rml menu closes. Defer the native picker
+				// until that teardown has completed.
+				const auto lifetime = editor->getLifetimeToken();
+				juce::MessageManager::callAsync([lifetime, editor]
+				{
+					if(!lifetime.expired())
+						editor->chooseUserSysexFile();
+				});
+			});
 	}
 }

--- a/source/elektron/md/mdJucePlugin/mdPluginEditorState.h
+++ b/source/elektron/md/mdJucePlugin/mdPluginEditorState.h
@@ -13,5 +13,6 @@ namespace mdJucePlugin
 
 	private:
 		jucePluginEditorLib::Editor* createEditor(const jucePluginEditorLib::Skin& _skin) override;
+		void initContextMenu(juceRmlUi::Menu& _menu) override;
 	};
 }

--- a/source/elektron/md/mdLib/CMakeLists.txt
+++ b/source/elektron/md/mdLib/CMakeLists.txt
@@ -24,6 +24,8 @@ set(SOURCES
 	mdromdata.cpp mdromdata.h
 	mdromloader.cpp mdromloader.h
 	mdstate.cpp mdstate.h
+	mdsysextransfer.h
+	mdturbomidi.cpp mdturbomidi.h
 	mdtypes.h
 )
 

--- a/source/elektron/md/mdLib/mddevice.cpp
+++ b/source/elektron/md/mdLib/mddevice.cpp
@@ -240,7 +240,8 @@ namespace md
 			stateHardware = m_deferredPreparedState->m_hardware.get();
 		const auto patchRam = stateHardware->copyPatchRam();
 		if(m_model == MachineModel::Monomachine)
-			return encodeState(_state, patchRam, m_model, _type);
+			return encodeState(_state, patchRam, m_model, _type,
+				stateHardware->copyUserFlash());
 		std::vector<uint8_t> factoryBaseline;
 		if(stateHardware->copyFactoryFlashBaseline(factoryBaseline))
 			return encodeStateWithFactoryBaseline(_state, patchRam,
@@ -384,8 +385,12 @@ namespace md
 		bool containsFlash = false;
 		if(_context->m_model == MachineModel::Monomachine)
 		{
-			if(!decodeState(patchRam, _state, _context->m_model, _type))
+			DecodedState decoded;
+			if(!decodeState(decoded, _state, {}, _context->m_model, _type))
 				return fail("The Monomachine project payload is invalid or incompatible.");
+			patchRam = std::move(decoded.patchRam);
+			initialFlash = std::move(decoded.userFlash);
+			containsFlash = decoded.containsFlash;
 		}
 		else
 		{
@@ -451,7 +456,8 @@ namespace md
 
 		auto replacement = std::make_unique<Hardware>(
 			_context->m_romData, _context->m_romName, _context->m_model, patchRam,
-			std::shared_ptr<FrontPanelPublisher>{}, initialFlash);
+			std::shared_ptr<FrontPanelPublisher>{}, std::vector<uint8_t>{},
+			std::vector<uint8_t>{}, FlashSectorOverlay{}, initialFlash);
 		if(!replacement->isValid())
 			return fail("The replacement Monomachine rejected the restored firmware or memory image.");
 		return std::unique_ptr<PreparedState>(

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -63,12 +63,26 @@ namespace md
 		return dsp56k::sample2dsp(_inputs[_channel][_cursor]);
 	}
 
+	Hardware::Hardware(const std::vector<uint8_t>& _romData,
+		const std::string& _romName, const MachineModel _model,
+		const std::vector<uint8_t>& _initialPatchRam,
+		std::shared_ptr<FrontPanelPublisher> _frontPanelPublisher,
+		const std::vector<uint8_t>& _initialFlash,
+		const std::vector<uint8_t>& _factoryFlashCache,
+		const FlashSectorOverlay& _pendingFlashOverlay)
+		: Hardware(_romData, _romName, _model, _initialPatchRam,
+			std::move(_frontPanelPublisher), _initialFlash, _factoryFlashCache,
+			_pendingFlashOverlay, {})
+	{
+	}
+
 	Hardware::Hardware(const std::vector<uint8_t>& _romData, const std::string& _romName,
 		const MachineModel _model, const std::vector<uint8_t>& _initialPatchRam,
 		std::shared_ptr<FrontPanelPublisher> _frontPanelPublisher,
 		const std::vector<uint8_t>& _initialFlash,
 		const std::vector<uint8_t>& _factoryFlashCache,
-		const FlashSectorOverlay& _pendingFlashOverlay)
+		const FlashSectorOverlay& _pendingFlashOverlay,
+		const std::vector<uint8_t>& _initialUserFlash)
 		: m_model(_model)
 		, m_rom(initRom(_romData, _romName, _model))
 		, m_firmwareFingerprint(fingerprintRom(m_rom.data()))
@@ -76,7 +90,7 @@ namespace md
 			&& _initialFlash.empty() && _factoryFlashCache.empty())
 		, m_uc(m_rom, m_model,
 			_pendingFlashOverlay.valid ? std::vector<uint8_t>{} : _initialPatchRam,
-			_initialFlash)
+			_initialFlash, _initialUserFlash)
 		// A complete project image can boot directly without a local factory cache,
 		// but it must never become the machine-local factory baseline itself.
 		, m_externalInteraction(_model == MachineModel::Machinedrum
@@ -96,6 +110,7 @@ namespace md
 		, m_frontPanelPublisher(_frontPanelPublisher
 			? std::move(_frontPanelPublisher)
 			: std::make_shared<FrontPanelPublisher>())
+		, m_midiSysexTransfer(g_ucClockHz)
 		, m_dspMixer(*this, m_uc.getHdi08Dsp1(), 0)		// DSP1, mixer/main
 		, m_dspProducer(*this, m_uc.getHdi08Dsp2(), 1)	// DSP2, producer
 	{
@@ -106,6 +121,10 @@ namespace md
 
 		if(!m_rom.isValid())
 			return;
+		m_uc.setMidiTransmitTap([this](const uint8_t _byte)
+		{
+			m_midiSysexTransfer.observeTransmitByte(_byte);
+		});
 		if(isMonomachine())
 		{
 			auto& mixerMemory = m_dspMixer.dsp().memory();
@@ -500,7 +519,10 @@ namespace md
 		(void)m_frontPanelPublisher->tryPublish(m_frontPanel);
 	}
 
-	Hardware::~Hardware() = default;
+	Hardware::~Hardware()
+	{
+		m_uc.setMidiTransmitTap({});
+	}
 
 	bool Hardware::isValid() const
 	{
@@ -843,7 +865,8 @@ namespace md
 
 		// Avoid entering MIDI arbitration when every source is idle; a producer
 		// racing this observation is visible at the next instruction boundary.
-		if(!projectRestorePending && (m_midiInByteCursor != 0
+		if(!projectRestorePending && (m_midiSysexTransfer.ownsMidiWire()
+			|| m_midiInByteCursor != 0
 			|| !m_midiIn.empty()
 			|| m_realtimeMidiIn.size() != 0))
 			pumpMidiIngress();
@@ -856,6 +879,12 @@ namespace md
 			pumpDsp2HostRequest();
 
 		const auto deltaCycles = m_uc.exec();
+		if(!projectRestorePending)
+			m_midiSysexTransfer.service(deltaCycles,
+				m_midiInByteCursor == 0
+					&& m_realtimeMidiIn.sizeBefore(
+						m_midiSysexTransfer.realtimeWriteBoundary()) == 0,
+				m_uc);
 
 		m_schedUcCyclesDone += deltaCycles;
 	}
@@ -1260,11 +1289,15 @@ namespace md
 
 	void Hardware::pumpMidiIngress()
 	{
-		const auto pumpRealtime = [this]()
+		const auto pumpRealtime = [this](const bool _hasBoundary,
+			const size_t _writeBoundary)
 		{
 			uint8_t byte = 0;
 			while(m_realtimeMidiIn.tryPeek(byte))
 			{
+				if(_hasBoundary
+					&& m_realtimeMidiIn.sizeBefore(_writeBoundary) == 0)
+					return true;
 				if(!m_uc.tryQueueMidiRx(byte))
 					return false;
 				uint8_t committed = 0;
@@ -1277,6 +1310,8 @@ namespace md
 		const auto pumpGeneralFront = [this]()
 		{
 			if(m_midiIn.empty())
+				return false;
+			if(m_midiInByteCursor == 0 && m_midiSysexTransfer.ownsMidiWire())
 				return false;
 			const auto& event = m_midiIn.front();
 			const auto type = static_cast<uint8_t>(event.a & 0xf0);
@@ -1297,18 +1332,40 @@ namespace md
 			return true;
 		};
 
+		// A file transfer owns the wire, but never splits an event already admitted.
+		// Realtime bytes queued before start also cross before its payload.
+		if(m_midiSysexTransfer.ownsMidiWire())
+		{
+			if(m_midiInByteCursor != 0 && !pumpGeneralFront())
+				return;
+			(void)pumpRealtime(true,
+				m_midiSysexTransfer.realtimeWriteBoundary());
+			return;
+		}
+
 		// Once a normal MIDI event has begun, finish it before switching back to the
 		// semantic byte queue. At event boundaries semantic commands retain their old
 		// priority over general host input.
-		if(m_midiInByteCursor == 0 && !pumpRealtime())
+		if(m_midiInByteCursor == 0 && !pumpRealtime(false, 0))
 			return;
 		while(!m_midiIn.empty())
 		{
 			if(!pumpGeneralFront())
 				return;
-			if(!pumpRealtime())
+			if(!pumpRealtime(false, 0))
 				return;
 		}
+	}
+
+	bool Hardware::startMidiSysexTransfer(PreparedMidiSysexTransfer& _transfer)
+	{
+		if(isProjectStateRestorePending())
+			return false;
+		if(!m_midiSysexTransfer.start(
+			_transfer, m_realtimeMidiIn.writePosition()))
+			return false;
+		registerExternalInteraction();
+		return true;
 	}
 
 }

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -16,6 +16,8 @@
 #include "mdrealtimemidiqueue.h"
 #include "mdrom.h"
 #include "mdstate.h"
+#include "mdsysextransfer.h"
+#include "mdturbomidi.h"
 #include "mdtypes.h"
 
 #include "synthLib/audioTypes.h"
@@ -55,6 +57,13 @@ namespace md
 			const std::vector<uint8_t>& _initialFlash = {},
 			const std::vector<uint8_t>& _factoryFlashCache = {},
 			const FlashSectorOverlay& _pendingFlashOverlay = {});
+		Hardware(const std::vector<uint8_t>& _romData, const std::string& _romName,
+			MachineModel _model, const std::vector<uint8_t>& _initialPatchRam,
+			std::shared_ptr<FrontPanelPublisher> _frontPanelPublisher,
+			const std::vector<uint8_t>& _initialFlash,
+			const std::vector<uint8_t>& _factoryFlashCache,
+			const FlashSectorOverlay& _pendingFlashOverlay,
+			const std::vector<uint8_t>& _initialUserFlash);
 		~Hardware();
 
 		bool isValid() const;
@@ -96,6 +105,7 @@ namespace md
 		Microcontroller& getUC() { return m_uc; }
 		std::vector<uint8_t> copyPatchRam() const;
 		std::vector<uint8_t> copyFlashData() const { return m_uc.copyFlashData(); }
+		std::vector<uint8_t> copyUserFlash() const { return m_uc.copyUserFlash(); }
 		const std::vector<uint8_t>& flashBaseline() const { return m_rom.data(); }
 		bool flashDirty() const { return m_uc.flashDirty(); }
 		bool factoryFlashCacheReady();
@@ -184,6 +194,30 @@ namespace md
 		{
 			m_uc.readMidiOut(_midiOut);
 		}
+		// Queue a validated file-sized stream for paced delivery through the
+		// emulated MIDI UART. The caller must hold the owning Plugin device lock.
+		bool startMidiSysexTransfer(PreparedMidiSysexTransfer& _transfer);
+		bool cancelMidiSysexTransfer(std::vector<uint8_t>& _retiredPayload)
+		{
+			return m_midiSysexTransfer.cancel(_retiredPayload);
+		}
+		bool retireMidiSysexTransferPayload(std::vector<uint8_t>& _retiredPayload)
+		{
+			return m_midiSysexTransfer.retirePayload(_retiredPayload);
+		}
+		MidiSysexTransferProgress getMidiSysexTransferProgress() const
+		{
+			return m_midiSysexTransfer.progress();
+		}
+		// Diagnostic/control-plane observation. The caller must serialize with the
+		// machine thread (the Plugin device lock does this in product code).
+		bool isMidiIngressIdle() const
+		{
+			return !m_midiSysexTransfer.ownsMidiWire()
+				&& m_midiInByteCursor == 0 && m_midiIn.empty()
+				&& m_realtimeMidiIn.size() == 0
+				&& m_uc.queuedMidiRxBytes() == 0;
+		}
 		// Queue a front-panel button/encoder event ([row][mask]). trySendPanelEvent is bounded,
 		// thread-safe, allocation-free, and never waits; false reports that the FIFO
 		// rejected the packet. Row state is retained for recovery, while pulse commands
@@ -250,6 +284,7 @@ namespace md
 		size_t m_pendingFlashSectorIndex = 0;
 		FrontPanel m_frontPanel;	// writer-owned UART2 LCD/LED decoder
 		std::shared_ptr<FrontPanelPublisher> m_frontPanelPublisher;
+		TurboMidiTransfer m_midiSysexTransfer;
 		Dsp m_dspMixer;		// index 0 = DSP1 (0x500000), receives the ring, drives the DAC
 		Dsp m_dspProducer;	// index 1 = DSP2 (0x600000), produces voices into the ring
 

--- a/source/elektron/md/mdLib/mdmc.cpp
+++ b/source/elektron/md/mdLib/mdmc.cpp
@@ -22,6 +22,30 @@ namespace md
 {
 	namespace
 	{
+		// The SFX-60 MKII stores user DigiPRO waves in the uniform-sector portion
+		// of its AMD-compatible flash. Its sectors differ from the MD bottom-boot
+		// part handled by FlashCommandDecoder.
+		class MonomachineFlash final : public hwLib::Am29f
+		{
+		public:
+			MonomachineFlash(uint8_t* const _data, const size_t _size)
+				: Am29f(_data, _size, false, true), m_size(_size)
+			{
+			}
+
+			bool eraseSector(const uint32_t _address) const override
+			{
+				constexpr size_t sectorSize = 64 * 1024;
+				if((_address % sectorSize) != 0 || _address > m_size
+					|| sectorSize > m_size - _address)
+					return false;
+				return Am29f::eraseSector(_address, sectorSize / 1024);
+			}
+
+		private:
+			const size_t m_size;
+		};
+
 		constexpr auto makeMmPanelStartupProbe()
 		{
 			std::array<uint8_t, 30> probe{};
@@ -47,6 +71,14 @@ namespace md
 	Microcontroller::Microcontroller(const Rom& _rom, const MachineModel _model,
 		const std::vector<uint8_t>& _initialPatchRam,
 		const std::vector<uint8_t>& _initialFlash)
+		: Microcontroller(_rom, _model, _initialPatchRam, _initialFlash, {})
+	{
+	}
+
+	Microcontroller::Microcontroller(const Rom& _rom, const MachineModel _model,
+		const std::vector<uint8_t>& _initialPatchRam,
+		const std::vector<uint8_t>& _initialFlash,
+		const std::vector<uint8_t>& _initialUserFlash)
 		: Mc68k(M68K_CPU_TYPE_MCF5206E)
 		, m_model(_model)
 		, m_rom(_rom)
@@ -59,6 +91,19 @@ namespace md
 		if(m_model == MachineModel::Machinedrum
 			&& _initialFlash.size() == m_flashData.size())
 			m_flashData = _initialFlash;
+		if(m_model == MachineModel::Monomachine
+			&& _initialUserFlash.size() == memorymap::g_mmUserFlash.size()
+			&& m_flashData.size() >= memorymap::g_flashFull.offset(
+				memorymap::g_mmUserFlash.end))
+		{
+			const auto offset = memorymap::g_flashFull.offset(
+				memorymap::g_mmUserFlash.begin);
+			std::copy(_initialUserFlash.begin(), _initialUserFlash.end(),
+				m_flashData.begin() + offset);
+		}
+		if(m_model == MachineModel::Monomachine && !m_flashData.empty())
+			m_monomachineFlash = std::make_unique<MonomachineFlash>(
+				m_flashData.data(), m_flashData.size());
 
 		// Report the MKII board profile used by both supported targets.
 		m_sim.setMk2PortAInvertedLoopback(true);
@@ -79,6 +124,8 @@ namespace md
 					m_midiTxOverflow.fetch_add(1, std::memory_order_relaxed);
 				}
 			}
+			if(m_midiTransmitTap)
+				m_midiTransmitTap(_b);
 		});
 
 
@@ -105,6 +152,18 @@ namespace md
 	{
 		std::shared_lock lock(m_flashMutex);
 		return m_flashData;
+	}
+
+	std::vector<uint8_t> Microcontroller::copyUserFlash() const
+	{
+		if(m_model != MachineModel::Monomachine
+			|| m_flashData.size() < memorymap::g_flashFull.offset(
+				memorymap::g_mmUserFlash.end))
+			return {};
+		std::shared_lock lock(m_flashMutex);
+		const auto begin = m_flashData.begin() + memorymap::g_flashFull.offset(
+			memorymap::g_mmUserFlash.begin);
+		return {begin, begin + memorymap::g_mmUserFlash.size()};
 	}
 
 	bool Microcontroller::copyFlashDataRangeRealtime(uint8_t* const _destination,
@@ -690,6 +749,20 @@ namespace md
 		if(memorymap::g_sim.contains(_addr))		{ m_sim.write16(memorymap::g_sim.offset(_addr), _val); return; }
 		if(memorymap::g_dsp1Hdi08.contains(_addr))	{ m_hdi08Dsp1.write16(static_cast<mc68k::PeriphAddress>(memorymap::g_dsp1Hdi08.offset(_addr)), _val); return; }
 		if(memorymap::g_dsp2Hdi08.contains(_addr))	{ m_hdi08Dsp2.write16(static_cast<mc68k::PeriphAddress>(memorymap::g_dsp2Hdi08.offset(_addr)), _val); return; }
+		if(m_monomachineFlash && (memorymap::g_flashFull.contains(_addr)
+			|| memorymap::g_flashLow.contains(_addr)))
+		{
+			const auto offset = memorymap::g_flashFull.contains(_addr)
+				? memorymap::g_flashFull.offset(_addr)
+				: memorymap::g_flashLow.offset(_addr);
+			std::unique_lock flashLock(m_flashMutex);
+			m_monomachineFlash->write(offset, _val);
+			m_flashDirty = true;
+			m_lastFlashWriteCycle = getCycles();
+			m_immPageAddress = 0xffffffffu;
+			m_immPageData = nullptr;
+			return;
+		}
 		const bool patchRam = memorymap::isPatchRam(_addr);
 		std::unique_lock patchLock(m_patchRamMutex, std::defer_lock);
 		if(patchRam)

--- a/source/elektron/md/mdLib/mdmc.h
+++ b/source/elektron/md/mdLib/mdmc.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
@@ -13,9 +14,11 @@
 
 #include "mc68k/mc68k.h"
 #include "mc68k/hdi08.h"
+#include "hardwareLib/am29f.h"
 
 #include "mdflash.h"
 #include "mdsim.h"
+#include "mdturbomidi.h"
 #include "mdtypes.h"
 
 #include "synthLib/midiBufferParser.h"
@@ -44,12 +47,16 @@ namespace md
 	//   0x00600000-0x00600007  DSP 2 HI08                       (md::Dsp)
 	//   0x01000000-0x01001fff  ColdFire internal SRAM (8 KB)
 	//   0x10000000-0x107fffff  ROM  (full 8 MB flash)
-	class Microcontroller final : public mc68k::Mc68k
+	class Microcontroller final : public mc68k::Mc68k, public MidiByteSink
 	{
 	public:
 		Microcontroller(const Rom& _rom, MachineModel _model = MachineModel::Machinedrum,
 			const std::vector<uint8_t>& _initialPatchRam = {},
 			const std::vector<uint8_t>& _initialFlash = {});
+		Microcontroller(const Rom& _rom, MachineModel _model,
+			const std::vector<uint8_t>& _initialPatchRam,
+			const std::vector<uint8_t>& _initialFlash,
+			const std::vector<uint8_t>& _initialUserFlash);
 
 		// mc68k::Mc68k overrides
 		uint32_t exec() override;
@@ -101,10 +108,18 @@ namespace md
 		{
 			return m_sim.tryQueueRx(Sim::g_uartMidi, _byte);
 		}
+		bool tryWriteMidiByte(uint8_t _byte) override
+		{
+			return tryQueueMidiRx(_byte);
+		}
 		void queueMidiRx(uint8_t _byte) { (void)tryQueueMidiRx(_byte); }
 		size_t queuedMidiRxBytes() const
 		{
 			return m_sim.queuedRxBytes(Sim::g_uartMidi);
+		}
+		size_t queuedMidiByteCount() const override
+		{
+			return queuedMidiRxBytes();
 		}
 		size_t availableMidiRxBytes() const
 		{
@@ -144,9 +159,16 @@ namespace md
 		{
 			return m_midiTxOverflow.load(std::memory_order_relaxed);
 		}
+		// Observe raw UART1 TX bytes without consuming normal plug-in MIDI output.
+		// The callback runs synchronously on the emulation scheduler thread.
+		void setMidiTransmitTap(std::function<void(uint8_t)> _tap)
+		{
+			m_midiTransmitTap = std::move(_tap);
+		}
 		std::vector<uint8_t> copyPatchRam() const;
 		bool replacePatchRam(const std::vector<uint8_t>& _data);
 		std::vector<uint8_t> copyFlashData() const;
+		std::vector<uint8_t> copyUserFlash() const;
 		// Scheduler-thread-only bounded state transfer. The containing Hardware is
 		// serialized by synthLib::Plugin, so these avoid taking a callback-time lock.
 		bool copyFlashDataRangeRealtime(uint8_t* _destination, size_t _offset,
@@ -201,6 +223,7 @@ namespace md
 		// Each emulated machine owns a private flash image. Firmware may program this
 		// copy without changing the user's ROM file or another plug-in instance.
 		std::vector<uint8_t> m_flashData;
+		std::unique_ptr<hwLib::Am29f> m_monomachineFlash;
 		mutable std::shared_mutex m_flashMutex;
 		bool m_flashDirty = false;
 		uint64_t m_lastFlashWriteCycle = 0;
@@ -222,6 +245,7 @@ namespace md
 		size_t m_midiTxDrainIndex = 1;
 		bool m_midiTxDiscontinuity = false;
 		std::atomic<uint64_t> m_midiTxOverflow{0};
+		std::function<void(uint8_t)> m_midiTransmitTap;
 		synthLib::MidiBufferParser m_midiTxParser{synthLib::MidiEventSource::Device};
 
 		// ColdFire-facing HI08 register files for the two DSP host-port windows. The

--- a/source/elektron/md/mdLib/mdmemorymap.h
+++ b/source/elektron/md/mdLib/mdmemorymap.h
@@ -28,6 +28,8 @@ namespace md::memorymap
 	inline constexpr Range g_patchOsAlias    {0x00700000, 0x00800000};
 	inline constexpr Range g_internalSram    {0x01000000, 0x01010000};
 	inline constexpr Range g_flashFull       {0x10000000, 0x10800000};
+	// SFX-60 MKII user DigiPRO records occupy this 2 MiB flash window.
+	inline constexpr Range g_mmUserFlash     {0x10200000, 0x10400000};
 	inline constexpr Range g_mainHighAlias   {0x20000000, 0x20100000};
 	inline constexpr Range g_mainExecAlias   {0x40000000, 0x40100000};
 

--- a/source/elektron/md/mdLib/mdstate.cpp
+++ b/source/elektron/md/mdLib/mdstate.cpp
@@ -12,6 +12,8 @@ namespace md
 		constexpr std::array<uint8_t, 4> g_magic = {'M', 'D', 'S', 'T'};
 		constexpr uint16_t g_version1 = 1;
 		constexpr uint16_t g_version1HeaderSize = 20;
+		constexpr uint16_t g_version2 = 2;
+		constexpr uint16_t g_version2HeaderSize = 28;
 		constexpr uint16_t g_version3 = 3;
 		constexpr uint16_t g_version4 = 4;
 		constexpr uint16_t g_version3HeaderSize = 52;
@@ -147,6 +149,40 @@ namespace md
 			return true;
 		}
 
+		bool decodeVersion2(DecodedState& _decoded,
+			const std::vector<uint8_t>& _state,
+			const MachineModel _expectedModel,
+			const synthLib::StateType _expectedType)
+		{
+			if(_expectedModel != MachineModel::Monomachine
+				|| _state.size() < g_version2HeaderSize || !hasMagic(_state)
+				|| readU16(_state, 4) != g_version2
+				|| readU16(_state, 6) != g_version2HeaderSize
+				|| _state[8] != modelTag(_expectedModel)
+				|| _state[9] != static_cast<uint8_t>(_expectedType)
+				|| readU16(_state, 10) != 0)
+				return false;
+			const auto patchSize = readU32(_state, 12);
+			const auto userFlashSize = readU32(_state, 20);
+			if(patchSize != g_patchRamStateSize
+				|| userFlashSize != g_mmUserFlashStateSize
+				|| _state.size() != static_cast<size_t>(g_version2HeaderSize)
+					+ patchSize + userFlashSize)
+				return false;
+			const auto* const patch = _state.data() + g_version2HeaderSize;
+			const auto* const userFlash = patch + patchSize;
+			if(readU32(_state, 16) != crc32(patch, patchSize)
+				|| readU32(_state, 24) != crc32(userFlash, userFlashSize))
+				return false;
+
+			DecodedState decoded;
+			decoded.patchRam.assign(patch, patch + patchSize);
+			decoded.userFlash.assign(userFlash, userFlash + userFlashSize);
+			decoded.containsFlash = true;
+			_decoded = std::move(decoded);
+			return true;
+		}
+
 		bool makeFlashOverlay(FlashSectorOverlay& _overlay,
 			const std::vector<uint8_t>& _flashData,
 			const std::vector<uint8_t>& _baseline,
@@ -240,20 +276,41 @@ namespace md
 	bool encodeState(std::vector<uint8_t>& _state, const std::vector<uint8_t>& _patchRam,
 		const MachineModel _model, const synthLib::StateType _type)
 	{
+		return encodeState(_state, _patchRam, _model, _type, {});
+	}
+
+	bool encodeState(std::vector<uint8_t>& _state,
+		const std::vector<uint8_t>& _patchRam, const MachineModel _model,
+		const synthLib::StateType _type,
+		const std::vector<uint8_t>& _userFlash)
+	{
 		if(_patchRam.size() != g_patchRamStateSize || !validStateType(_type))
+			return false;
+		const bool containsUserFlash = !_userFlash.empty();
+		if(containsUserFlash && (_model != MachineModel::Monomachine
+			|| _userFlash.size() != g_mmUserFlashStateSize))
 			return false;
 
 		const auto originalSize = _state.size();
-		_state.reserve(originalSize + g_version1HeaderSize + _patchRam.size());
+		const auto headerSize = containsUserFlash
+			? g_version2HeaderSize : g_version1HeaderSize;
+		_state.reserve(originalSize + headerSize + _patchRam.size()
+			+ _userFlash.size());
 		_state.insert(_state.end(), g_magic.begin(), g_magic.end());
-		appendU16(_state, g_version1);
-		appendU16(_state, g_version1HeaderSize);
+		appendU16(_state, containsUserFlash ? g_version2 : g_version1);
+		appendU16(_state, headerSize);
 		_state.push_back(modelTag(_model));
 		_state.push_back(static_cast<uint8_t>(_type));
 		appendU16(_state, 0);
 		appendU32(_state, static_cast<uint32_t>(_patchRam.size()));
 		appendU32(_state, crc32(_patchRam.data(), _patchRam.size()));
+		if(containsUserFlash)
+		{
+			appendU32(_state, static_cast<uint32_t>(_userFlash.size()));
+			appendU32(_state, crc32(_userFlash.data(), _userFlash.size()));
+		}
 		_state.insert(_state.end(), _patchRam.begin(), _patchRam.end());
+		_state.insert(_state.end(), _userFlash.begin(), _userFlash.end());
 		return true;
 	}
 
@@ -353,6 +410,8 @@ namespace md
 			_decoded = std::move(decoded);
 			return true;
 		}
+		if(readU16(_state, 4) == g_version2)
+			return decodeVersion2(_decoded, _state, _expectedModel, _expectedType);
 		const auto version = readU16(_state, 4);
 		if((version != g_version3 && version != g_version4)
 			|| _state.size() < g_version3HeaderSize

--- a/source/elektron/md/mdLib/mdstate.h
+++ b/source/elektron/md/mdLib/mdstate.h
@@ -11,6 +11,7 @@ namespace md
 {
 	constexpr uint32_t g_patchRamStateSize = 0x100000;
 	constexpr uint32_t g_uwFlashSectorSize = 0x10000;
+	constexpr uint32_t g_mmUserFlashStateSize = 0x200000;
 
 	struct FlashSectorOverlay
 	{
@@ -25,6 +26,7 @@ namespace md
 	struct DecodedState
 	{
 		std::vector<uint8_t> patchRam;
+		std::vector<uint8_t> userFlash;
 		FlashSectorOverlay flashOverlay;
 		bool containsFlash = false;
 	};
@@ -34,6 +36,11 @@ namespace md
 	// not clear it.
 	bool encodeState(std::vector<uint8_t>& _state, const std::vector<uint8_t>& _patchRam,
 		MachineModel _model, synthLib::StateType _type);
+	// Version 2 extends Monomachine state with its private 2 MiB DigiPRO flash
+	// window. Version-1 patch-only states remain readable.
+	bool encodeState(std::vector<uint8_t>& _state,
+		const std::vector<uint8_t>& _patchRam, MachineModel _model,
+		synthLib::StateType _type, const std::vector<uint8_t>& _userFlash);
 
 	// Machinedrum UW state extends the patch-RAM snapshot with sectors that differ
 	// from the initialized factory-flash baseline. The matching ROM and factory
@@ -66,8 +73,9 @@ namespace md
 	bool decodeState(std::vector<uint8_t>& _patchRam, const std::vector<uint8_t>& _state,
 		MachineModel _expectedModel, synthLib::StateType _expectedType);
 
-	// Decode either the legacy version-1 patch-RAM format or version 3. Version 3
-	// retains a validated sparse overlay until its factory baseline is available.
+	// Decode legacy version-1 patch RAM, version-2 MM patch RAM plus user flash,
+	// or the version-3/4 MD sparse-flash formats. An MD overlay remains deferred
+	// until its factory baseline is available.
 	// No output is changed on failure.
 	bool decodeState(DecodedState& _decoded, const std::vector<uint8_t>& _state,
 		const std::vector<uint8_t>& _romBaseline,

--- a/source/elektron/md/mdLib/mdsysextransfer.h
+++ b/source/elektron/md/mdLib/mdsysextransfer.h
@@ -1,0 +1,240 @@
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "mdtypes.h"
+
+namespace md
+{
+	class TurboMidiTransfer;
+
+	inline const char* midiTurboSpeedLabel(const uint8_t _code)
+	{
+		switch(_code)
+		{
+		case 2: return "2";
+		case 3: return "3.33";
+		case 4: return "4";
+		case 5: return "5";
+		case 6: return "6.66";
+		case 7: return "8";
+		case 8: return "10";
+		default: return "1";
+		}
+	}
+
+	inline constexpr size_t g_midiSysexTransferMaxBytes = 8u * 1024u * 1024u;
+
+	enum class MidiSysexStreamValidation : uint8_t
+	{
+		Valid,
+		Empty,
+		TooLarge,
+		InvalidFraming,
+		InvalidDataByte,
+		ChecksumMismatch,
+		UnsupportedMessage,
+		WrongModel,
+		FirmwareUpdate
+	};
+
+	// Accept only complete, concatenated Elektron user-data messages for this
+	// machine. OS update messages are deliberately rejected by this user-data path.
+	inline MidiSysexStreamValidation validateMidiSysexStream(
+		const std::vector<uint8_t>& _bytes, const MachineModel _model)
+	{
+		if(_bytes.empty())
+			return MidiSysexStreamValidation::Empty;
+		if(_bytes.size() > g_midiSysexTransferMaxBytes)
+			return MidiSysexStreamValidation::TooLarge;
+
+		const uint8_t expectedProduct = _model == MachineModel::Monomachine
+			? uint8_t{0x03} : uint8_t{0x02};
+		size_t offset = 0;
+		while(offset < _bytes.size())
+		{
+			if(offset + 8 > _bytes.size() || _bytes[offset] != 0xf0
+				|| _bytes[offset + 1] != 0x00 || _bytes[offset + 2] != 0x20
+				|| _bytes[offset + 3] != 0x3c)
+				return MidiSysexStreamValidation::InvalidFraming;
+			if(_bytes[offset + 4] != expectedProduct)
+				return MidiSysexStreamValidation::WrongModel;
+
+			const auto end = std::find(
+				_bytes.begin() + static_cast<std::ptrdiff_t>(offset + 7),
+				_bytes.end(), uint8_t{0xf7});
+			if(end == _bytes.end())
+				return MidiSysexStreamValidation::InvalidFraming;
+			if(std::any_of(_bytes.begin() + static_cast<std::ptrdiff_t>(offset + 1),
+				end, [](const uint8_t _byte) { return _byte > 0x7f; }))
+				return MidiSysexStreamValidation::InvalidDataByte;
+
+			const uint8_t command = _bytes[offset + 6];
+			if(command == 0x7e || command == 0x7f)
+				return MidiSysexStreamValidation::FirmwareUpdate;
+			const bool commonDataDump = command == 0x50 || command == 0x52
+				|| command == 0x67 || command == 0x69;
+			const bool digiProDump = _model == MachineModel::Monomachine
+				&& command == 0x5d;
+			if(!commonDataDump && !digiProDump)
+				return MidiSysexStreamValidation::UnsupportedMessage;
+
+			const size_t messageSize = static_cast<size_t>(end
+				- (_bytes.begin() + static_cast<std::ptrdiff_t>(offset))) + 1;
+			// Elektron data dumps carry [checksum MSB, checksum LSB, length MSB,
+			// length LSB] immediately before EOX. Short request/status messages do
+			// not. Every command admitted above is a data dump, so a short message
+			// is incomplete rather than a valid control request.
+			if(messageSize < 13)
+				return MidiSysexStreamValidation::ChecksumMismatch;
+			const size_t checksumPosition = offset + messageSize - 5;
+			uint32_t sum = 0;
+			// DigiPRO excludes its destination slot at byte 9. Other Elektron
+			// data dumps include byte 9 in the common checksum range.
+			const size_t checksumBegin = digiProDump ? offset + 10 : offset + 9;
+			for(size_t i = checksumBegin; i < checksumPosition; ++i)
+				sum += _bytes[i];
+			const uint16_t checksum = static_cast<uint16_t>(
+				(_bytes[checksumPosition] << 7)
+				| _bytes[checksumPosition + 1]);
+			const uint16_t length = static_cast<uint16_t>(
+				(_bytes[checksumPosition + 2] << 7)
+				| _bytes[checksumPosition + 3]);
+			if((sum & 0x3fff) != checksum
+				|| messageSize - 10 > 0x3fff
+				|| length != messageSize - 10)
+				return MidiSysexStreamValidation::ChecksumMismatch;
+			offset = static_cast<size_t>(end - _bytes.begin()) + 1;
+		}
+		return MidiSysexStreamValidation::Valid;
+	}
+
+	class PreparedMidiSysexTransfer
+	{
+	public:
+		PreparedMidiSysexTransfer(PreparedMidiSysexTransfer&&) noexcept = default;
+		PreparedMidiSysexTransfer& operator=(PreparedMidiSysexTransfer&&) noexcept = default;
+		PreparedMidiSysexTransfer(const PreparedMidiSysexTransfer&) = delete;
+		PreparedMidiSysexTransfer& operator=(const PreparedMidiSysexTransfer&) = delete;
+
+		bool empty() const { return m_bytes.empty(); }
+		size_t size() const { return m_bytes.size(); }
+
+	private:
+		explicit PreparedMidiSysexTransfer(std::vector<uint8_t>&& _bytes)
+			: m_bytes(std::move(_bytes))
+		{
+		}
+
+		friend class TurboMidiTransfer;
+		friend std::optional<PreparedMidiSysexTransfer>
+			prepareMidiSysexTransfer(std::vector<uint8_t> _bytes);
+		std::vector<uint8_t> m_bytes;
+	};
+
+	inline std::optional<PreparedMidiSysexTransfer> prepareMidiSysexTransfer(
+		std::vector<uint8_t> _bytes)
+	{
+		if(_bytes.empty() || _bytes.front() != 0xf0 || _bytes.back() != 0xf7)
+			return std::nullopt;
+		return PreparedMidiSysexTransfer(std::move(_bytes));
+	}
+
+	enum class MidiSysexTransferState : uint8_t
+	{
+		Idle,
+		Queued,
+		NegotiatingTurbo,
+		Sending,
+		Complete,
+		Cancelling,
+		Cancelled
+	};
+
+	enum class MidiTurboFallbackReason : uint8_t
+	{
+		None,
+		MalformedSpeedAnswer,
+		NoCommonCertifiedSpeed,
+		CapabilityRequestTimedOut,
+		SpeedAcknowledgementTimedOut,
+		FirstLinkTestBadData,
+		FirstLinkTestTimedOut,
+		SecondLinkTestTimedOut
+	};
+
+	struct MidiSysexTransferProgress
+	{
+		MidiSysexTransferState state = MidiSysexTransferState::Idle;
+		size_t sent = 0;
+		size_t total = 0;
+		uint8_t speedCode = 1;
+		bool turbo = false;
+		MidiTurboFallbackReason fallbackReason = MidiTurboFallbackReason::None;
+		uint32_t fallbackCount = 0;
+	};
+
+	// Coherent lock-free observations for UI and diagnostic readers. Transport
+	// mutation is single-owner, while this publisher makes accidental unlocked
+	// progress reads safe without putting a mutex on the audio path.
+	class MidiSysexTransferProgressPublisher
+	{
+	public:
+		static_assert(std::atomic<uint32_t>::is_always_lock_free);
+		static_assert(std::atomic<size_t>::is_always_lock_free);
+		static_assert(std::atomic<uint8_t>::is_always_lock_free);
+		static_assert(std::atomic<bool>::is_always_lock_free);
+		static_assert(std::atomic<MidiSysexTransferState>::is_always_lock_free);
+		static_assert(std::atomic<MidiTurboFallbackReason>::is_always_lock_free);
+
+		void publish(const MidiSysexTransferProgress& _progress)
+		{
+			m_sequence.fetch_add(1, std::memory_order_acq_rel);
+			m_state.store(_progress.state, std::memory_order_relaxed);
+			m_sent.store(_progress.sent, std::memory_order_relaxed);
+			m_total.store(_progress.total, std::memory_order_relaxed);
+			m_speedCode.store(_progress.speedCode, std::memory_order_relaxed);
+			m_turbo.store(_progress.turbo, std::memory_order_relaxed);
+			m_fallbackReason.store(_progress.fallbackReason, std::memory_order_relaxed);
+			m_fallbackCount.store(_progress.fallbackCount, std::memory_order_relaxed);
+			m_sequence.fetch_add(1, std::memory_order_release);
+		}
+
+		MidiSysexTransferProgress read() const
+		{
+			for(;;)
+			{
+				const auto before = m_sequence.load(std::memory_order_acquire);
+				if((before & 1u) != 0)
+					continue;
+				const MidiSysexTransferProgress result{
+					m_state.load(std::memory_order_relaxed),
+					m_sent.load(std::memory_order_relaxed),
+					m_total.load(std::memory_order_relaxed),
+					m_speedCode.load(std::memory_order_relaxed),
+					m_turbo.load(std::memory_order_relaxed),
+					m_fallbackReason.load(std::memory_order_relaxed),
+					m_fallbackCount.load(std::memory_order_relaxed)};
+				if(before == m_sequence.load(std::memory_order_acquire))
+					return result;
+			}
+		}
+
+	private:
+		std::atomic<uint32_t> m_sequence{0};
+		std::atomic<MidiSysexTransferState> m_state{MidiSysexTransferState::Idle};
+		std::atomic<size_t> m_sent{0};
+		std::atomic<size_t> m_total{0};
+		std::atomic<uint8_t> m_speedCode{1};
+		std::atomic<bool> m_turbo{false};
+		std::atomic<MidiTurboFallbackReason> m_fallbackReason{
+			MidiTurboFallbackReason::None};
+		std::atomic<uint32_t> m_fallbackCount{0};
+	};
+}

--- a/source/elektron/md/mdLib/mdturbomidi.cpp
+++ b/source/elektron/md/mdLib/mdturbomidi.cpp
@@ -1,0 +1,453 @@
+#include "mdturbomidi.h"
+
+#include <algorithm>
+#include <iterator>
+#include <utility>
+
+#include "synthLib/midiTypes.h"
+
+namespace md
+{
+	TurboMidiTransfer::TurboMidiTransfer(const uint64_t _clockHz)
+		: m_clockHz(_clockHz)
+	{
+	}
+
+	bool TurboMidiTransfer::ownsMidiWire() const
+	{
+		const auto state = m_state.load(std::memory_order_acquire);
+		return state == MidiSysexTransferState::Queued
+			|| state == MidiSysexTransferState::NegotiatingTurbo
+			|| state == MidiSysexTransferState::Sending
+			|| state == MidiSysexTransferState::Cancelling;
+	}
+
+	void TurboMidiTransfer::publishProgress()
+	{
+		m_progress.publish({m_state.load(std::memory_order_relaxed), m_sent,
+			m_total, m_speedCode, m_speedCode > 1, m_fallbackReason,
+			m_fallbackCount});
+	}
+
+	bool TurboMidiTransfer::start(PreparedMidiSysexTransfer& _transfer,
+		const size_t _realtimeWriteBoundary)
+	{
+		if(_transfer.m_bytes.empty())
+			return false;
+		AccessGuard access(m_access);
+		if(!access || ownsMidiWire())
+			return false;
+
+		// Swap rather than move-assign: the retired allocation leaves Hardware in
+		// _transfer and is freed by the caller after releasing the plug-in lock.
+		m_payload.swap(_transfer.m_bytes);
+		m_payloadCursor = 0;
+		m_total = m_payload.size();
+		m_sent = 0;
+		m_realtimeWriteBoundary = _realtimeWriteBoundary;
+		m_wire.clear();
+		m_baudAccumulator = 0;
+		m_phase = Phase::BeginNegotiation;
+		m_speed1 = 1;
+		m_speed2 = 1;
+		m_speedCode = 1;
+		m_bytesPerSecond = 3125;
+		m_phaseCycles = 0;
+		m_activeSenseCycles = 0;
+		m_fallbackReason = MidiTurboFallbackReason::None;
+		m_fallbackCount = 0;
+		m_partialResponse.clear();
+		clearResponses();
+		m_transmitBytes.clear();
+		m_captureTransmit = false;
+		m_state.store(MidiSysexTransferState::Queued, std::memory_order_release);
+		publishProgress();
+		return true;
+	}
+
+	bool TurboMidiTransfer::cancel(std::vector<uint8_t>& _retiredPayload)
+	{
+		AccessGuard access(m_access);
+		if(!access || !ownsMidiWire() || !_retiredPayload.empty())
+			return false;
+
+		// Payload ownership leaves the scheduler immediately, but destruction is
+		// deferred to the control-plane caller after it releases the Plugin lock.
+		_retiredPayload.swap(m_payload);
+		m_payloadCursor = 0;
+		m_captureTransmit = false;
+		m_transmitBytes.clear();
+		m_partialResponse.clear();
+		clearResponses();
+		m_wire.clear();
+		m_speedCode = 1;
+		m_bytesPerSecond = 3125;
+		m_activeSenseCycles = 0;
+		m_baudAccumulator = m_clockHz;
+		m_phaseCycles = 0;
+		// A prefix of the current SysEx may already be buffered in the emulated
+		// UART. Append EOX behind it before releasing the wire so subsequent MIDI
+		// cannot become part of a truncated message.
+		if(!m_wire.tryPush(0xf7))
+		{
+			++m_overflow;
+			return false;
+		}
+		m_phase = Phase::DrainCancellation;
+		m_state.store(MidiSysexTransferState::Cancelling,
+			std::memory_order_release);
+		publishProgress();
+		return true;
+	}
+
+	bool TurboMidiTransfer::retirePayload(std::vector<uint8_t>& _retiredPayload)
+	{
+		AccessGuard access(m_access);
+		if(!access || ownsMidiWire() || !_retiredPayload.empty() || m_payload.empty())
+			return false;
+		_retiredPayload.swap(m_payload);
+		m_payloadCursor = 0;
+		return true;
+	}
+
+	void TurboMidiTransfer::observeTransmitByte(const uint8_t _byte)
+	{
+		AccessGuard access(m_access);
+		if(!access)
+		{
+			m_overflow.fetch_add(1, std::memory_order_relaxed);
+			return;
+		}
+		if(m_captureTransmit && !m_transmitBytes.tryPush(_byte))
+			m_overflow.fetch_add(1, std::memory_order_relaxed);
+	}
+
+	void TurboMidiTransfer::queueMessage(const uint8_t _command,
+		const std::initializer_list<uint8_t> _payload)
+	{
+		static constexpr uint8_t header[] = {0xf0, 0x00, 0x20, 0x3c, 0x00, 0x00};
+		std::array<uint8_t, 32> message{};
+		const size_t size = std::size(header) + 1 + _payload.size() + 1;
+		if(size > message.size())
+		{
+			++m_overflow;
+			return;
+		}
+		auto output = std::copy(std::begin(header), std::end(header), message.begin());
+		*output++ = _command;
+		output = std::copy(_payload.begin(), _payload.end(), output);
+		*output = 0xf7;
+		if(!m_wire.tryPush(message.data(), size))
+			++m_overflow;
+	}
+
+	void TurboMidiTransfer::parseTransmitBytes()
+	{
+		uint8_t byte = 0;
+		while(m_transmitBytes.tryPop(byte))
+		{
+			if(byte >= 0xf8 && byte != 0xf7)
+				continue;
+			if(byte == 0xf0)
+			{
+				m_partialResponse.clear();
+				m_partialResponse.bytes[m_partialResponse.size++] = byte;
+				continue;
+			}
+			if(m_partialResponse.empty())
+				continue;
+			if(m_partialResponse.size >= Response::Capacity)
+			{
+				++m_overflow;
+				m_partialResponse.clear();
+				continue;
+			}
+			m_partialResponse.bytes[m_partialResponse.size++] = byte;
+			if(byte != 0xf7)
+				continue;
+
+			const auto& message = m_partialResponse;
+			if(message.size >= 8 && message[0] == 0xf0 && message[1] == 0x00
+				&& message[2] == 0x20 && message[3] == 0x3c
+				&& message[4] == 0x00 && message[5] == 0x00
+				&& !pushResponse(message))
+				++m_overflow;
+			m_partialResponse.clear();
+		}
+	}
+
+	bool TurboMidiTransfer::pushResponse(const Response& _message)
+	{
+		if(m_responseCount >= m_responses.size())
+			return false;
+		const auto write = (m_responseRead + m_responseCount) % m_responses.size();
+		m_responses[write] = _message;
+		++m_responseCount;
+		return true;
+	}
+
+	void TurboMidiTransfer::clearResponses()
+	{
+		m_responseRead = 0;
+		m_responseCount = 0;
+	}
+
+	bool TurboMidiTransfer::takeResponse(const uint8_t _command, Response& _message)
+	{
+		while(m_responseCount > 0)
+		{
+			auto& candidate = m_responses[m_responseRead];
+			m_responseRead = (m_responseRead + 1) % m_responses.size();
+			--m_responseCount;
+			if(candidate.size > 7 && candidate[6] == _command)
+			{
+				_message = candidate;
+				return true;
+			}
+		}
+		return false;
+	}
+
+	void TurboMidiTransfer::beginPayload()
+	{
+		m_phase = Phase::Payload;
+		m_phaseCycles = 0;
+		m_captureTransmit = false;
+		m_state.store(MidiSysexTransferState::Sending, std::memory_order_release);
+	}
+
+	void TurboMidiTransfer::fallBack(const bool _waitForPeerReset,
+		const MidiTurboFallbackReason _reason)
+	{
+		m_fallbackReason = _reason;
+		++m_fallbackCount;
+		m_captureTransmit = false;
+		m_wire.clear();
+		clearResponses();
+		m_partialResponse.clear();
+		m_speedCode = 1;
+		m_bytesPerSecond = 3125;
+		m_activeSenseCycles = 0;
+		m_baudAccumulator = 0;
+		m_phaseCycles = 0;
+		if(_waitForPeerReset)
+			m_phase = Phase::WaitFallbackReset;
+		else
+			beginPayload();
+	}
+
+	void TurboMidiTransfer::pumpWire(MidiByteSink& _midiPort)
+	{
+		const uint64_t activeSenseIntervalCycles = (m_clockHz * 150u) / 1000u;
+		bool blocked = false;
+		while(m_baudAccumulator >= m_clockHz)
+		{
+			bool admitted = false;
+			if(m_speedCode > 1 && m_activeSenseCycles >= activeSenseIntervalCycles)
+			{
+				if(!_midiPort.tryWriteMidiByte(synthLib::M_ACTIVESENSING))
+				{
+					blocked = true;
+					break;
+				}
+				m_activeSenseCycles -= activeSenseIntervalCycles;
+				admitted = true;
+			}
+			else if(!m_wire.empty())
+			{
+				uint8_t byte = 0;
+				if(!m_wire.tryPeek(byte))
+					break;
+				if(!_midiPort.tryWriteMidiByte(byte))
+				{
+					blocked = true;
+					break;
+				}
+				uint8_t committed = 0;
+				if(!m_wire.tryPop(committed))
+					break;
+				admitted = true;
+			}
+			else if(m_phase == Phase::Payload && m_payloadCursor < m_payload.size())
+			{
+				if(!_midiPort.tryWriteMidiByte(m_payload[m_payloadCursor]))
+				{
+					blocked = true;
+					break;
+				}
+				++m_payloadCursor;
+				++m_sent;
+				admitted = true;
+			}
+
+			if(!admitted)
+				break;
+			m_baudAccumulator -= m_clockHz;
+		}
+
+		if(!blocked && m_wire.empty()
+			&& (m_phase != Phase::Payload || m_payloadCursor >= m_payload.size()))
+			m_baudAccumulator = std::min<uint64_t>(m_baudAccumulator, m_clockHz - 1u);
+	}
+
+	void TurboMidiTransfer::service(const uint32_t _cycles,
+		const bool _ingressDrained, MidiByteSink& _midiPort)
+	{
+		if(!ownsMidiWire())
+			return;
+		AccessGuard access(m_access);
+		if(!access || !ownsMidiWire() || !_ingressDrained)
+			return;
+
+		parseTransmitBytes();
+		m_phaseCycles += _cycles;
+		if(m_speedCode > 1)
+			m_activeSenseCycles += _cycles;
+
+		const uint64_t responseTimeoutCycles = m_clockHz;
+		const uint64_t fallbackResetCycles = (m_clockHz * 350u) / 1000u;
+		Response response;
+		switch(m_phase)
+		{
+		case Phase::BeginNegotiation:
+			m_captureTransmit = true;
+			queueMessage(0x10);
+			m_phase = Phase::SendRequest;
+			m_phaseCycles = 0;
+			m_state.store(MidiSysexTransferState::NegotiatingTurbo,
+				std::memory_order_release);
+			break;
+		case Phase::WaitAnswer:
+			if(takeResponse(0x11, response))
+			{
+				if(response.size < 12)
+				{
+					fallBack(false, MidiTurboFallbackReason::MalformedSpeedAnswer);
+					break;
+				}
+				const uint16_t supported = static_cast<uint16_t>(response[7])
+					| (static_cast<uint16_t>(response[8]) << 7);
+				const uint16_t certified = static_cast<uint16_t>(response[9])
+					| (static_cast<uint16_t>(response[10]) << 7);
+				const auto highestCode = [](const uint16_t _mask)
+				{
+					for(int bit = 7; bit >= 0; --bit)
+						if(_mask & (uint16_t{1} << bit))
+							return static_cast<uint8_t>(bit + 1);
+					return uint8_t{1};
+				};
+				const uint16_t common = supported & 0x00ffu;
+				m_speed1 = highestCode(common);
+				const uint16_t speed1Bit = uint16_t{1} << (m_speed1 - 1);
+				m_speed2 = (certified & speed1Bit) ? m_speed1
+					: highestCode(common & (speed1Bit - 1u));
+				if(m_speed1 <= 1 || m_speed2 <= 1)
+				{
+					fallBack(false, MidiTurboFallbackReason::NoCommonCertifiedSpeed);
+					break;
+				}
+				queueMessage(0x12, {m_speed1, m_speed2});
+				m_phase = Phase::SendNegotiation;
+				m_phaseCycles = 0;
+			}
+			else if(m_phaseCycles > responseTimeoutCycles)
+				fallBack(false, MidiTurboFallbackReason::CapabilityRequestTimedOut);
+			break;
+		case Phase::WaitAck:
+			if(takeResponse(0x13, response))
+			{
+				static constexpr uint32_t speeds[] =
+					{3125, 3125, 6250, 10406, 12500, 15625, 20812, 25000, 31250};
+				m_speedCode = m_speed1;
+				m_bytesPerSecond = speeds[m_speedCode];
+				m_baudAccumulator = 0;
+				m_activeSenseCycles = 0;
+				for(uint32_t i = 0; i < 16; ++i)
+					if(!m_wire.tryPush(0x00))
+						++m_overflow;
+				queueMessage(0x14,
+					{0x55, 0x55, 0x55, 0x55, 0x00, 0x00, 0x00, 0x00});
+				m_phase = Phase::SendTest1;
+				m_phaseCycles = 0;
+			}
+			else if(m_phaseCycles > responseTimeoutCycles)
+				fallBack(false, MidiTurboFallbackReason::SpeedAcknowledgementTimedOut);
+			break;
+		case Phase::WaitTest1:
+			if(takeResponse(0x15, response))
+			{
+				static constexpr uint8_t expected[] =
+					{0x55, 0x55, 0x55, 0x55, 0x00, 0x00, 0x00, 0x00};
+				const bool valid = response.size >= 16
+					&& std::equal(std::begin(expected), std::end(expected),
+						response.bytes.begin() + 7);
+				if(!valid)
+				{
+					fallBack(true, MidiTurboFallbackReason::FirstLinkTestBadData);
+					break;
+				}
+				static constexpr uint32_t speeds[] =
+					{3125, 3125, 6250, 10406, 12500, 15625, 20812, 25000, 31250};
+				m_speedCode = m_speed2;
+				m_bytesPerSecond = speeds[m_speedCode];
+				m_baudAccumulator = 0;
+				queueMessage(0x16);
+				m_phase = Phase::SendTest2;
+				m_phaseCycles = 0;
+			}
+			else if(m_phaseCycles > responseTimeoutCycles)
+				fallBack(true, MidiTurboFallbackReason::FirstLinkTestTimedOut);
+			break;
+		case Phase::WaitTest2:
+			if(takeResponse(0x17, response))
+				beginPayload();
+			else if(m_phaseCycles > responseTimeoutCycles)
+				fallBack(true, MidiTurboFallbackReason::SecondLinkTestTimedOut);
+			break;
+		case Phase::WaitFallbackReset:
+			if(m_phaseCycles >= fallbackResetCycles)
+				beginPayload();
+			break;
+		default:
+			break;
+		}
+
+		m_baudAccumulator += static_cast<uint64_t>(_cycles) * m_bytesPerSecond;
+		pumpWire(_midiPort);
+
+		const auto enterWait = [this](const Phase _send, const Phase _wait)
+		{
+			if(m_phase == _send && m_wire.empty())
+			{
+				m_phase = _wait;
+				m_phaseCycles = 0;
+			}
+		};
+		enterWait(Phase::SendRequest, Phase::WaitAnswer);
+		enterWait(Phase::SendNegotiation, Phase::WaitAck);
+		enterWait(Phase::SendTest1, Phase::WaitTest1);
+		enterWait(Phase::SendTest2, Phase::WaitTest2);
+
+		if(m_phase == Phase::Payload && m_payloadCursor >= m_payload.size())
+		{
+			m_speedCode = 1;
+			m_bytesPerSecond = 3125;
+			m_baudAccumulator = 0;
+			m_phase = Phase::DrainPayload;
+		}
+		if(m_phase == Phase::DrainPayload && _midiPort.queuedMidiByteCount() == 0)
+		{
+			m_phase = Phase::Idle;
+			m_state.store(MidiSysexTransferState::Complete,
+				std::memory_order_release);
+		}
+		if(m_phase == Phase::DrainCancellation && m_wire.empty()
+			&& _midiPort.queuedMidiByteCount() == 0)
+		{
+			m_phase = Phase::Idle;
+			m_state.store(MidiSysexTransferState::Cancelled,
+				std::memory_order_release);
+		}
+		publishProgress();
+	}
+}

--- a/source/elektron/md/mdLib/mdturbomidi.h
+++ b/source/elektron/md/mdLib/mdturbomidi.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <vector>
+
+#include "mdfixedbytequeue.h"
+#include "mdsysextransfer.h"
+
+namespace md
+{
+	class MidiByteSink
+	{
+	public:
+		virtual ~MidiByteSink() = default;
+		virtual bool tryWriteMidiByte(uint8_t _byte) = 0;
+		virtual size_t queuedMidiByteCount() const = 0;
+	};
+
+	// Host side of the TurboMIDI protocol documented in Appendix C of the
+	// Machinedrum manual. All calls are externally serialized by Hardware's owning
+	// synthLib::Plugin lock; the UART transmit observer runs synchronously on that
+	// same scheduler path. No lock or allocation occurs while service() is running.
+	class TurboMidiTransfer
+	{
+	public:
+		explicit TurboMidiTransfer(uint64_t _clockHz);
+
+		bool start(PreparedMidiSysexTransfer& _transfer,
+			size_t _realtimeWriteBoundary);
+		bool cancel(std::vector<uint8_t>& _retiredPayload);
+		bool retirePayload(std::vector<uint8_t>& _retiredPayload);
+		void service(uint32_t _cycles, bool _ingressDrained,
+			MidiByteSink& _midiPort);
+		void observeTransmitByte(uint8_t _byte);
+
+		bool ownsMidiWire() const;
+		size_t realtimeWriteBoundary() const { return m_realtimeWriteBoundary; }
+		MidiSysexTransferProgress progress() const { return m_progress.read(); }
+		uint64_t overflowCount() const
+		{
+			return m_overflow.load(std::memory_order_relaxed);
+		}
+
+	private:
+		struct Response
+		{
+			static constexpr size_t Capacity = 256;
+			std::array<uint8_t, Capacity> bytes{};
+			size_t size = 0;
+
+			void clear() { size = 0; }
+			bool empty() const { return size == 0; }
+			uint8_t operator[](size_t _index) const { return bytes[_index]; }
+		};
+
+		enum class Phase : uint8_t
+		{
+			Idle,
+			BeginNegotiation,
+			SendRequest,
+			WaitAnswer,
+			SendNegotiation,
+			WaitAck,
+			SendTest1,
+			WaitTest1,
+			SendTest2,
+			WaitTest2,
+			WaitFallbackReset,
+			Payload,
+			DrainPayload,
+			DrainCancellation
+		};
+
+		void queueMessage(uint8_t _command,
+			std::initializer_list<uint8_t> _payload = {});
+		void parseTransmitBytes();
+		bool pushResponse(const Response& _message);
+		bool takeResponse(uint8_t _command, Response& _message);
+		void clearResponses();
+		void beginPayload();
+		void fallBack(bool _waitForPeerReset, MidiTurboFallbackReason _reason);
+		void pumpWire(MidiByteSink& _midiPort);
+		void publishProgress();
+
+		class AccessGuard
+		{
+		public:
+			explicit AccessGuard(std::atomic_flag& _flag)
+				: m_flag(_flag)
+				, m_acquired(!m_flag.test_and_set(std::memory_order_acquire))
+			{
+			}
+			~AccessGuard()
+			{
+				if(m_acquired)
+					m_flag.clear(std::memory_order_release);
+			}
+			explicit operator bool() const { return m_acquired; }
+
+		private:
+			std::atomic_flag& m_flag;
+			bool m_acquired;
+		};
+
+		const uint64_t m_clockHz;
+		std::vector<uint8_t> m_payload;
+		size_t m_payloadCursor = 0;
+		size_t m_total = 0;
+		size_t m_sent = 0;
+		size_t m_realtimeWriteBoundary = 0;
+		FixedByteQueue<4096> m_wire;
+		uint64_t m_baudAccumulator = 0;
+		Phase m_phase = Phase::Idle;
+		uint8_t m_speed1 = 1;
+		uint8_t m_speed2 = 1;
+		uint8_t m_speedCode = 1;
+		uint32_t m_bytesPerSecond = 3125;
+		uint64_t m_phaseCycles = 0;
+		uint64_t m_activeSenseCycles = 0;
+		MidiTurboFallbackReason m_fallbackReason = MidiTurboFallbackReason::None;
+		uint32_t m_fallbackCount = 0;
+		bool m_captureTransmit = false;
+		FixedByteQueue<4096> m_transmitBytes;
+		std::atomic<uint64_t> m_overflow{0};
+		Response m_partialResponse;
+		std::array<Response, 8> m_responses{};
+		size_t m_responseRead = 0;
+		size_t m_responseCount = 0;
+		std::atomic<MidiSysexTransferState> m_state{MidiSysexTransferState::Idle};
+		std::atomic_flag m_access = ATOMIC_FLAG_INIT;
+		MidiSysexTransferProgressPublisher m_progress;
+	};
+}

--- a/source/elektron/md/mdLibTest/CMakeLists.txt
+++ b/source/elektron/md/mdLibTest/CMakeLists.txt
@@ -8,6 +8,20 @@ set_tests_properties(mdLibTests PROPERTIES LABELS "UnitTest")
 
 set_property(TARGET mdLibTest PROPERTY FOLDER "Elektron")
 
+add_executable(mdTurboMidiUnitTest turboMidiTest.cpp)
+find_package(Threads REQUIRED)
+target_link_libraries(mdTurboMidiUnitTest PRIVATE mdLib Threads::Threads)
+add_test(NAME mdTurboMidiUnitTest COMMAND mdTurboMidiUnitTest)
+set_tests_properties(mdTurboMidiUnitTest PROPERTIES LABELS "UnitTest;Midi")
+set_property(TARGET mdTurboMidiUnitTest PROPERTY FOLDER "Elektron")
+
+# Manual acceptance test: user-supplied firmware/data paths make this unsuitable
+# for ctest, but it exercises the same validated sender against real firmware and
+# requires an observable machine-state mutation after the UART drains.
+add_executable(mdUserSysexFirmwareTest userSysexFirmwareTest.cpp)
+target_link_libraries(mdUserSysexFirmwareTest PRIVATE mdLib)
+set_property(TARGET mdUserSysexFirmwareTest PROPERTY FOLDER "Elektron/test")
+
 add_executable(mdFirmwareImageTest firmwareImageTest.cpp)
 target_link_libraries(mdFirmwareImageTest PRIVATE mdLib)
 

--- a/source/elektron/md/mdLibTest/mdStateTest.cpp
+++ b/source/elektron/md/mdLibTest/mdStateTest.cpp
@@ -208,6 +208,52 @@ namespace
 			"legacy state changes patch RAM without replacing flash");
 	}
 
+	void testMonomachineUserFlashState()
+	{
+		const auto patchRam = makePatchRam();
+		std::vector<uint8_t> userFlash(md::g_mmUserFlashStateSize);
+		for(size_t i = 0; i < userFlash.size(); ++i)
+			userFlash[i] = static_cast<uint8_t>((i * 37u) ^ (i >> 9));
+
+		std::vector<uint8_t> encoded;
+		check(md::encodeState(encoded, patchRam, md::MachineModel::Monomachine,
+			synthLib::StateTypeGlobal, userFlash),
+			"Monomachine DigiPRO user flash encodes");
+		check(encoded.size() == 28 + patchRam.size() + userFlash.size(),
+			"Monomachine state has bounded patch-plus-user-flash size");
+		md::DecodedState decoded;
+		check(md::decodeState(decoded, encoded, {},
+			md::MachineModel::Monomachine, synthLib::StateTypeGlobal),
+			"Monomachine DigiPRO user flash decodes");
+		check(decoded.containsFlash && decoded.patchRam == patchRam
+			&& decoded.userFlash == userFlash,
+			"Monomachine patch RAM and DigiPRO flash round-trip byte exactly");
+
+		auto corrupt = encoded;
+		corrupt.back() ^= 1;
+		md::DecodedState unchanged;
+		unchanged.patchRam = {1, 2, 3};
+		check(!md::decodeState(unchanged, corrupt, {},
+			md::MachineModel::Monomachine, synthLib::StateTypeGlobal),
+			"Monomachine state rejects corrupt DigiPRO flash");
+		check(unchanged.patchRam == std::vector<uint8_t>({1, 2, 3}),
+			"corrupt Monomachine state leaves decoded output unchanged");
+		check(!md::decodeState(unchanged, encoded, {},
+			md::MachineModel::Machinedrum, synthLib::StateTypeGlobal),
+			"Monomachine user-flash state rejects the wrong model");
+
+		std::vector<uint8_t> legacy;
+		md::DecodedState decodedLegacy;
+		check(md::encodeState(legacy, patchRam, md::MachineModel::Monomachine,
+			synthLib::StateTypeGlobal)
+			&& md::decodeState(decodedLegacy, legacy, {},
+				md::MachineModel::Monomachine, synthLib::StateTypeGlobal),
+			"legacy version-1 Monomachine state remains compatible");
+		check(!decodedLegacy.containsFlash && decodedLegacy.userFlash.empty()
+			&& decodedLegacy.patchRam == patchRam,
+			"legacy Monomachine state remains patch-only");
+	}
+
 	void testFactoryCache()
 	{
 		std::vector<uint8_t> rom(md::g_romSize, 0xff);
@@ -267,6 +313,7 @@ int main()
 {
 	std::puts("Machinedrum UW state and cache tests\n");
 	testSparseProjectState();
+	testMonomachineUserFlashState();
 	testFactoryCache();
 	testCacheFilePublication();
 	std::printf("\n%s (%d failures)\n", g_failures == 0 ? "OK" : "FAILED",

--- a/source/elektron/md/mdLibTest/turboMidiTest.cpp
+++ b/source/elektron/md/mdLibTest/turboMidiTest.cpp
@@ -1,0 +1,347 @@
+#include "mdLib/mdturbomidi.h"
+
+#include <cstdint>
+#include <atomic>
+#include <iostream>
+#include <initializer_list>
+#include <limits>
+#include <thread>
+#include <vector>
+
+namespace
+{
+	constexpr uint64_t g_testClockHz = 1000;
+
+	class MidiSink final : public md::MidiByteSink
+	{
+	public:
+		bool tryWriteMidiByte(const uint8_t _byte) override
+		{
+			if(bytes.size() >= acceptLimit)
+				return false;
+			bytes.push_back(_byte);
+			return true;
+		}
+		size_t queuedMidiByteCount() const override { return 0; }
+		std::vector<uint8_t> bytes;
+		size_t acceptLimit = std::numeric_limits<size_t>::max();
+	};
+
+	bool check(const bool _condition, const char* const _message)
+	{
+		if(_condition)
+			return true;
+		std::cerr << _message << '\n';
+		return false;
+	}
+
+	std::vector<uint8_t> turboMessage(const uint8_t _command,
+		const std::initializer_list<uint8_t> _payload = {})
+	{
+		std::vector<uint8_t> result{0xf0, 0x00, 0x20, 0x3c, 0x00, 0x00, _command};
+		result.insert(result.end(), _payload.begin(), _payload.end());
+		result.push_back(0xf7);
+		return result;
+	}
+
+	void reply(md::TurboMidiTransfer& _transfer, const uint8_t _command,
+		const std::initializer_list<uint8_t> _payload = {})
+	{
+		for(const auto byte : turboMessage(_command, _payload))
+			_transfer.observeTransmitByte(byte);
+	}
+
+	bool testTimeoutFallback()
+	{
+		md::TurboMidiTransfer transfer(g_testClockHz);
+		MidiSink sink;
+		auto prepared = md::prepareMidiSysexTransfer({0xf0, 0x01, 0xf7});
+		if(!check(prepared.has_value(), "valid SysEx was rejected")
+			|| !check(transfer.start(*prepared, 0), "transfer did not start"))
+			return false;
+
+		transfer.service(g_testClockHz, true, sink);
+		if(!check(sink.bytes == turboMessage(0x10), "capability request is malformed"))
+			return false;
+		transfer.service(g_testClockHz + 1, true, sink);
+		const auto progress = transfer.progress();
+		return check(progress.state == md::MidiSysexTransferState::Complete,
+			"fallback transfer did not complete")
+			&& check(progress.sent == 3, "fallback byte count is wrong")
+			&& check(progress.fallbackReason
+				== md::MidiTurboFallbackReason::CapabilityRequestTimedOut,
+				"fallback reason is wrong");
+	}
+
+	bool testDocumentedHandshake()
+	{
+		md::TurboMidiTransfer transfer(g_testClockHz);
+		MidiSink sink;
+		auto prepared = md::prepareMidiSysexTransfer({0xf0, 0x02, 0xf7});
+		if(!prepared || !transfer.start(*prepared, 0))
+			return check(false, "TurboMIDI transfer did not start");
+
+		transfer.service(g_testClockHz, true, sink);
+		reply(transfer, 0x11, {0x7f, 0x01, 0x7f, 0x01});
+		transfer.service(g_testClockHz, true, sink);
+		reply(transfer, 0x13);
+		transfer.service(g_testClockHz, true, sink);
+		reply(transfer, 0x15,
+			{0x55, 0x55, 0x55, 0x55, 0x00, 0x00, 0x00, 0x00});
+		transfer.service(g_testClockHz, true, sink);
+		reply(transfer, 0x17);
+		transfer.service(g_testClockHz, true, sink);
+
+		const auto progress = transfer.progress();
+		return check(progress.state == md::MidiSysexTransferState::Complete,
+			"TurboMIDI transfer did not complete")
+			&& check(progress.sent == 3, "TurboMIDI byte count is wrong")
+			&& check(progress.fallbackReason == md::MidiTurboFallbackReason::None,
+				"TurboMIDI unexpectedly fell back");
+	}
+
+	bool testCancellationAndRetirement()
+	{
+		md::TurboMidiTransfer transfer(g_testClockHz);
+		MidiSink sink;
+		auto prepared = md::prepareMidiSysexTransfer({0xf0, 0x01, 0xf7});
+		if(!prepared || !transfer.start(*prepared, 0))
+			return check(false, "cancellation transfer did not start");
+
+		transfer.service(g_testClockHz, true, sink);
+		sink.acceptLimit = sink.bytes.size() + 2;
+		transfer.service(g_testClockHz + 1, true, sink);
+		if(!check(transfer.progress().sent == 2,
+			"cancellation fixture did not stop inside the payload"))
+			return false;
+
+		std::vector<uint8_t> retired;
+		if(!check(transfer.cancel(retired), "active transfer was not cancelled")
+			|| !check(retired == std::vector<uint8_t>({0xf0, 0x01, 0xf7}),
+				"cancel did not hand payload storage to the caller")
+			|| !check(transfer.progress().state
+				== md::MidiSysexTransferState::Cancelling,
+				"cancel did not retain MIDI-wire ownership"))
+			return false;
+
+		sink.acceptLimit = std::numeric_limits<size_t>::max();
+		transfer.service(g_testClockHz, true, sink);
+		return check(transfer.progress().state
+				== md::MidiSysexTransferState::Cancelled,
+			"cancel did not drain to a terminal state")
+			&& check(sink.bytes.size() >= 3
+				&& sink.bytes[sink.bytes.size() - 3] == 0xf0
+				&& sink.bytes[sink.bytes.size() - 2] == 0x01
+				&& sink.bytes.back() == 0xf7,
+				"cancel did not terminate the partial SysEx message");
+	}
+
+	bool testCompletedPayloadRetirement()
+	{
+		md::TurboMidiTransfer transfer(g_testClockHz);
+		MidiSink sink;
+		auto prepared = md::prepareMidiSysexTransfer({0xf0, 0x03, 0xf7});
+		if(!prepared || !transfer.start(*prepared, 0))
+			return check(false, "retirement transfer did not start");
+		transfer.service(g_testClockHz, true, sink);
+		transfer.service(g_testClockHz + 1, true, sink);
+
+		std::vector<uint8_t> retired;
+		return check(transfer.progress().state
+				== md::MidiSysexTransferState::Complete,
+			"retirement fixture did not complete")
+			&& check(transfer.retirePayload(retired),
+				"completed payload was not retired")
+			&& check(retired == std::vector<uint8_t>({0xf0, 0x03, 0xf7}),
+				"retired payload was corrupted")
+			&& check(!transfer.retirePayload(retired),
+				"payload retirement was not single-owner");
+	}
+
+	bool testPausedServiceResumes()
+	{
+		md::TurboMidiTransfer transfer(g_testClockHz);
+		MidiSink sink;
+		auto prepared = md::prepareMidiSysexTransfer({0xf0, 0x04, 0xf7});
+		if(!prepared || !transfer.start(*prepared, 0))
+			return check(false, "paused transfer did not start");
+
+		const auto paused = transfer.progress();
+		// A suspended host makes no service calls. Control-plane observation must
+		// remain safe and must not advance or discard the queued operation.
+		for(size_t i = 0; i < 1000; ++i)
+		{
+			const auto observed = transfer.progress();
+			if(observed.state != paused.state || observed.sent != paused.sent)
+				return check(false, "paused transfer advanced without processing");
+		}
+		transfer.service(g_testClockHz, true, sink);
+		transfer.service(g_testClockHz + 1, true, sink);
+		const auto resumed = transfer.progress();
+		return check(resumed.state == md::MidiSysexTransferState::Complete,
+			"paused transfer did not resume")
+			&& check(resumed.sent == resumed.total,
+				"resumed transfer lost payload bytes");
+	}
+
+	bool testValidation()
+	{
+		using md::MidiSysexStreamValidation;
+		const std::vector<uint8_t> mmOsUpdate{
+			0xf0, 0x00, 0x20, 0x3c, 0x03, 0x00, 0x7e, 0x00, 0xf7};
+		const std::vector<uint8_t> mdRequest{
+			0xf0, 0x00, 0x20, 0x3c, 0x02, 0x00, 0x53, 0x01, 0xf7};
+		const std::vector<uint8_t> validDump{
+			0xf0, 0x00, 0x20, 0x3c, 0x02, 0x00, 0x52, 0x01, 0x01,
+			0x01, 0x00, 0x01, 0x00, 0x05, 0xf7};
+		const std::vector<uint8_t> validDigiProFooter{
+			0xf0, 0x00, 0x20, 0x3c, 0x03, 0x00, 0x5d, 0x01, 0x01,
+			0x21, 0x02, 0x00, 0x02, 0x00, 0x06, 0xf7};
+		if(!check(md::validateMidiSysexStream(validDump, md::MachineModel::Machinedrum)
+				== MidiSysexStreamValidation::Valid, "MD data was rejected")
+			|| !check(md::validateMidiSysexStream(validDigiProFooter,
+				md::MachineModel::Monomachine) == MidiSysexStreamValidation::Valid,
+				"MM data was rejected")
+			|| !check(md::validateMidiSysexStream(validDump,
+				md::MachineModel::Monomachine)
+				== MidiSysexStreamValidation::WrongModel, "wrong model was accepted")
+			|| !check(md::validateMidiSysexStream(mmOsUpdate, md::MachineModel::Monomachine)
+				== MidiSysexStreamValidation::FirmwareUpdate, "OS update was accepted")
+			|| !check(md::validateMidiSysexStream(validDump, md::MachineModel::Machinedrum)
+				== MidiSysexStreamValidation::Valid, "valid checksummed dump was rejected")
+			|| !check(md::validateMidiSysexStream(mdRequest,
+				md::MachineModel::Machinedrum)
+				== MidiSysexStreamValidation::UnsupportedMessage,
+				"non-import command was accepted"))
+			return false;
+
+		auto corruptDump = validDump;
+		corruptDump[11] ^= 0x01;
+		if(!check(md::validateMidiSysexStream(corruptDump,
+				md::MachineModel::Machinedrum)
+				== MidiSysexStreamValidation::ChecksumMismatch,
+			"corrupt dump checksum was accepted"))
+			return false;
+		auto corruptDigiPro = validDigiProFooter;
+		corruptDigiPro[10] ^= 0x01;
+		if(!check(md::validateMidiSysexStream(corruptDigiPro,
+				md::MachineModel::Monomachine)
+				== MidiSysexStreamValidation::ChecksumMismatch,
+			"corrupt DigiPRO checksum was accepted"))
+			return false;
+		auto invalidData = validDump;
+		invalidData[10] = 0x80;
+		if(!check(md::validateMidiSysexStream(invalidData,
+				md::MachineModel::Machinedrum)
+				== MidiSysexStreamValidation::InvalidDataByte,
+			"non-7-bit SysEx data was accepted"))
+			return false;
+
+		auto concatenated = validDump;
+		concatenated.insert(concatenated.end(), validDump.begin(), validDump.end());
+		if(!check(md::validateMidiSysexStream(concatenated, md::MachineModel::Machinedrum)
+				== MidiSysexStreamValidation::Valid, "concatenated data was rejected"))
+			return false;
+		concatenated.push_back(0x00);
+		return check(md::validateMidiSysexStream(concatenated,
+			md::MachineModel::Machinedrum) == MidiSysexStreamValidation::InvalidFraming,
+			"trailing data was accepted");
+	}
+
+	bool testConcurrentServiceAndProgressReaders()
+	{
+		md::TurboMidiTransfer transfer(g_testClockHz);
+		MidiSink sink;
+		std::vector<uint8_t> payload(10000, 0x01);
+		payload.front() = 0xf0;
+		payload.back() = 0xf7;
+		auto prepared = md::prepareMidiSysexTransfer(std::move(payload));
+		if(!prepared || !transfer.start(*prepared, 0))
+			return check(false, "concurrency transfer did not start");
+
+		std::atomic<bool> invalidProgress{false};
+		auto service = [&]
+		{
+			for(size_t i = 0; i < 100000
+				&& transfer.progress().state != md::MidiSysexTransferState::Complete; ++i)
+				transfer.service(1, true, sink);
+		};
+		auto observe = [&]
+		{
+			for(size_t i = 0; i < 100000; ++i)
+			{
+				const auto progress = transfer.progress();
+				if(progress.sent > progress.total
+					|| (progress.total != 0 && progress.total != 10000))
+					invalidProgress.store(true, std::memory_order_relaxed);
+				if(progress.state == md::MidiSysexTransferState::Complete)
+					break;
+			}
+		};
+
+		std::thread serviceA(service);
+		std::thread serviceB(service); // intentional contract violation: gate must reject overlap
+		std::thread observerA(observe);
+		std::thread observerB(observe);
+		serviceA.join();
+		serviceB.join();
+		observerA.join();
+		observerB.join();
+
+		const auto progress = transfer.progress();
+		return check(!invalidProgress.load(std::memory_order_relaxed),
+			"progress publisher returned a torn observation")
+			&& check(progress.state == md::MidiSysexTransferState::Complete,
+				"nonblocking serialization gate did not complete transfer")
+			&& check(progress.sent == progress.total,
+				"concurrent service duplicated or lost payload bytes");
+	}
+
+	bool testConcurrentStartHasOneOwner()
+	{
+		for(size_t iteration = 0; iteration < 100; ++iteration)
+		{
+			md::TurboMidiTransfer transfer(g_testClockHz);
+			auto first = md::prepareMidiSysexTransfer({0xf0, 0x11, 0xf7});
+			auto second = md::prepareMidiSysexTransfer({0xf0, 0x22, 0x23, 0xf7});
+			if(!first || !second)
+				return check(false, "concurrent-start fixtures were rejected");
+			std::atomic<unsigned> winners{0};
+			std::thread startA([&]
+			{
+				if(transfer.start(*first, 0))
+					winners.fetch_add(1, std::memory_order_relaxed);
+			});
+			std::thread startB([&]
+			{
+				if(transfer.start(*second, 0))
+					winners.fetch_add(1, std::memory_order_relaxed);
+			});
+			startA.join();
+			startB.join();
+			const auto progress = transfer.progress();
+			if(!check(winners.load(std::memory_order_relaxed) == 1,
+					"concurrent starts acquired more or fewer than one owner")
+				|| !check(first->empty() != second->empty(),
+					"concurrent start did not preserve the rejected payload")
+				|| !check(progress.state == md::MidiSysexTransferState::Queued
+					&& (progress.total == 3 || progress.total == 4),
+					"concurrent start published an invalid winner"))
+				return false;
+		}
+		return true;
+	}
+}
+
+int main()
+{
+	if(!testTimeoutFallback() || !testDocumentedHandshake()
+		|| !testCancellationAndRetirement()
+		|| !testCompletedPayloadRetirement() || !testPausedServiceResumes()
+		|| !testValidation()
+		|| !testConcurrentServiceAndProgressReaders()
+		|| !testConcurrentStartHasOneOwner())
+		return 1;
+	std::cout << "TurboMIDI unit tests passed\n";
+	return 0;
+}

--- a/source/elektron/md/mdLibTest/userSysexFirmwareTest.cpp
+++ b/source/elektron/md/mdLibTest/userSysexFirmwareTest.cpp
@@ -1,0 +1,395 @@
+#include "mdLib/mdhardware.h"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstdio>
+#include <fstream>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace
+{
+	std::vector<uint8_t> load(const char* const _path)
+	{
+		std::ifstream input(_path, std::ios::binary);
+		return {std::istreambuf_iterator<char>(input),
+			std::istreambuf_iterator<char>()};
+	}
+
+	size_t changedBytes(const std::vector<uint8_t>& _before,
+		const std::vector<uint8_t>& _after)
+	{
+		if(_before.size() != _after.size())
+			return std::max(_before.size(), _after.size());
+		size_t changed = 0;
+		for(size_t i = 0; i < _before.size(); ++i)
+			changed += _before[i] != _after[i] ? 1u : 0u;
+		return changed;
+	}
+
+	const char* validationName(const md::MidiSysexStreamValidation _validation)
+	{
+		switch(_validation)
+		{
+		case md::MidiSysexStreamValidation::Valid: return "valid";
+		case md::MidiSysexStreamValidation::Empty: return "empty";
+		case md::MidiSysexStreamValidation::TooLarge: return "too large";
+		case md::MidiSysexStreamValidation::InvalidFraming: return "invalid framing";
+		case md::MidiSysexStreamValidation::InvalidDataByte: return "invalid data byte";
+		case md::MidiSysexStreamValidation::ChecksumMismatch: return "checksum/length mismatch";
+		case md::MidiSysexStreamValidation::UnsupportedMessage: return "unsupported message";
+		case md::MidiSysexStreamValidation::WrongModel: return "wrong model";
+		case md::MidiSysexStreamValidation::FirmwareUpdate: return "firmware update";
+		}
+		return "unknown";
+	}
+
+	void settle(md::Hardware& _hardware, const size_t _steps = 100)
+	{
+		for(size_t i = 0; i < _steps; ++i)
+			_hardware.advance(64);
+	}
+
+	void pulse(md::Hardware& _hardware, const md::PanelControl _control)
+	{
+		const auto packet = md::panelPacket(md::MachineModel::Monomachine, _control);
+		if(!packet)
+			return;
+		_hardware.sendPanelEvent(packet->row, packet->mask);
+		settle(_hardware, 8);
+		_hardware.sendPanelEvent(packet->row, 0);
+		settle(_hardware);
+	}
+
+	void chord(md::Hardware& _hardware, const md::PanelControl _control)
+	{
+		const auto function = md::panelPacket(md::MachineModel::Monomachine,
+			md::PanelControl::Function);
+		const auto target = md::panelPacket(md::MachineModel::Monomachine, _control);
+		if(!function || !target)
+			return;
+		md::PanelRowState rows;
+		auto packet = rows.press(*function);
+		_hardware.sendPanelEvent(packet.row, packet.mask);
+		settle(_hardware, 4);
+		packet = rows.press(*target);
+		_hardware.sendPanelEvent(packet.row, packet.mask);
+		settle(_hardware, 8);
+		packet = rows.release(*target);
+		_hardware.sendPanelEvent(packet.row, packet.mask);
+		settle(_hardware, 4);
+		packet = rows.release(*function);
+		_hardware.sendPanelEvent(packet.row, packet.mask);
+		settle(_hardware);
+	}
+
+	void writePanelProbe(const md::Hardware& _hardware, const char* _suffix);
+
+	void enterMmGeneralSysexReceive(md::Hardware& _hardware)
+	{
+		writePanelProbe(_hardware, "-0");
+		chord(_hardware, md::PanelControl::Kit);
+		writePanelProbe(_hardware, "-1");
+		pulse(_hardware, md::PanelControl::Enter);
+		writePanelProbe(_hardware, "-2");
+		pulse(_hardware, md::PanelControl::Down);
+		writePanelProbe(_hardware, "-3");
+		pulse(_hardware, md::PanelControl::Down);
+		writePanelProbe(_hardware, "-4");
+		pulse(_hardware, md::PanelControl::Right);
+		writePanelProbe(_hardware, "-5");
+		pulse(_hardware, md::PanelControl::Down);
+		writePanelProbe(_hardware, "-6");
+		pulse(_hardware, md::PanelControl::Enter);
+		writePanelProbe(_hardware, "-7");
+		pulse(_hardware, md::PanelControl::Right);
+		writePanelProbe(_hardware, "-8");
+		pulse(_hardware, md::PanelControl::Enter);
+		writePanelProbe(_hardware, "-9");
+	}
+
+	void enterMmDigiProReceive(md::Hardware& _hardware)
+	{
+		writePanelProbe(_hardware, "-0");
+		chord(_hardware, md::PanelControl::Kit);
+		writePanelProbe(_hardware, "-1");
+		pulse(_hardware, md::PanelControl::Enter);
+		writePanelProbe(_hardware, "-2");
+		pulse(_hardware, md::PanelControl::Down);
+		writePanelProbe(_hardware, "-3");
+		pulse(_hardware, md::PanelControl::Down);
+		writePanelProbe(_hardware, "-4");
+		pulse(_hardware, md::PanelControl::Right);
+		writePanelProbe(_hardware, "-5");
+		pulse(_hardware, md::PanelControl::Down);
+		writePanelProbe(_hardware, "-6");
+		pulse(_hardware, md::PanelControl::Down);
+		writePanelProbe(_hardware, "-7");
+		pulse(_hardware, md::PanelControl::Enter);
+		writePanelProbe(_hardware, "-8");
+		pulse(_hardware, md::PanelControl::Right);
+		writePanelProbe(_hardware, "-9");
+		pulse(_hardware, md::PanelControl::Enter);
+		writePanelProbe(_hardware, "-10");
+	}
+
+	void writePanelProbe(const md::Hardware& _hardware, const char* const _suffix)
+	{
+		const auto* const prefix = std::getenv("MM_SYSEX_PANEL_PREFIX");
+		if(prefix == nullptr || *prefix == '\0')
+			return;
+		const auto panel = _hardware.getFrontPanelSnapshot();
+		std::ofstream output(std::string(prefix) + _suffix + ".pgm", std::ios::binary);
+		output << "P5\n" << md::FrontPanel::g_lcdWidth << ' '
+			<< md::FrontPanel::g_lcdHeight << "\n255\n";
+		for(uint32_t y = 0; y < md::FrontPanel::g_lcdHeight; ++y)
+			for(uint32_t x = 0; x < md::FrontPanel::g_lcdWidth; ++x)
+				output.put(panel.getLcdPixel(x, y) ? '\0' : '\xff');
+	}
+
+}
+
+int main(const int _argc, char** _argv)
+{
+	if(_argc < 4 || _argc > 6)
+	{
+		std::fprintf(stderr,
+			"usage:\n"
+			"  mdUserSysexFirmwareTest md <rom> <user-data.syx> [first|cancel]\n"
+			"  mdUserSysexFirmwareTest mm <rom> <1MiB-patch-ram> "
+			"<user-data.syx> [first|cancel]\n");
+		return 2;
+	}
+
+	const std::string modelName(_argv[1]);
+	const bool monomachine = modelName == "mm";
+	const int baseArgumentCount = monomachine ? 5 : 4;
+	if((modelName != "md" && !monomachine)
+		|| (_argc != baseArgumentCount && _argc != baseArgumentCount + 1)
+		|| (_argc == baseArgumentCount + 1
+			&& std::string(_argv[baseArgumentCount]) != "first"
+			&& std::string(_argv[baseArgumentCount]) != "cancel"))
+		return 2;
+	const auto model = monomachine ? md::MachineModel::Monomachine
+		: md::MachineModel::Machinedrum;
+	const auto rom = load(_argv[2]);
+	const auto patchRam = monomachine ? load(_argv[3]) : std::vector<uint8_t>{};
+	const char* const sysexPath = _argv[monomachine ? 4 : 3];
+	auto fileBytes = load(sysexPath);
+	const bool firstMessageOnly = _argc == baseArgumentCount + 1
+		&& std::string(_argv[baseArgumentCount]) == "first";
+	const bool cancelMidMessage = _argc == baseArgumentCount + 1
+		&& std::string(_argv[baseArgumentCount]) == "cancel";
+	if(firstMessageOnly)
+	{
+		const auto end = std::find(fileBytes.begin(), fileBytes.end(), uint8_t{0xf7});
+		if(end == fileBytes.end())
+			return 2;
+		fileBytes.erase(end + 1, fileBytes.end());
+	}
+	const auto validation = md::validateMidiSysexStream(fileBytes, model);
+	if(validation != md::MidiSysexStreamValidation::Valid)
+	{
+		std::fprintf(stderr, "SysEx validation failed: %s\n",
+			validationName(validation));
+		return 2;
+	}
+	if(monomachine && patchRam.size() != 0x100000)
+	{
+		std::fputs("Monomachine patch RAM must be exactly 1 MiB\n", stderr);
+		return 2;
+	}
+
+	md::Hardware hardware(rom, _argv[2], model, patchRam);
+	if(!hardware.isValid())
+	{
+		std::fputs("firmware did not construct a valid machine\n", stderr);
+		return 1;
+	}
+	const auto bootDeadline = std::chrono::steady_clock::now()
+		+ std::chrono::seconds(180);
+	while(!hardware.isFirmwareMidiReady() || (monomachine
+		&& (!hardware.isAudioReady()
+			|| hardware.getFrontPanelSnapshot().countLitPixels() <= 2000)))
+	{
+		hardware.advance(64);
+		if(std::chrono::steady_clock::now() >= bootDeadline)
+		{
+			std::fprintf(stderr, "firmware MIDI boot timed out: pc=%08x\n",
+				hardware.getUC().getPC());
+			return 1;
+		}
+	}
+	const bool digiPro = monomachine && fileBytes.size() > 6
+		&& fileBytes[6] == 0x5d;
+	if(monomachine)
+	{
+		if(digiPro)
+			enterMmDigiProReceive(hardware);
+		else
+			enterMmGeneralSysexReceive(hardware);
+	}
+
+	const auto patchBefore = hardware.copyPatchRam();
+	const auto flashBefore = hardware.copyFlashData();
+	// Exercise all three ingress classes around the ownership boundary: a clock
+	// already queued must cross before the file sender, while later semantic and
+	// ordinary host events must remain intact behind it.
+	const std::array<uint8_t, 1> clockBefore{uint8_t{synthLib::M_TIMINGCLOCK}};
+	if(!hardware.trySendRealtimeMidi(clockBefore))
+	{
+		std::fputs("could not queue pre-transfer MIDI clock\n", stderr);
+		return 1;
+	}
+	auto prepared = md::prepareMidiSysexTransfer(fileBytes);
+	if(!prepared || !hardware.startMidiSysexTransfer(*prepared))
+	{
+		std::fputs("validated transfer did not start\n", stderr);
+		return 1;
+	}
+	const std::array<uint8_t, 4> automationAfter{
+		uint8_t{synthLib::M_CONTROLCHANGE}, uint8_t{synthLib::M_ALLNOTESOFF},
+		0x00, uint8_t{synthLib::M_TIMINGCLOCK}};
+	if(!hardware.trySendRealtimeMidi(automationAfter)
+		|| !hardware.sendMidi(synthLib::SMidiEvent(synthLib::MidiEventSource::Host,
+			synthLib::M_NOTEOFF, 0x00, 0x00)))
+	{
+		std::fputs("could not queue concurrent MIDI arbitration traffic\n", stderr);
+		return 1;
+	}
+
+	const auto transferStart = std::chrono::steady_clock::now();
+	const auto transferDeadline = transferStart + std::chrono::seconds(180);
+	uint8_t payloadSpeed = 1;
+	bool cancellationRequested = false;
+	for(;;)
+	{
+		hardware.advance(64);
+		const auto progress = hardware.getMidiSysexTransferProgress();
+		if(progress.state == md::MidiSysexTransferState::Sending)
+		{
+			payloadSpeed = progress.speedCode;
+			if(cancelMidMessage && !cancellationRequested && progress.sent >= 32
+				&& progress.sent < progress.total)
+			{
+				std::vector<uint8_t> retiredPayload;
+				if(!hardware.cancelMidiSysexTransfer(retiredPayload)
+					|| retiredPayload != fileBytes)
+				{
+					std::fputs("mid-message cancellation did not retire its payload\n", stderr);
+					return 1;
+				}
+				cancellationRequested = true;
+			}
+		}
+		if((!cancelMidMessage
+				&& progress.state == md::MidiSysexTransferState::Complete)
+			|| (cancelMidMessage && cancellationRequested
+				&& progress.state == md::MidiSysexTransferState::Cancelled))
+			break;
+		if(std::chrono::steady_clock::now() >= transferDeadline)
+		{
+			std::fprintf(stderr, "transfer timed out: sent=%zu/%zu state=%u\n",
+				progress.sent, progress.total,
+				static_cast<unsigned>(progress.state));
+			return 1;
+		}
+	}
+	if(cancelMidMessage)
+	{
+		while(!hardware.isMidiIngressIdle()
+			&& std::chrono::steady_clock::now() < transferDeadline)
+			hardware.advance(64);
+		const auto finalProgress = hardware.getMidiSysexTransferProgress();
+		std::printf("[%s SysEx firmware cancellation test] sent=%zu/%zu "
+			"payload=%sx state=%u idle=%u\n", monomachine ? "MM" : "MD",
+			finalProgress.sent, finalProgress.total,
+			md::midiTurboSpeedLabel(payloadSpeed),
+			static_cast<unsigned>(finalProgress.state), hardware.isMidiIngressIdle());
+		return cancellationRequested && payloadSpeed > 1
+			&& finalProgress.state == md::MidiSysexTransferState::Cancelled
+			&& hardware.isMidiIngressIdle() ? 0 : 1;
+	}
+
+	// UART-drained is a transport result. Give firmware time to validate, unpack,
+	// and commit the last message, then require an externally observable mutation.
+	for(size_t i = 0; i < 1200; ++i)
+		hardware.advance(64);
+	if(monomachine)
+	{
+		writePanelProbe(hardware, "-after");
+		// Match the hardware workflow: leave the receive screen so firmware can
+		// finish any deferred store operation before persistence is inspected.
+		pulse(hardware, md::PanelControl::Exit);
+		if(digiPro)
+		{
+			const auto storeDeadline = std::chrono::steady_clock::now()
+				+ std::chrono::seconds(60);
+			size_t stableObservations = 0;
+			auto observed = flashBefore;
+			do
+			{
+				settle(hardware, 200);
+				auto current = hardware.copyFlashData();
+				if(current != observed)
+				{
+					observed = std::move(current);
+					stableObservations = 0;
+				}
+				else if(observed != flashBefore)
+					++stableObservations;
+			} while(stableObservations < 10
+				&& std::chrono::steady_clock::now() < storeDeadline);
+		}
+		else
+			settle(hardware, 1000);
+		writePanelProbe(hardware, "-exit");
+	}
+	if(!hardware.isMidiIngressIdle())
+	{
+		std::fputs("MIDI queued around the transfer did not drain afterward\n", stderr);
+		return 1;
+	}
+	const auto patchAfter = hardware.copyPatchRam();
+	const auto flashAfter = hardware.copyFlashData();
+	const auto changedPatch = changedBytes(patchBefore, patchAfter);
+	const auto changedFlash = changedBytes(flashBefore, flashAfter);
+	size_t stateBytes = 0;
+	if(digiPro)
+	{
+		const auto userFlash = hardware.copyUserFlash();
+		std::vector<uint8_t> state;
+		md::DecodedState decoded;
+		if(userFlash.size() != md::g_mmUserFlashStateSize
+			|| !md::encodeState(state, patchAfter, model,
+				synthLib::StateTypeGlobal, userFlash)
+			|| !md::decodeState(decoded, state, {}, model,
+				synthLib::StateTypeGlobal))
+		{
+			std::fputs("DigiPRO project-state persistence failed\n", stderr);
+			return 1;
+		}
+		md::Hardware restored(rom, _argv[2], model, decoded.patchRam,
+			std::shared_ptr<md::FrontPanelPublisher>{}, std::vector<uint8_t>{},
+			std::vector<uint8_t>{}, md::FlashSectorOverlay{}, decoded.userFlash);
+		if(!restored.isValid() || restored.copyUserFlash() != userFlash)
+		{
+			std::fputs("DigiPRO flash did not survive a machine-state rebuild\n", stderr);
+			return 1;
+		}
+		stateBytes = state.size();
+	}
+	const auto elapsed = std::chrono::duration<double>(
+		std::chrono::steady_clock::now() - transferStart).count();
+	std::printf("[%s SysEx firmware test] bytes=%zu payload=%sx "
+		"patchChanged=%zu flashChanged=%zu stateBytes=%zu wall=%.3fs\n",
+		monomachine ? "MM" : "MD", fileBytes.size(),
+		md::midiTurboSpeedLabel(payloadSpeed), changedPatch, changedFlash,
+		stateBytes, elapsed);
+	return payloadSpeed > 1 && (changedPatch != 0 || changedFlash != 0) ? 0 : 1;
+}


### PR DESCRIPTION
## Summary\n\n- add Send SysEx File to the Machinedrum and Monomachine right-click menu, with progress, stalled-host guidance, and safe cancellation\n- validate complete model-specific user-data dumps and negotiate TurboMIDI while serializing ordinary MIDI, automation, and clock traffic on the emulated UART\n- persist Monomachine DigiPRO user flash in version-2 project state while retaining version-1 compatibility\n- document transport completion semantics, bounded payload retention, usage, limitations, and verification evidence\n\n## Local verification\n\n- clean macOS arm64 Release builds: MD/MM Standalone, VST3, and AU\n- strict ad-hoc signature verification for all six bundles; valid AU property lists\n- mdTurboMidiUnitTest and mdStateTest pass\n- both VST3s pass project pluginTester audio-bus and automation/state smoke checks\n- full firmware imports pass:\n  - Machinedrum backup: 777,212 bytes; persistent patch RAM and flash mutation\n  - Monomachine backup: 288,472 bytes; persistent patch RAM mutation\n  - Monomachine DigiPRO: 449,728 bytes; persistent user-flash mutation plus byte-exact project-state rebuild\n- cancellation regression passes after 40 of 777,212 bytes with terminal transport and idle MIDI ingress\n\n## Review notes\n\nTransfer completion deliberately means UART-drained, not firmware-accepted; the instrument display remains authoritative. Public CI cannot contain firmware fixtures. A human right-click/file-picker smoke test remains useful because macOS did not grant this automation session accessibility control.