### PR TITLE
Fix Machinedrum mode labels and RAM recording audio

### DIFF
--- a/doc/md_ram_audio_fix_provenance.md
+++ b/doc/md_ram_audio_fix_provenance.md
@@ -1,0 +1,92 @@
+# MD RAM audio fixes: provenance and possible upstream contributions
+
+Recorded on 2026-09-05, after review of
+[`dsp56300-md-mm` PR #5](https://github.com/joelanders/dsp56300-md-mm/pull/5)
+and [`gearmulator-md-mm` PR #42](https://github.com/joelanders/gearmulator-md-mm/pull/42).
+For symptoms, technical explanations, validation, and remaining hardware risks,
+see [MD RAM audio validation](md_ram_audio_validation.md).
+
+These PRs fix a mixture of inherited DSP emulator gaps and bugs introduced by
+our MD/MM fork. They do not modify Elektron's firmware. This distinction matters
+if we later prepare contributions to the upstream DSP emulator project.
+
+## Scope of the provenance check
+
+The evidence below comes from local Git history, including blame on the code
+before these fixes and inspection of the relevant commit diffs. It establishes
+what our fork inherited and subsequently changed; it does **not** establish
+whether the latest upstream branch still has each issue. Recheck upstream before
+opening a PR. Blame dates identify the traced historical lines, not necessarily
+the first-ever introduction of a bug.
+
+Reviewed implementation heads:
+
+- DSP repository: `363d3fc0632392a4cc9329cf5fd6e9f53e7a8ff6`.
+- Main repository: `b59bf4b31a60a48cf8db6e5c80455ccede4b8a16`.
+
+## Findings
+
+| Change | Provenance | Evidence and upstream relevance |
+| --- | --- | --- |
+| Implement `MERGE` in interpreter and JIT | Inherited upstream omission | The interpreter stub in `dsp_ops_alu.inl` traces to `17dda2d8` (2021-04-23); the JIT stub in `jitops.h` traces to `2473575f` (2021-05-19). A general instruction implementation is a candidate for upstream. |
+| Declare `MERGE` destination as read/write | Inherited upstream metadata error | `opcodeanalysis.h` marked the destination write-only in `8aa104cc` (2022-01-09), although the operation consumes its previous contents. Include this correction with the instruction implementation. |
+| Preserve pending E/U flags before `MERGE` updates N/Z/V | Bug in our initial implementation | `ac2351a4` used `resetCCRCache()`, discarding deferred flags from preceding arithmetic. `930447ef` replaces it with `updateDirtyCCR()` and adds sequence coverage. Upstream should receive the corrected implementation, not the intermediate version. |
+| Restore 24-bit 3D DMA address wrapping | Regression introduced by our fork | The mask was present in historical commit `5f1568d8` (2026-03-26 author date). Our scheduling/peripheral commit `00c48833` removed `_target &= 0xffffff;`. `ac2351a4` restores it. Do not present this restoration as a newly discovered missing upstream fix. |
+| Correct Classic/Extended labels | Our MD/MM integration | The reversed enum values in `mdfrontpanel.h` trace to our MD/MM support commit `bd5800b8` (2026-08-26). This is specific to our front-panel model. |
+| Deliver codec input to MD DSP2 | Our MD/MM hardware model | DSP2's ESSI1 silence callback traces to `bd5800b8`. The single-receiver input assumption is also explicit in `6dcbdcb8` (2026-08-31). Independent queues correct our model of the shared ADC bus. |
+| Suppress empty MD DSP2 ESSI0 receive edges | Our MD/MM integration | The callback wiring is in our `mddsp.cpp`. It applies the existing availability mechanism to the MD main-mix link; it is separate from codec input delivery over ESSI1. |
+| Improve telemetry and firmware/audio tests | Our validation infrastructure | Per-DSP counters, signal-fidelity checks, and named firmware test functions improve our fork's diagnostics and regression coverage. They are not fixes to Elektron's firmware. |
+
+## Suggested upstream contribution
+
+Prepare a small, self-contained **MERGE implementation and regression tests** PR
+against the then-current upstream base, if still needed:
+
+1. Implement the normal 24-bit packing operation in interpreter and JIT.
+2. Preserve the other accumulator fields and unaffected condition flags,
+   including flags still pending from preceding arithmetic.
+3. Correct the destination dependency in opcode analysis.
+4. Include firmware-independent tests for all six source registers, both
+   destinations, source/destination aliasing, distinct half words, N/Z/V, and
+   preserved flags after an ADD/MERGE sequence.
+
+Reference implementation: DSP commits `ac2351a4` and `930447ef`. Extract the
+relevant changes rather than blindly cherry-picking `ac2351a4`, which also
+contains our DMA-mask restoration. Check the upstream flag-cache, register
+representation, and JIT APIs when adapting the patch.
+
+The instruction reference is the DSP56300 Family Manual, Rev. 5, MERGE entry
+(13-108). **Sixteen-bit Arithmetic mode is distinct from S0/S1 scaling modes.**
+Our implementation covers the normal 24-bit operation used by the traced MD
+firmware; it does not implement Sixteen-bit Arithmetic mode. Explain that scope
+explicitly and follow the upstream project's expectations for unsupported modes.
+
+The DSP suites passed on native ARM64 and x86-64 under Rosetta. A negative
+control restoring our old cache reset failed the new flag-preservation test.
+The real MD OS 1.63 regression provides additional integration evidence, but
+the upstream PR's tests should not require proprietary firmware.
+
+## DMA contribution should remain separate
+
+DSP commit `363d3fc0` adds single-word-request regressions for 24-bit source
+address wrapping: in-line increment and positive/negative DOR-A and DOR-B
+offsets. Removing the mask made those tests fail.
+
+Those tests may be useful upstream after adaptation, even if its mask is already
+correct. First inspect its current DMA implementation and counter/trigger
+semantics. Do not bundle our broader MD/MM scheduling changes into a MERGE PR,
+and do not claim these tests exhaustively validate DMA: the current boundary
+cases exercise the 3D source side, not every source/destination mode.
+
+## Local commits for continuation
+
+- DSP initial implementation and DMA restoration: `ac2351a4`.
+- DSP flag preservation, operand coverage, and dependency correction: `930447ef`.
+- DSP DMA boundary regressions: `363d3fc0`.
+- Main mode labels and MD link change: `654fdf53`.
+- Main independent codec-input receivers: `069c900b`.
+- Main per-DSP telemetry and updated DSP submodule: `540787e1`.
+- Main waveform-fidelity tests, test organization, and validation note: `b59bf4b3`.
+
+No upstream PR was opened as part of this work. The two linked PRs target our
+forks; an upstream submission is future work.

--- a/doc/md_ram_audio_validation.md
+++ b/doc/md_ram_audio_validation.md
@@ -1,0 +1,204 @@
+# Machinedrum mode and RAM audio validation
+
+This note records the investigation, fixes, validation evidence, and remaining
+risk for:
+
+- reversed Classic/Extended mode behavior as presented by the UI;
+- a garbled noise floor from RAM playback machines; and
+- pitched tones introduced by the RAM-R `RATE` parameter.
+
+The changes are split across two repositories and should be merged in dependency
+order:
+
+1. [`dsp56300-md-mm` PR #5](https://github.com/joelanders/dsp56300-md-mm/pull/5)
+   implements the missing DSP instruction and restores 24-bit DMA address
+   wrapping.
+2. [`gearmulator-md-mm` PR #42](https://github.com/joelanders/gearmulator-md-mm/pull/42)
+   corrects the MD mode labels, models the codec input connection to both MD
+   DSPs, adds firmware regressions, and advances the DSP submodule.
+
+The corresponding local commits are `ac2351a4` in the DSP repository and
+`654fdf53` plus `069c900b` in the main repository.
+
+## Conclusions and confidence
+
+Confidence is an engineering judgment based on the evidence below, not a claim
+that all MD/MM audio behavior is covered.
+
+| Area | Confidence | Basis |
+| --- | ---: | --- |
+| Classic/Extended mode presentation | 98% | Real MD OS 1.63 status messages identify the raw values unambiguously; synthetic and firmware-backed tests agree. |
+| DSP `MERGE` implementation and RAM sample packing | 97% | The instruction sequence and corrupt packed words were traced directly; interpreter/JIT unit tests and real firmware playback pass. |
+| MD codec-input delivery to RAM-R | 90% | Both DSPs' ESSI/DMA setup was traced, external recording now works, and queue telemetry remains clean in the measured tests. Exact hardware timing and long-duration behavior remain to be checked. |
+| Combined change | 92-94% | Fresh Release builds and all available automated MD tests pass. The remaining uncertainty is primarily hardware, old-firmware, long-duration, and MM-fixture coverage. |
+
+## Classic and Extended mode
+
+MD OS 1.63 reports the mode through SysEx status `0x20` and the front-panel mode
+LED bank. The observations are:
+
+- raw value/bit 0 is **Classic**;
+- raw value/bit 1 is **Extended**; and
+- the firmware sequencer already implements the hardware behavior.
+
+The emulator attached the UI names to the opposite LED bits. Consequently, the
+firmware behavior appeared reversed when described using the displayed mode.
+The fix swaps the semantic names in `mdfrontpanel.h`; it does not patch or
+override the firmware sequencer.
+
+This is high confidence because the correction is a direct mapping with two
+possible values. A physical smoke test should nevertheless confirm that the
+mode named Extended changes kits with patterns and the mode named Classic does
+not.
+
+## RAM noise and `RATE` tones
+
+### Missing `MERGE` instruction
+
+MD OS 1.63 packs two 12-bit RAM samples on DSP2 with this sequence:
+
+```text
+move  y:(r4)+,a
+move  y:(r4)+,b
+merge a1,b
+move  b1,x:(r0)+
+```
+
+`MERGE` was decoded but effectively unimplemented in both the interpreter and
+JIT. The second sample therefore remained in the low half while the high sample
+was absent. Recorded silence repeatedly became `0x000800`; RAM-P decoded that as
+a strong alternating signal, with a measured sustained peak of `0.02363`, RMS
+of `0.020316`, and adjacent-sample correlation of `-0.995868`. Moving `RATE`
+changed the pitch of this corruption, which explains why the report sounded
+like a rate-control or firmware problem.
+
+The corrected instruction produces `{S[11:0], D[35:24]}` in destination bits
+`47:24`, preserves the other accumulator fields, sets `N` from result bit 23,
+sets `Z` when the 24-bit result is zero, and clears `V`. Correctly packed silence
+is `0x800800`.
+
+Unit coverage exercises the interpreter and JIT results, preserved fields, and
+condition flags. The implementation follows the standard arithmetic mode used
+by the traced MD path.
+
+### DSP2 received silence instead of the codec input
+
+Correct sample packing exposed a second problem: external RAM-R recordings were
+actually silent. The earlier malformed samples had made the old firmware test
+mistake corruption for recorded audio.
+
+Firmware tracing established the MD input topology:
+
+- DSP1 receives codec ADC Input A/B into its ESSI1 DMA ring and uses that ring
+  for input metering.
+- DSP1 sends the processed main mix to DSP2 over ESSI0.
+- DSP2 independently configures ESSI1 receive DMA for the codec ADC input.
+- DSP2 owns the UW RAM and applies RAM-R's external-input level/balance controls
+  to that ESSI1 input; the main-mix controls use the separate ESSI0 stream.
+
+The emulator previously connected DSP2's ESSI1 receiver to a silence producer.
+For Machinedrum, each host input frame is now copied into an independent queue
+for each DSP. Independent queues are required because the two emulated DSP
+schedulers consume the shared physical ADC stream separately; a single queue
+would allow one DSP to steal the other one's frame.
+
+Monomachine retains its established DSP2 silence producer. Its second queue is
+neither primed nor appended, avoiding stale samples and false overflow reports.
+
+## Validation evidence
+
+A clean Release build outside the worktree passed the following gates on
+2026-09-05:
+
+- DSP assembler tests: 280/280;
+- DSP interpreter unit tests;
+- DSP JIT unit tests;
+- DSP JIT optimizer tests;
+- `mdLibTest`, including Classic/Extended LED mapping;
+- `mdAudioQueueTest`;
+- `mdUwFirmwareTest` with MD UW OS 1.63; and
+- `mdAudioFirmwareTest` with MD UW OS 1.63.
+
+The firmware-backed RAM test verifies:
+
+- RAM-R at `RATE=64` records silence that stays below `0.0001` during sustained
+  RAM-P playback;
+- an injected saw signal at `RATE=127` changes UW sample memory;
+- the recorded external signal plays back with peak `0.10081` (the comparison
+  ROM-machine peak is `0.276559`); and
+- the measured 16,000-frame capture has zero host-input queue underflows and
+  zero overflows.
+
+The randomized audio test passed with the Legacy, MameHq, and MameLofi
+resamplers at 44.1, 48, and 96 kHz, including hostile host block sizes and
+randomized DSP scheduling. The repositories were clean and both commit ranges
+passed `git diff-tree --check` after validation.
+
+## Remaining reservations
+
+### Physical timing
+
+The data topology is supported by the firmware, but a physical Machinedrum is
+still the authority for the exact frame latency and phase relationship seen by
+the two DSP receivers. The independent queues could reveal slow drift only in a
+recording substantially longer than the automated capture.
+
+### RAM machine coverage
+
+The regression deliberately isolates silence and an external saw input. It does
+not exhaustively cover:
+
+- RAM-P2 and interaction between RAM-P1/RAM-P2;
+- combined main-mix and external-input recording;
+- all `ILEV`, `IBAL`, `MLEV`, and `MBAL` extremes;
+- intermediate and extreme `RATE` values beyond the two regression points;
+- record retriggering, loop wrap, and boundary lengths; or
+- host suspend/resume, sample-rate changes, or state restoration while input
+  queues contain data.
+
+These are the most likely places for remaining MD RAM behavior bugs. The
+original pitched-tone mechanism should be gone at every rate because packing is
+now independent of the playback rate, but interpolation and boundary behavior
+still come from firmware paths not fully exercised by the regression.
+
+### Firmware versions and Monomachine
+
+Only MD UW OS 1.63 was available for real-firmware testing. Older Machinedrum
+firmware might configure the serial links differently. No Monomachine firmware
+fixture was available locally. The main-repository change explicitly preserves
+the existing MM DSP2 producer behavior, but the generic DSP instruction change
+would benefit from a real MM boot/audio regression.
+
+### Generic DSP emulator scope
+
+The DSP56300 manual defines separate behavior associated with arithmetic scaling
+mode. The emulator does not model that mode globally, and the traced MD `MERGE`
+path does not enable it. If another firmware executes `MERGE` with nonstandard
+scaling, that should be implemented and tested as a separate emulator change.
+
+The DMA audit also found generic conformance debt outside the observed MD/MM
+paths: Mode-E count extraction, DTD state, live DCO visibility, DE-triggered 3D
+timing, and dual-3D addressing. Only the previously lost 24-bit target-address
+mask was restored here. The other items should be tracked and tested separately
+rather than folded into this audio fix.
+
+## Recommended hardware smoke matrix
+
+Before calling the behavior fully hardware-validated, run at least the following
+on the same pattern and source material in the emulator and on a Machinedrum UW:
+
+| Test | Controls | Pass condition |
+| --- | --- | --- |
+| Mode semantics | Switch Classic/Extended while changing patterns assigned to different kits | Kits follow patterns only while the UI says Extended. |
+| Silent RAM record | RAM-R external-only, several `RATE` values | RAM-P output has no pitched tone or structured noise floor. |
+| External RAM record | Sweep `ILEV`, `IBAL`, and `RATE`; play through RAM-P1 and RAM-P2 | Level, balance, and pitch follow hardware without corruption. |
+| Main-mix RAM record | Sweep `MLEV` and `MBAL`, including mixed external/main input | Recorded balance and gain agree with hardware. |
+| Boundary behavior | Short/maximum loops, retrigger, and loop wrap | No stale burst, discontinuity beyond hardware behavior, or address wrap fault. |
+| Long capture | Record/play for several minutes at 44.1, 48, and 96 kHz with varied host block sizes | No queue drift, dropouts, changing noise floor, or growing latency. |
+| Host lifecycle | Suspend/resume audio, change sample rate, save/restore state | Queues recover without stale audio, underflow storms, or crashes. |
+
+Record the hardware OS version, host/DAW, plugin format, sample rate, block size,
+RAM machine parameters, and whether input-queue telemetry changed. A failure in
+the long-capture or lifecycle rows is more likely to implicate queue scheduling;
+a failure at particular RAM parameters is more likely to be a firmware-path,
+interpolation, or buffer-boundary emulation issue.

--- a/doc/md_ram_audio_validation.md
+++ b/doc/md_ram_audio_validation.md
@@ -1,5 +1,9 @@
 # Machinedrum mode and RAM audio validation
 
+For the Git-history split between inherited upstream issues and our fork's bugs,
+plus possible future upstream contributions, see
+[fix provenance and upstream candidates](md_ram_audio_fix_provenance.md).
+
 This note records the investigation, fixes, validation evidence, and remaining
 risk for:
 

--- a/doc/md_ram_audio_validation.md
+++ b/doc/md_ram_audio_validation.md
@@ -77,9 +77,12 @@ The corrected instruction produces `{S[11:0], D[35:24]}` in destination bits
 sets `Z` when the 24-bit result is zero, and clears `V`. Correctly packed silence
 is `0x800800`.
 
-Unit coverage exercises the interpreter and JIT results, preserved fields, and
-condition flags. The implementation follows the standard arithmetic mode used
-by the traced MD path.
+Unit coverage exercises all six source registers, both destinations, aliased
+operands, asymmetric half words, preserved fields, and condition flags in the
+interpreter and JIT. An ADD/MERGE sequence checks that lazy E/U flags from the
+preceding arithmetic instruction are materialized before MERGE updates N/Z/V.
+The opcode analysis also declares the destination as read/write. The
+implementation follows the standard arithmetic mode used by the traced MD path.
 
 ### DSP2 received silence instead of the codec input
 
@@ -116,6 +119,8 @@ A clean Release build outside the worktree passed the following gates on
 - DSP JIT optimizer tests;
 - `mdLibTest`, including Classic/Extended LED mapping;
 - `mdAudioQueueTest`;
+- `mdRamAudioOracleTest`, including rejected silence, transients, alternating
+  noise, wrong-input waveforms, NaN, and infinity;
 - `mdUwFirmwareTest` with MD UW OS 1.63; and
 - `mdAudioFirmwareTest` with MD UW OS 1.63.
 
@@ -123,16 +128,33 @@ The firmware-backed RAM test verifies:
 
 - RAM-R at `RATE=64` records silence that stays below `0.0001` during sustained
   RAM-P playback;
-- an injected saw signal at `RATE=127` changes UW sample memory;
-- the recorded external signal plays back with peak `0.10081` (the comparison
-  ROM-machine peak is `0.276559`); and
-- the measured 16,000-frame capture has zero host-input queue underflows and
-  zero overflows.
+- distinct saw signals on Input A/B at `RATE=127` change UW sample memory;
+- `IBAL` at each extreme records the selected input: two consecutive 512-sample
+  playback windows correlate above 0.99 with that input (required: 0.90), while
+  correlation with the other input stays below 0.20 (maximum allowed: 0.35);
+- both output channels have sustained RMS around 0.0574-0.0576 and peaks of
+  `0.103503` / `0.108209` for the A/B captures (ROM peak: `0.276559`); and
+- each 16,384-frame capture has zero host-input queue underflows and overflows.
+
+The audio oracle fits phase and gain rather than requiring a fixed firmware
+latency. Its test translation unit disables fast-math so NaN/Inf rejection
+remains meaningful in Release builds. This is a waveform-fidelity regression,
+not a physical-hardware latency or gain calibration.
+
+The review follow-up also passed the DSP assembler, interpreter, JIT, and
+optimizer suites in both native ARM64 and x86-64 (Rosetta) Release builds.
+Focused DMA tests issue single word requests and inspect 24-bit source-address
+wrapping for in-line increment and positive/negative DOR-A and DOR-B offsets.
+As negative controls, temporarily restoring MERGE's old cache reset failed the
+new E/U preservation test, and removing the DMA mask failed the address-wrap
+test. Both fixes were restored before final validation.
 
 The randomized audio test passed with the Legacy, MameHq, and MameLofi
 resamplers at 44.1, 48, and 96 kHz, including hostile host block sizes and
-randomized DSP scheduling. The repositories were clean and both commit ranges
-passed `git diff-tree --check` after validation.
+randomized DSP scheduling. Queue telemetry now exposes each DSP separately;
+aggregate counts sum receiver-frame events for both underflow and overflow.
+The Monomachine's unused second receiver remains at zero. Both commit ranges
+passed whitespace checks after validation.
 
 ## Remaining reservations
 
@@ -171,10 +193,11 @@ would benefit from a real MM boot/audio regression.
 
 ### Generic DSP emulator scope
 
-The DSP56300 manual defines separate behavior associated with arithmetic scaling
-mode. The emulator does not model that mode globally, and the traced MD `MERGE`
-path does not enable it. If another firmware executes `MERGE` with nonstandard
-scaling, that should be implemented and tested as a separate emulator change.
+The DSP56300 manual defines separate behavior in Sixteen-bit Arithmetic mode
+(distinct from the S0/S1 scaling modes). The emulator does not model that mode
+globally, and the traced MD `MERGE` path does not enable it. If another firmware
+executes `MERGE` in Sixteen-bit Arithmetic mode, that should be implemented and
+tested as a separate emulator change.
 
 The DMA audit also found generic conformance debt outside the observed MD/MM
 paths: Mode-E count extraction, DTD state, live DCO visibility, DE-triggered 3D

--- a/source/elektron/md/mdLib/mddsp.cpp
+++ b/source/elektron/md/mdLib/mddsp.cpp
@@ -54,11 +54,11 @@ namespace md
 		m_periphX.getEssiClock().setExactCycleDeadlineEnabled(m_hardware.isMonomachine());
 
 		// Fine-link mode must be active before the firmware writes CRA so ESSI0 can
-		// run below the codec clock base. DSP1 also skips RX on an empty link instead
-		// of fabricating a silent word into the DMA4 window.
+		// run below the codec clock base. Synchronous receivers skip RX when their
+		// wire is empty instead of fabricating a DMA word from the retained RX value.
 		m_periphX.getEssiClock().setCyclesPerSample(1152u);
 		m_periphX.getEssi0().setFineLinkMode(true);
-		if(m_index == 0)
+		if(m_index == 0 || !m_hardware.isMonomachine())
 		{
 			m_periphX.getEssi0().setRxDataAvailableCallback([this]
 			{
@@ -67,7 +67,8 @@ namespace md
 
 			// An RX0 read with DMA4 disabled flushes staged link data. DMA reads
 			// occur with the channel enabled, which distinguishes the two cases.
-			if(!m_hardware.isMonomachine())
+			// This protocol is specific to Machinedrum DSP1.
+			if(m_index == 0 && !m_hardware.isMonomachine())
 			{
 				m_periphX.getEssi0().setRxConsumeCallback([this]
 				{

--- a/source/elektron/md/mdLib/mdfrontpanel.h
+++ b/source/elektron/md/mdLib/mdfrontpanel.h
@@ -82,8 +82,8 @@ namespace md
 		// Bit positions inside the 0x23 mode bank (active-low, 0 = lit).
 		enum class ModeLed : uint8_t
 		{
-			Extended    = 0,
-			Classic     = 1,
+			Classic     = 0,
+			Extended    = 1,
 			BankGroupAD = 2,
 			BankGroupEH = 3,
 			Record      = 4, // grid-edit

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -368,16 +368,20 @@ namespace md
 			_frame.clear();
 			++_frameIndex;
 		};
-		const auto codecInput = [this](uint64_t& _frameIndex,
-			dsp56k::Audio::RxFrame& _frame)
+		const auto codecInput = [this](const size_t _dspIndex)
 		{
-			RealtimeHostAudioInputQueue::Frame input{};
-			if(!m_hostAudioInput.pop(input) && m_hostAudioInputLatencyInitialized)
-				m_hostAudioInputUnderflow.fetch_add(1, std::memory_order_relaxed);
-			_frame.resize(2);
-			_frame[0] = dsp56k::Audio::RxSlot{input[0]};
-			_frame[1] = dsp56k::Audio::RxSlot{input[1]};
-			++_frameIndex;
+			return [this, _dspIndex](uint64_t& _frameIndex,
+				dsp56k::Audio::RxFrame& _frame)
+			{
+				RealtimeHostAudioInputQueue::Frame input{};
+				if(!m_hostAudioInput[_dspIndex].pop(input)
+					&& m_hostAudioInputLatencyInitialized)
+					m_hostAudioInputUnderflow.fetch_add(1, std::memory_order_relaxed);
+				_frame.resize(2);
+				_frame[0] = dsp56k::Audio::RxSlot{input[0]};
+				_frame[1] = dsp56k::Audio::RxSlot{input[1]};
+				++_frameIndex;
+			};
 		};
 
 		// ESSI0 inter-DSP ring, full-duplex: DSP2 TX -> DSP1 input and vice versa.
@@ -420,10 +424,15 @@ namespace md
 			m_dspMixer.getPeriph().getEssi0(), 0));
 		m_dspProducer.getPeriph().getEssi0().setReadRxCallback(blockingPop(
 			m_dspProducer.getPeriph().getEssi0(), 1));
-		// Input A/B reaches the codec receiver on the mixer; the producer has no
-		// separate host input stream.
-		m_dspMixer.getPeriph().getEssi1().setReadRxCallback(codecInput);
-		m_dspProducer.getPeriph().getEssi1().setReadRxCallback(silence);
+		// The Machinedrum codec ADC bus reaches both DSPs. DSP1 meters it; DSP2
+		// consumes it directly for UW RAM recording. Each receiver gets an
+		// independent copy so scheduler order cannot steal the peer's frame. Keep
+		// the Monomachine producer's established silent-input model.
+		m_dspMixer.getPeriph().getEssi1().setReadRxCallback(codecInput(0));
+		if(isMonomachine())
+			m_dspProducer.getPeriph().getEssi1().setReadRxCallback(silence);
+		else
+			m_dspProducer.getPeriph().getEssi1().setReadRxCallback(codecInput(1));
 
 		// Each mixer ESSI1 output frame advances the codec frame counter used by
 		// the audio plumbing.
@@ -963,19 +972,27 @@ namespace md
 		if(m_hostAudioInputLatencyInitialized && latency == m_hostAudioInputLatency)
 			return;
 
-		m_hostAudioInput.clear();
 		const RealtimeHostAudioInputQueue::Frame silence{};
-		for(uint32_t i = 0; i < latency; ++i)
-			m_hostAudioInput.push(silence);
+		const size_t receiverCount = isMonomachine() ? 1 : m_hostAudioInput.size();
+		for(size_t receiver = 0; receiver < receiverCount; ++receiver)
+		{
+			auto& queue = m_hostAudioInput[receiver];
+			queue.clear();
+			for(uint32_t i = 0; i < latency; ++i)
+				queue.push(silence);
+		}
 		m_hostAudioInputLatency = latency;
 		m_hostAudioInputLatencyInitialized = true;
 	}
 
 	void Hardware::queueHostAudioInput(const uint32_t _frames)
 	{
-		const auto dropped = appendHostAudioInput(m_hostAudioInput,
-			m_hostAudioInputSource, m_hostAudioInputSourceFrames,
-			m_hostAudioInputSourceCursor, _frames);
+		size_t dropped = 0;
+		const size_t receiverCount = isMonomachine() ? 1 : m_hostAudioInput.size();
+		for(size_t receiver = 0; receiver < receiverCount; ++receiver)
+			dropped = std::max(dropped, appendHostAudioInput(m_hostAudioInput[receiver],
+				m_hostAudioInputSource, m_hostAudioInputSourceFrames,
+				m_hostAudioInputSourceCursor, _frames));
 		if(dropped)
 			m_hostAudioInputOverflow.fetch_add(dropped, std::memory_order_relaxed);
 		m_hostAudioInputSourceCursor += _frames;

--- a/source/elektron/md/mdLib/mdhardware.cpp
+++ b/source/elektron/md/mdLib/mdhardware.cpp
@@ -376,7 +376,7 @@ namespace md
 				RealtimeHostAudioInputQueue::Frame input{};
 				if(!m_hostAudioInput[_dspIndex].pop(input)
 					&& m_hostAudioInputLatencyInitialized)
-					m_hostAudioInputUnderflow.fetch_add(1, std::memory_order_relaxed);
+					m_hostAudioInputUnderflow[_dspIndex].fetch_add(1, std::memory_order_relaxed);
 				_frame.resize(2);
 				_frame[0] = dsp56k::Audio::RxSlot{input[0]};
 				_frame[1] = dsp56k::Audio::RxSlot{input[1]};
@@ -987,14 +987,15 @@ namespace md
 
 	void Hardware::queueHostAudioInput(const uint32_t _frames)
 	{
-		size_t dropped = 0;
 		const size_t receiverCount = isMonomachine() ? 1 : m_hostAudioInput.size();
 		for(size_t receiver = 0; receiver < receiverCount; ++receiver)
-			dropped = std::max(dropped, appendHostAudioInput(m_hostAudioInput[receiver],
+		{
+			const auto dropped = appendHostAudioInput(m_hostAudioInput[receiver],
 				m_hostAudioInputSource, m_hostAudioInputSourceFrames,
-				m_hostAudioInputSourceCursor, _frames));
-		if(dropped)
-			m_hostAudioInputOverflow.fetch_add(dropped, std::memory_order_relaxed);
+				m_hostAudioInputSourceCursor, _frames);
+			if(dropped)
+				m_hostAudioInputOverflow[receiver].fetch_add(dropped, std::memory_order_relaxed);
+		}
 		m_hostAudioInputSourceCursor += _frames;
 	}
 

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -314,7 +314,7 @@ namespace md
 		std::atomic<uint64_t> m_schedHostAudioOverflow{0};
 		bool     m_schedHostAudioActive = false;	// retain drained frames for a host callback
 		bool     m_schedBoundedJit = true;		// cycle-bounded DSP background slices
-		RealtimeHostAudioInputQueue m_hostAudioInput;
+		std::array<RealtimeHostAudioInputQueue, 2> m_hostAudioInput;
 		std::atomic<uint64_t> m_hostAudioInputUnderflow{0};
 		std::atomic<uint64_t> m_hostAudioInputOverflow{0};
 		synthLib::TAudioInputs m_hostAudioInputSource{};

--- a/source/elektron/md/mdLib/mdhardware.h
+++ b/source/elektron/md/mdLib/mdhardware.h
@@ -87,16 +87,26 @@ namespace md
 		}
 		uint64_t hostAudioInputUnderflowCount() const
 		{
-			return m_hostAudioInputUnderflow.load(std::memory_order_relaxed);
+			return hostAudioInputUnderflowCount(0) + hostAudioInputUnderflowCount(1);
+		}
+		uint64_t hostAudioInputUnderflowCount(const size_t _dspIndex) const
+		{
+			return m_hostAudioInputUnderflow.at(_dspIndex).load(std::memory_order_relaxed);
 		}
 		uint64_t hostAudioInputOverflowCount() const
 		{
-			return m_hostAudioInputOverflow.load(std::memory_order_relaxed);
+			return hostAudioInputOverflowCount(0) + hostAudioInputOverflowCount(1);
+		}
+		uint64_t hostAudioInputOverflowCount(const size_t _dspIndex) const
+		{
+			return m_hostAudioInputOverflow.at(_dspIndex).load(std::memory_order_relaxed);
 		}
 		void resetHostAudioInputQueueTelemetry()
 		{
-			m_hostAudioInputUnderflow.store(0, std::memory_order_relaxed);
-			m_hostAudioInputOverflow.store(0, std::memory_order_relaxed);
+			for(auto& counter : m_hostAudioInputUnderflow)
+				counter.store(0, std::memory_order_relaxed);
+			for(auto& counter : m_hostAudioInputOverflow)
+				counter.store(0, std::memory_order_relaxed);
 		}
 		size_t queuedMidiRxBytes() const { return m_uc.queuedMidiRxBytes(); }
 		size_t midiRxOverflowCount() const { return m_uc.midiRxOverflowCount(); }
@@ -315,8 +325,9 @@ namespace md
 		bool     m_schedHostAudioActive = false;	// retain drained frames for a host callback
 		bool     m_schedBoundedJit = true;		// cycle-bounded DSP background slices
 		std::array<RealtimeHostAudioInputQueue, 2> m_hostAudioInput;
-		std::atomic<uint64_t> m_hostAudioInputUnderflow{0};
-		std::atomic<uint64_t> m_hostAudioInputOverflow{0};
+		// Counts are receiver-frame events; aggregate accessors sum both DSPs.
+		std::array<std::atomic<uint64_t>, 2> m_hostAudioInputUnderflow{};
+		std::array<std::atomic<uint64_t>, 2> m_hostAudioInputOverflow{};
 		synthLib::TAudioInputs m_hostAudioInputSource{};
 		uint32_t m_hostAudioInputSourceFrames = 0;
 		uint32_t m_hostAudioInputSourceCursor = 0;

--- a/source/elektron/md/mdLibTest/CMakeLists.txt
+++ b/source/elektron/md/mdLibTest/CMakeLists.txt
@@ -38,7 +38,15 @@ set_property(TARGET mdAutomationMidiTest PROPERTY FOLDER "Elektron")
 
 add_executable(mdUwFirmwareTest mdUwFirmwareTest.cpp)
 target_link_libraries(mdUwFirmwareTest PRIVATE mdLib)
+# The audio oracle must detect NaN/Inf even in builds using -Ofast or /fp:fast.
+if(MSVC)
+	target_compile_options(mdUwFirmwareTest PRIVATE /fp:precise)
+else()
+	target_compile_options(mdUwFirmwareTest PRIVATE -fno-fast-math)
+endif()
 add_test(NAME mdUwFirmwareTest COMMAND mdUwFirmwareTest)
+add_test(NAME mdRamAudioOracleTest COMMAND mdUwFirmwareTest --audio-oracle)
+set_tests_properties(mdRamAudioOracleTest PROPERTIES LABELS "UnitTest;AudioIo")
 set_tests_properties(mdUwFirmwareTest PROPERTIES
 	LABELS "Integration;FirmwareTest;Uw"
 	SKIP_RETURN_CODE 77

--- a/source/elektron/md/mdLibTest/mdRuntimeTest.cpp
+++ b/source/elektron/md/mdLibTest/mdRuntimeTest.cpp
@@ -195,7 +195,26 @@ namespace
 			if(!check(lit, "Machinedrum tempo/page LED bank mapping is wrong"))
 				return false;
 		}
-		return true;
+
+		// OS 1.63 owns the sequencer semantics: raw mode bit 0 accompanies
+		// Classic behavior (patterns retain the current kit), while bit 1
+		// accompanies Extended behavior (patterns recall their associated kit).
+		// Keep the semantic labels tied to those wire bits rather than merely
+		// asserting that both UI elements can light.
+		md::FrontPanel classic;
+		const uint8_t classicMessage[] = {0x23, 0xfe};
+		classic.processBytes(classicMessage, sizeof(classicMessage));
+		if(!check(classic.getModeLed(md::FrontPanel::ModeLed::Classic)
+				&& !classic.getModeLed(md::FrontPanel::ModeLed::Extended),
+			"Machinedrum Classic LED was assigned to the Extended wire bit"))
+			return false;
+
+		md::FrontPanel extended;
+		const uint8_t extendedMessage[] = {0x23, 0xfd};
+		extended.processBytes(extendedMessage, sizeof(extendedMessage));
+		return check(extended.getModeLed(md::FrontPanel::ModeLed::Extended)
+				&& !extended.getModeLed(md::FrontPanel::ModeLed::Classic),
+			"Machinedrum Extended LED was assigned to the Classic wire bit");
 	}
 
 	bool testFrontPanelTransitionPublication()

--- a/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
+++ b/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
@@ -15,6 +15,7 @@
 #include <functional>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -140,6 +141,106 @@ namespace
 		return (raw & 0x03u) == (_mode == 0 ? 0x02u : 0x01u);
 	}
 
+	// Fit a periodic input with arbitrary phase and gain. Firmware latency and
+	// the player envelope may change gain, but must preserve the waveform.
+	double waveformCorrelation(const std::vector<float>& _audio, const size_t _begin,
+		const size_t _count, const uint32_t _period)
+	{
+		double best = 0;
+		for(uint32_t lag = 0; lag < _period; ++lag)
+		{
+			double x = 0, y = 0, xx = 0, yy = 0, xy = 0;
+			for(size_t i = 0; i < _count; ++i)
+			{
+				const double reference = double((i + lag) % _period) / _period - 0.5;
+				const double sample = _audio[_begin + i];
+				x += reference; y += sample;
+				xx += reference * reference; yy += sample * sample;
+				xy += reference * sample;
+			}
+			const auto variance = (xx - x * x / _count) * (yy - y * y / _count);
+			if(variance > 0)
+				best = std::max(best, (xy - x * y / _count) / std::sqrt(variance));
+		}
+		return best;
+	}
+
+	bool recordedWaveformMatches(const std::array<std::vector<float>, 2>& _audio,
+		const uint32_t _period, const uint32_t _otherPeriod, const bool _report = true)
+	{
+		// Find a sustained active region, then require both halves to match.
+		// A single transient or a loud corrupted recording cannot pass.
+		constexpr size_t window = 1024;
+		for(const auto& channel : _audio)
+		{
+			if(!std::all_of(channel.begin(), channel.end(),
+				[](const float sample) { return std::isfinite(sample); }))
+				return false;
+			double energy = 0, maximum = 0;
+			size_t begin = 0;
+			for(size_t i = 0; i < channel.size(); ++i)
+			{
+				energy += double(channel[i]) * channel[i];
+				if(i >= window)
+					energy -= double(channel[i - window]) * channel[i - window];
+				if(i + 1 >= window && energy > maximum)
+				{
+					maximum = energy;
+					begin = i + 1 - window;
+				}
+			}
+			const auto rms = std::sqrt(maximum / window);
+			if(rms < 0.003 || rms > 0.5)
+				return false;
+			for(size_t half = 0; half < 2; ++half)
+			{
+				const auto offset = begin + half * window / 2;
+				const auto match = waveformCorrelation(channel, offset, window / 2, _period);
+				const auto other = waveformCorrelation(channel, offset, window / 2, _otherPeriod);
+				if(_report)
+					std::cout << "RAM waveform period=" << _period << ", correlation="
+						<< match << ", other input=" << other << ", RMS=" << rms << '\n';
+				if(match < 0.90 || other > 0.35)
+					return false;
+			}
+		}
+		return true;
+	}
+
+	bool testAudioOracle()
+	{
+		std::array<std::vector<float>, 2> audio{
+			std::vector<float>(2048), std::vector<float>(2048)};
+		const auto matches = [&]() { return recordedWaveformMatches(audio, 97, 151, false); };
+		if(matches()) // silence
+			return false;
+		for(auto& channel : audio)
+			for(size_t i = 0; i < channel.size(); ++i)
+				channel[i] = 0.2f * (float((i + 23) % 97) / 97.0f - 0.5f);
+		if(!matches() || recordedWaveformMatches(audio, 151, 97, false))
+			return false; // tolerate latency/gain, reject swapped inputs
+		for(const auto invalid : {std::numeric_limits<float>::quiet_NaN(),
+			std::numeric_limits<float>::infinity()})
+		{
+			const auto previous = audio[1].back();
+			audio[1].back() = invalid;
+			if(matches())
+				return false;
+			audio[1].back() = previous;
+		}
+		for(auto& channel : audio)
+		{
+			std::fill(channel.begin(), channel.end(), 0);
+			channel[500] = 0.2f;
+		}
+		if(matches()) // an audible transient is not a sustained recording
+			return false;
+		for(auto& channel : audio)
+			for(size_t i = 0; i < channel.size(); ++i)
+				channel[i] = i % 2 ? 0.02f : -0.02f;
+		return !matches(); // structured noise resembling the old packing fault
+	}
+
 	void assignUwMachine(md::Hardware& _hardware, const uint8_t _track,
 		const uint8_t _machine)
 	{
@@ -182,6 +283,191 @@ namespace
 		const auto elapsed = std::chrono::duration<double, std::micro>(
 			std::chrono::steady_clock::now() - begin).count();
 		return elapsed / static_cast<double>(_blocks);
+	}
+	constexpr uint32_t uwMemoryBegin = 0x180000;
+	constexpr uint32_t uwMemoryEnd = 0x200000;
+	constexpr uint32_t captureFrames = 16384;
+
+	int testLockMode(md::Hardware& hardware)
+	{
+		// Tie the UI labels to firmware's own named lock-mode status rather than to
+		// an assumed panel-bit order. This catches a Classic/Extended label swap
+		// without having to construct and save two kits and patterns.
+		const auto initialLockMode = queryLockMode(hardware);
+		if(!initialLockMode
+			|| !lockModeLedMatches(hardware.getFrontPanelSnapshot(), *initialLockMode))
+			return fail("Machinedrum lock-mode LEDs disagree with firmware status");
+		if(!tap(hardware, md::PanelControl::ClassicExtended))
+			return fail("failed to toggle Machinedrum lock mode");
+		const auto toggledLockMode = queryLockMode(hardware);
+		if(!toggledLockMode || *toggledLockMode != (*initialLockMode ^ 1u)
+			|| !lockModeLedMatches(hardware.getFrontPanelSnapshot(), *toggledLockMode))
+			return fail("Machinedrum lock-mode toggle or LED mapping is wrong");
+		if(!tap(hardware, md::PanelControl::ClassicExtended))
+			return fail("failed to restore Machinedrum lock mode");
+		const auto restoredLockMode = queryLockMode(hardware);
+		if(!restoredLockMode || *restoredLockMode != *initialLockMode
+			|| !lockModeLedMatches(hardware.getFrontPanelSnapshot(), *restoredLockMode))
+			return fail("Machinedrum lock mode did not restore cleanly");
+		return 0;
+	}
+
+	int testSilentRecording(md::Hardware& hardware, const md::PanelPacket& trigger,
+		const md::PanelPacket& player)
+	{
+		// A non-default RAM-R RATE must preserve digital silence. Before MERGE was
+		// implemented, the recorder packed each pair as $000800 instead of $800800;
+		// RAM-P decoded that as a strong alternating tone.
+		setTrack1Parameter(hardware, 7, 64);
+		std::array<std::vector<float>, 2> silentCapture{
+			std::vector<float>(captureFrames), std::vector<float>(captureFrames)};
+		synthLib::TAudioOutputs silentCaptureOutputs{};
+		silentCaptureOutputs[0] = silentCapture[0].data();
+		silentCaptureOutputs[1] = silentCapture[1].data();
+		hardware.sendPanelEvent(trigger.row, trigger.mask);
+		hardware.processAudio(silentCaptureOutputs, captureFrames, 0);
+		hardware.sendPanelEvent(trigger.row, 0);
+		advance(hardware, 4096);
+
+		std::array<std::vector<float>, 2> silentPlayback{
+			std::vector<float>(captureFrames), std::vector<float>(captureFrames)};
+		synthLib::TAudioOutputs silentPlaybackOutputs{};
+		silentPlaybackOutputs[0] = silentPlayback[0].data();
+		silentPlaybackOutputs[1] = silentPlayback[1].data();
+		hardware.sendPanelEvent(player.row, player.mask);
+		hardware.processAudio(silentPlaybackOutputs, captureFrames / 2, 0);
+		hardware.sendPanelEvent(player.row, 0);
+		silentPlaybackOutputs[0] += captureFrames / 2;
+		silentPlaybackOutputs[1] += captureFrames / 2;
+		hardware.processAudio(silentPlaybackOutputs, captureFrames / 2, 0);
+		float silentRamPeak = 0.0f;
+		for(const auto& channel : silentPlayback)
+			for(size_t i = 0; i < channel.size(); ++i)
+			{
+				if(!std::isfinite(channel[i]))
+					return fail("silent RAM playback produced a non-finite sample");
+				if(i >= 4096)
+					silentRamPeak = std::max(silentRamPeak, std::abs(channel[i]));
+			}
+		if(silentRamPeak > 0.0001f)
+			return fail("RAM-R RATE introduced a tone into a silent recording");
+		return 0;
+	}
+
+	int testExternalRecording(md::Hardware& hardware, const md::PanelPacket& trigger,
+		const md::PanelPacket& player, const size_t inputSide)
+	{
+		setTrack1Parameter(hardware, 3, inputSide == 0 ? 0 : 127); // IBAL: A/B only
+		setTrack1Parameter(hardware, 7, 127); // maximum-quality signal capture
+		std::vector<dsp56k::TWord> uwMemoryBefore(uwMemoryEnd - uwMemoryBegin);
+		auto& producerMemory = hardware.getDspProducer().dsp().memory();
+		for(uint32_t address = uwMemoryBegin; address < uwMemoryEnd; ++address)
+			uwMemoryBefore[address - uwMemoryBegin] =
+				producerMemory.get(dsp56k::MemArea_X, address);
+
+		std::array<std::vector<float>, 2> captureInput{
+			std::vector<float>(captureFrames), std::vector<float>(captureFrames)};
+		for(uint32_t i = 0; i < captureFrames; ++i)
+		{
+			const auto phase = static_cast<float>(i % 97) / 97.0f;
+			captureInput[0][i] = phase * 1.0f - 0.5f;
+			captureInput[1][i] = static_cast<float>(i % 151) / 151.0f - 0.5f;
+		}
+		synthLib::TAudioInputs inputs{};
+		inputs[0] = captureInput[0].data();
+		inputs[1] = captureInput[1].data();
+		std::array<std::vector<float>, 2> captureOutput{
+			std::vector<float>(captureFrames), std::vector<float>(captureFrames)};
+		synthLib::TAudioOutputs recordingOutputs{};
+		recordingOutputs[0] = captureOutput[0].data();
+		recordingOutputs[1] = captureOutput[1].data();
+		// The fixture performs long bare advances between host callbacks. Re-prime
+		// the callback look-ahead before measuring synchronization; a real host keeps
+		// this queue continuously fed.
+		hardware.processAudio(recordingOutputs, 0, 1);
+		hardware.processAudio(recordingOutputs, 0, 0);
+		hardware.resetHostAudioInputQueueTelemetry();
+		hardware.sendPanelEvent(trigger.row, trigger.mask);
+		constexpr uint32_t hostBlockFrames = 256;
+		for(uint32_t offset = 0; offset < captureFrames; offset += hostBlockFrames)
+		{
+			hardware.processAudio(inputs, recordingOutputs, hostBlockFrames, 0);
+			for(auto& input : inputs)
+				if(input)
+					input += hostBlockFrames;
+			for(auto& output : recordingOutputs)
+				if(output)
+					output += hostBlockFrames;
+		}
+		hardware.sendPanelEvent(trigger.row, 0);
+		if(hardware.hostAudioInputUnderflowCount() != 0
+			|| hardware.hostAudioInputOverflowCount() != 0)
+		{
+			for(size_t receiver = 0; receiver < 2; ++receiver)
+				std::cerr << "DSP" << receiver + 1 << " codec input underflows="
+					<< hardware.hostAudioInputUnderflowCount(receiver) << ", overflows="
+					<< hardware.hostAudioInputOverflowCount(receiver) << '\n';
+			return fail("RAM-R capture lost synchronization with the codec input bus");
+		}
+		advance(hardware, 4096);
+		size_t changedUwWords = 0;
+		for(uint32_t address = uwMemoryBegin; address < uwMemoryEnd; ++address)
+			if(uwMemoryBefore[address - uwMemoryBegin]
+				!= producerMemory.get(dsp56k::MemArea_X, address))
+				++changedUwWords;
+		if(changedUwWords < 100)
+			return fail("RAM-R1 did not write a recording into UW sample memory");
+
+		std::array<std::vector<float>, 2> ramRendered{
+			std::vector<float>(captureFrames), std::vector<float>(captureFrames)};
+		synthLib::TAudioOutputs ramOutputs{};
+		ramOutputs[0] = ramRendered[0].data();
+		ramOutputs[1] = ramRendered[1].data();
+		hardware.sendPanelEvent(player.row, player.mask);
+		hardware.processAudio(ramOutputs, captureFrames / 2, 0);
+		hardware.sendPanelEvent(player.row, 0);
+		ramOutputs[0] += captureFrames / 2;
+		ramOutputs[1] += captureFrames / 2;
+		hardware.processAudio(ramOutputs, captureFrames / 2, 0);
+
+		float ramPeak = 0.0f;
+		for(const auto& channel : ramRendered)
+			for(const auto sample : channel)
+				ramPeak = std::max(ramPeak, std::abs(sample));
+		if(ramPeak < 0.001f)
+			return fail("RAM-P1 produced no audible recording from the external input");
+		if(!recordedWaveformMatches(ramRendered, inputSide == 0 ? 97 : 151,
+			inputSide == 0 ? 151 : 97))
+			return fail("RAM-P1 did not preserve the selected external input waveform");
+		std::cout << "RAM input " << inputSide << " peak=" << ramPeak << '\n';
+		return 0;
+	}
+
+	int testEmptyMainMixLink(md::Hardware& hardware)
+	{
+		// DSP2 receives the main mix over ESSI0; external codec input uses ESSI1.
+		// With no wire word pending, an RX tick must not reuse its retained RX word,
+		// assert RDF, or trigger DMA: repeated retained words become pitched tones in
+		// a recording. Rewire only after the audio checks because this deliberately
+		// consumes the live test transport.
+		auto& recorderLink = hardware.getDspProducer().getPeriph().getEssi0();
+		if(!recorderLink.isFastLinkRx() || !recorderLink.hasEnabledReceivers())
+			return fail("RAM-R DSP2 receive link was not active");
+		auto& recorderInput = recorderLink.getAudioInputs();
+		while(!recorderInput.empty())
+			recorderInput.pop_front();
+		const auto emptyLinkReads = std::make_shared<uint32_t>(0);
+		recorderLink.setReadRxCallback(
+			[emptyLinkReads](uint64_t& _frameIndex, dsp56k::Audio::RxFrame& _frame)
+			{
+				++*emptyLinkReads;
+				_frame.clear();
+				++_frameIndex;
+			});
+		recorderLink.execRX();
+		if(*emptyLinkReads != 0)
+			return fail("RAM-R DSP2 fabricated an RX edge on an empty serial link");
+		return 0;
 	}
 }
 
@@ -407,25 +693,8 @@ static int runFirmwareTest(const char* const firmwarePath)
 	auto& hardware = *hardwareStorage;
 	advance(hardware, md::g_samplerate * 20);
 
-	// Tie the UI labels to firmware's own named lock-mode status rather than to
-	// an assumed panel-bit order. This catches a Classic/Extended label swap
-	// without having to construct and save two kits and patterns.
-	const auto initialLockMode = queryLockMode(hardware);
-	if(!initialLockMode
-		|| !lockModeLedMatches(hardware.getFrontPanelSnapshot(), *initialLockMode))
-		return fail("Machinedrum lock-mode LEDs disagree with firmware status");
-	if(!tap(hardware, md::PanelControl::ClassicExtended))
-		return fail("failed to toggle Machinedrum lock mode");
-	const auto toggledLockMode = queryLockMode(hardware);
-	if(!toggledLockMode || *toggledLockMode != (*initialLockMode ^ 1u)
-		|| !lockModeLedMatches(hardware.getFrontPanelSnapshot(), *toggledLockMode))
-		return fail("Machinedrum lock-mode toggle or LED mapping is wrong");
-	if(!tap(hardware, md::PanelControl::ClassicExtended))
-		return fail("failed to restore Machinedrum lock mode");
-	const auto restoredLockMode = queryLockMode(hardware);
-	if(!restoredLockMode || *restoredLockMode != *initialLockMode
-		|| !lockModeLedMatches(hardware.getFrontPanelSnapshot(), *restoredLockMode))
-		return fail("Machinedrum lock mode did not restore cleanly");
+	if(testLockMode(hardware))
+		return 1;
 
 	if(!tap(hardware, md::PanelControl::Kit)
 		|| !tap(hardware, md::PanelControl::Down)
@@ -473,7 +742,11 @@ static int runFirmwareTest(const char* const firmwarePath)
 	float peak = 0.0f;
 	for(const auto& channel : rendered)
 		for(const auto sample : channel)
+		{
+			if(!std::isfinite(sample))
+				return fail("factory ROM machine produced a non-finite sample");
 			peak = std::max(peak, std::abs(sample));
+		}
 	if(peak < 0.001f)
 		return fail("factory ROM machine produced no audible output");
 
@@ -489,154 +762,30 @@ static int runFirmwareTest(const char* const firmwarePath)
 	setTrack1Parameter(hardware, 4, 0);   // CUE1 off
 	setTrack1Parameter(hardware, 5, 0);   // CUE2 off
 	setTrack1Parameter(hardware, 6, 4);   // LEN: one sequencer step
-	constexpr uint32_t uwMemoryBegin = 0x180000;
-	constexpr uint32_t uwMemoryEnd = 0x200000;
-	constexpr uint32_t captureFrames = 16384;
 	const auto player = md::panelPacket(md::MachineModel::Machinedrum,
 		md::PanelControl::Trigger2);
 	if(!player)
 		return fail("trigger 2 has no panel mapping");
 
-	// A non-default RAM-R RATE must preserve digital silence. Before MERGE was
-	// implemented, the recorder packed each pair as $000800 instead of $800800;
-	// RAM-P decoded that as a strong alternating tone.
-	setTrack1Parameter(hardware, 7, 64);
-	std::array<std::vector<float>, 2> silentCapture{
-		std::vector<float>(captureFrames), std::vector<float>(captureFrames)};
-	synthLib::TAudioOutputs silentCaptureOutputs{};
-	silentCaptureOutputs[0] = silentCapture[0].data();
-	silentCaptureOutputs[1] = silentCapture[1].data();
-	hardware.sendPanelEvent(trigger->row, trigger->mask);
-	hardware.processAudio(silentCaptureOutputs, captureFrames, 0);
-	hardware.sendPanelEvent(trigger->row, 0);
-	advance(hardware, 4096);
+	if(testSilentRecording(hardware, *trigger, *player))
+		return 1;
 
-	std::array<std::vector<float>, 2> silentPlayback{
-		std::vector<float>(captureFrames), std::vector<float>(captureFrames)};
-	synthLib::TAudioOutputs silentPlaybackOutputs{};
-	silentPlaybackOutputs[0] = silentPlayback[0].data();
-	silentPlaybackOutputs[1] = silentPlayback[1].data();
-	hardware.sendPanelEvent(player->row, player->mask);
-	hardware.processAudio(silentPlaybackOutputs, captureFrames / 2, 0);
-	hardware.sendPanelEvent(player->row, 0);
-	silentPlaybackOutputs[0] += captureFrames / 2;
-	silentPlaybackOutputs[1] += captureFrames / 2;
-	hardware.processAudio(silentPlaybackOutputs, captureFrames / 2, 0);
-	float silentRamPeak = 0.0f;
-	for(const auto& channel : silentPlayback)
-		for(auto sample = channel.begin() + 4096; sample != channel.end(); ++sample)
-			silentRamPeak = std::max(silentRamPeak, std::abs(*sample));
-	if(silentRamPeak > 0.0001f)
-		return fail("RAM-R RATE introduced a tone into a silent recording");
+	if(testExternalRecording(hardware, *trigger, *player, 0)
+		|| testExternalRecording(hardware, *trigger, *player, 1))
+		return 1;
 
-	setTrack1Parameter(hardware, 7, 127); // maximum-quality signal capture
-	std::vector<dsp56k::TWord> uwMemoryBefore(uwMemoryEnd - uwMemoryBegin);
-	auto& producerMemory = hardware.getDspProducer().dsp().memory();
-	for(uint32_t address = uwMemoryBegin; address < uwMemoryEnd; ++address)
-		uwMemoryBefore[address - uwMemoryBegin] =
-			producerMemory.get(dsp56k::MemArea_X, address);
-
-	std::array<std::vector<float>, 2> captureInput{
-		std::vector<float>(captureFrames), std::vector<float>(captureFrames)};
-	for(uint32_t i = 0; i < captureFrames; ++i)
-	{
-		const auto phase = static_cast<float>(i % 97) / 97.0f;
-		captureInput[0][i] = phase * 1.0f - 0.5f;
-		captureInput[1][i] = captureInput[0][i];
-	}
-	synthLib::TAudioInputs inputs{};
-	inputs[0] = captureInput[0].data();
-	inputs[1] = captureInput[1].data();
-	std::array<std::vector<float>, 2> captureOutput{
-		std::vector<float>(captureFrames), std::vector<float>(captureFrames)};
-	synthLib::TAudioOutputs recordingOutputs{};
-	recordingOutputs[0] = captureOutput[0].data();
-	recordingOutputs[1] = captureOutput[1].data();
-	// The fixture performs long bare advances between host callbacks. Re-prime
-	// the callback look-ahead before measuring synchronization; a real host keeps
-	// this queue continuously fed.
-	hardware.processAudio(recordingOutputs, 0, 1);
-	hardware.processAudio(recordingOutputs, 0, 0);
-	hardware.resetHostAudioInputQueueTelemetry();
-	hardware.sendPanelEvent(trigger->row, trigger->mask);
-	constexpr uint32_t hostBlockFrames = 256;
-	for(uint32_t offset = 0; offset < captureFrames; offset += hostBlockFrames)
-	{
-		hardware.processAudio(inputs, recordingOutputs, hostBlockFrames, 0);
-		for(auto& input : inputs)
-			if(input)
-				input += hostBlockFrames;
-		for(auto& output : recordingOutputs)
-			if(output)
-				output += hostBlockFrames;
-	}
-	hardware.sendPanelEvent(trigger->row, 0);
-	if(hardware.hostAudioInputUnderflowCount() != 0
-		|| hardware.hostAudioInputOverflowCount() != 0)
-	{
-		std::cerr << "codec input underflows="
-			<< hardware.hostAudioInputUnderflowCount() << ", overflows="
-			<< hardware.hostAudioInputOverflowCount() << '\n';
-		return fail("RAM-R capture lost synchronization with the codec input bus");
-	}
-	advance(hardware, 4096);
-	size_t changedUwWords = 0;
-	for(uint32_t address = uwMemoryBegin; address < uwMemoryEnd; ++address)
-		if(uwMemoryBefore[address - uwMemoryBegin]
-			!= producerMemory.get(dsp56k::MemArea_X, address))
-			++changedUwWords;
-	if(changedUwWords < 100)
-		return fail("RAM-R1 did not write a recording into UW sample memory");
-
-	std::array<std::vector<float>, 2> ramRendered{
-		std::vector<float>(captureFrames), std::vector<float>(captureFrames)};
-	synthLib::TAudioOutputs ramOutputs{};
-	ramOutputs[0] = ramRendered[0].data();
-	ramOutputs[1] = ramRendered[1].data();
-	hardware.sendPanelEvent(player->row, player->mask);
-	hardware.processAudio(ramOutputs, captureFrames / 2, 0);
-	hardware.sendPanelEvent(player->row, 0);
-	ramOutputs[0] += captureFrames / 2;
-	ramOutputs[1] += captureFrames / 2;
-	hardware.processAudio(ramOutputs, captureFrames / 2, 0);
-
-	float ramPeak = 0.0f;
-	for(const auto& channel : ramRendered)
-		for(const auto sample : channel)
-			ramPeak = std::max(ramPeak, std::abs(sample));
-	if(ramPeak < 0.001f)
-		return fail("RAM-P1 produced no audible recording from the external input");
-
-	// DSP2 receives the RAM-R input stream over the synchronous ESSI0 link.
-	// With no wire word pending, an RX tick must not reuse its retained RX word,
-	// assert RDF, or trigger DMA: repeated retained words become pitched tones in
-	// a recording. Rewire only after the audio checks because this deliberately
-	// consumes the live test transport.
-	auto& recorderLink = hardware.getDspProducer().getPeriph().getEssi0();
-	if(!recorderLink.isFastLinkRx() || !recorderLink.hasEnabledReceivers())
-		return fail("RAM-R DSP2 receive link was not active");
-	auto& recorderInput = recorderLink.getAudioInputs();
-	while(!recorderInput.empty())
-		recorderInput.pop_front();
-	uint32_t emptyLinkReads = 0;
-	recorderLink.setReadRxCallback(
-		[&emptyLinkReads](uint64_t& _frameIndex, dsp56k::Audio::RxFrame& _frame)
-		{
-			++emptyLinkReads;
-			_frame.clear();
-			++_frameIndex;
-		});
-	recorderLink.execRX();
-	if(emptyLinkReads != 0)
-		return fail("RAM-R DSP2 fabricated an RX edge on an empty serial link");
+	if(testEmptyMainMixLink(hardware))
+		return 1;
 
 	std::cout << "Machinedrum UW ROM/RAM firmware test passed; ROM peak="
-		<< peak << ", RAM peak=" << ramPeak << '\n';
+		<< peak << '\n';
 	return 0;
 }
 
 int main(const int argc, const char* const* argv)
 {
+	if(argc == 2 && std::string(argv[1]) == "--audio-oracle")
+		return testAudioOracle() ? 0 : fail("RAM audio oracle accepted corrupt audio or rejected its reference");
 	if(argc > 2)
 	{
 		std::cerr << "usage: mdUwFirmwareTest [elektron_sps1-1uw_os1.63.bin]\n";

--- a/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
+++ b/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
@@ -489,16 +489,53 @@ static int runFirmwareTest(const char* const firmwarePath)
 	setTrack1Parameter(hardware, 4, 0);   // CUE1 off
 	setTrack1Parameter(hardware, 5, 0);   // CUE2 off
 	setTrack1Parameter(hardware, 6, 4);   // LEN: one sequencer step
-	setTrack1Parameter(hardware, 7, 127); // RATE: maximum quality
 	constexpr uint32_t uwMemoryBegin = 0x180000;
 	constexpr uint32_t uwMemoryEnd = 0x200000;
+	constexpr uint32_t captureFrames = 16384;
+	const auto player = md::panelPacket(md::MachineModel::Machinedrum,
+		md::PanelControl::Trigger2);
+	if(!player)
+		return fail("trigger 2 has no panel mapping");
+
+	// A non-default RAM-R RATE must preserve digital silence. Before MERGE was
+	// implemented, the recorder packed each pair as $000800 instead of $800800;
+	// RAM-P decoded that as a strong alternating tone.
+	setTrack1Parameter(hardware, 7, 64);
+	std::array<std::vector<float>, 2> silentCapture{
+		std::vector<float>(captureFrames), std::vector<float>(captureFrames)};
+	synthLib::TAudioOutputs silentCaptureOutputs{};
+	silentCaptureOutputs[0] = silentCapture[0].data();
+	silentCaptureOutputs[1] = silentCapture[1].data();
+	hardware.sendPanelEvent(trigger->row, trigger->mask);
+	hardware.processAudio(silentCaptureOutputs, captureFrames, 0);
+	hardware.sendPanelEvent(trigger->row, 0);
+	advance(hardware, 4096);
+
+	std::array<std::vector<float>, 2> silentPlayback{
+		std::vector<float>(captureFrames), std::vector<float>(captureFrames)};
+	synthLib::TAudioOutputs silentPlaybackOutputs{};
+	silentPlaybackOutputs[0] = silentPlayback[0].data();
+	silentPlaybackOutputs[1] = silentPlayback[1].data();
+	hardware.sendPanelEvent(player->row, player->mask);
+	hardware.processAudio(silentPlaybackOutputs, captureFrames / 2, 0);
+	hardware.sendPanelEvent(player->row, 0);
+	silentPlaybackOutputs[0] += captureFrames / 2;
+	silentPlaybackOutputs[1] += captureFrames / 2;
+	hardware.processAudio(silentPlaybackOutputs, captureFrames / 2, 0);
+	float silentRamPeak = 0.0f;
+	for(const auto& channel : silentPlayback)
+		for(auto sample = channel.begin() + 4096; sample != channel.end(); ++sample)
+			silentRamPeak = std::max(silentRamPeak, std::abs(*sample));
+	if(silentRamPeak > 0.0001f)
+		return fail("RAM-R RATE introduced a tone into a silent recording");
+
+	setTrack1Parameter(hardware, 7, 127); // maximum-quality signal capture
 	std::vector<dsp56k::TWord> uwMemoryBefore(uwMemoryEnd - uwMemoryBegin);
 	auto& producerMemory = hardware.getDspProducer().dsp().memory();
 	for(uint32_t address = uwMemoryBegin; address < uwMemoryEnd; ++address)
 		uwMemoryBefore[address - uwMemoryBegin] =
 			producerMemory.get(dsp56k::MemArea_X, address);
 
-	constexpr uint32_t captureFrames = 16384;
 	std::array<std::vector<float>, 2> captureInput{
 		std::vector<float>(captureFrames), std::vector<float>(captureFrames)};
 	for(uint32_t i = 0; i < captureFrames; ++i)
@@ -515,6 +552,12 @@ static int runFirmwareTest(const char* const firmwarePath)
 	synthLib::TAudioOutputs recordingOutputs{};
 	recordingOutputs[0] = captureOutput[0].data();
 	recordingOutputs[1] = captureOutput[1].data();
+	// The fixture performs long bare advances between host callbacks. Re-prime
+	// the callback look-ahead before measuring synchronization; a real host keeps
+	// this queue continuously fed.
+	hardware.processAudio(recordingOutputs, 0, 1);
+	hardware.processAudio(recordingOutputs, 0, 0);
+	hardware.resetHostAudioInputQueueTelemetry();
 	hardware.sendPanelEvent(trigger->row, trigger->mask);
 	constexpr uint32_t hostBlockFrames = 256;
 	for(uint32_t offset = 0; offset < captureFrames; offset += hostBlockFrames)
@@ -528,6 +571,14 @@ static int runFirmwareTest(const char* const firmwarePath)
 				output += hostBlockFrames;
 	}
 	hardware.sendPanelEvent(trigger->row, 0);
+	if(hardware.hostAudioInputUnderflowCount() != 0
+		|| hardware.hostAudioInputOverflowCount() != 0)
+	{
+		std::cerr << "codec input underflows="
+			<< hardware.hostAudioInputUnderflowCount() << ", overflows="
+			<< hardware.hostAudioInputOverflowCount() << '\n';
+		return fail("RAM-R capture lost synchronization with the codec input bus");
+	}
 	advance(hardware, 4096);
 	size_t changedUwWords = 0;
 	for(uint32_t address = uwMemoryBegin; address < uwMemoryEnd; ++address)
@@ -537,10 +588,6 @@ static int runFirmwareTest(const char* const firmwarePath)
 	if(changedUwWords < 100)
 		return fail("RAM-R1 did not write a recording into UW sample memory");
 
-	const auto player = md::panelPacket(md::MachineModel::Machinedrum,
-		md::PanelControl::Trigger2);
-	if(!player)
-		return fail("trigger 2 has no panel mapping");
 	std::array<std::vector<float>, 2> ramRendered{
 		std::vector<float>(captureFrames), std::vector<float>(captureFrames)};
 	synthLib::TAudioOutputs ramOutputs{};

--- a/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
+++ b/source/elektron/md/mdLibTest/mdUwFirmwareTest.cpp
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace md
@@ -100,6 +101,43 @@ namespace
 		event.sysex.assign(_bytes.begin(), _bytes.end());
 		_hardware.sendMidi(event);
 		advance(_hardware, 8192);
+	}
+
+	std::optional<uint8_t> queryLockMode(md::Hardware& _hardware)
+	{
+		// OS 1.63 Appendix C: status parameter 0x20 is the MD lock mode,
+		// reported as 0 for Classic and 1 for Extended.
+		std::vector<synthLib::SMidiEvent> discarded;
+		_hardware.readMidiOut(discarded);
+		synthLib::SMidiEvent request(synthLib::MidiEventSource::Host);
+		request.sysex =
+			{0xf0, 0x00, 0x20, 0x3c, 0x02, 0x00, 0x70, 0x20, 0xf7};
+		_hardware.sendMidi(request);
+
+		for(uint32_t attempt = 0; attempt < 8; ++attempt)
+		{
+			advance(_hardware, 2048);
+			std::vector<synthLib::SMidiEvent> events;
+			_hardware.readMidiOut(events);
+			for(const auto& event : events)
+			{
+				const auto& message = event.sysex;
+				if(message.size() == 10
+					&& message[0] == 0xf0 && message[1] == 0x00
+					&& message[2] == 0x20 && message[3] == 0x3c
+					&& message[4] == 0x02 && message[5] == 0x00
+					&& message[6] == 0x72 && message[7] == 0x20
+					&& message[8] <= 1 && message[9] == 0xf7)
+					return message[8];
+			}
+		}
+		return std::nullopt;
+	}
+
+	bool lockModeLedMatches(const md::FrontPanel& _panel, const uint8_t _mode)
+	{
+		const uint8_t raw = _panel.getLedBankRaw(md::FrontPanel::LedBank::Mode);
+		return (raw & 0x03u) == (_mode == 0 ? 0x02u : 0x01u);
 	}
 
 	void assignUwMachine(md::Hardware& _hardware, const uint8_t _track,
@@ -369,6 +407,26 @@ static int runFirmwareTest(const char* const firmwarePath)
 	auto& hardware = *hardwareStorage;
 	advance(hardware, md::g_samplerate * 20);
 
+	// Tie the UI labels to firmware's own named lock-mode status rather than to
+	// an assumed panel-bit order. This catches a Classic/Extended label swap
+	// without having to construct and save two kits and patterns.
+	const auto initialLockMode = queryLockMode(hardware);
+	if(!initialLockMode
+		|| !lockModeLedMatches(hardware.getFrontPanelSnapshot(), *initialLockMode))
+		return fail("Machinedrum lock-mode LEDs disagree with firmware status");
+	if(!tap(hardware, md::PanelControl::ClassicExtended))
+		return fail("failed to toggle Machinedrum lock mode");
+	const auto toggledLockMode = queryLockMode(hardware);
+	if(!toggledLockMode || *toggledLockMode != (*initialLockMode ^ 1u)
+		|| !lockModeLedMatches(hardware.getFrontPanelSnapshot(), *toggledLockMode))
+		return fail("Machinedrum lock-mode toggle or LED mapping is wrong");
+	if(!tap(hardware, md::PanelControl::ClassicExtended))
+		return fail("failed to restore Machinedrum lock mode");
+	const auto restoredLockMode = queryLockMode(hardware);
+	if(!restoredLockMode || *restoredLockMode != *initialLockMode
+		|| !lockModeLedMatches(hardware.getFrontPanelSnapshot(), *restoredLockMode))
+		return fail("Machinedrum lock mode did not restore cleanly");
+
 	if(!tap(hardware, md::PanelControl::Kit)
 		|| !tap(hardware, md::PanelControl::Down)
 		|| !tap(hardware, md::PanelControl::Enter))
@@ -501,6 +559,29 @@ static int runFirmwareTest(const char* const firmwarePath)
 			ramPeak = std::max(ramPeak, std::abs(sample));
 	if(ramPeak < 0.001f)
 		return fail("RAM-P1 produced no audible recording from the external input");
+
+	// DSP2 receives the RAM-R input stream over the synchronous ESSI0 link.
+	// With no wire word pending, an RX tick must not reuse its retained RX word,
+	// assert RDF, or trigger DMA: repeated retained words become pitched tones in
+	// a recording. Rewire only after the audio checks because this deliberately
+	// consumes the live test transport.
+	auto& recorderLink = hardware.getDspProducer().getPeriph().getEssi0();
+	if(!recorderLink.isFastLinkRx() || !recorderLink.hasEnabledReceivers())
+		return fail("RAM-R DSP2 receive link was not active");
+	auto& recorderInput = recorderLink.getAudioInputs();
+	while(!recorderInput.empty())
+		recorderInput.pop_front();
+	uint32_t emptyLinkReads = 0;
+	recorderLink.setReadRxCallback(
+		[&emptyLinkReads](uint64_t& _frameIndex, dsp56k::Audio::RxFrame& _frame)
+		{
+			++emptyLinkReads;
+			_frame.clear();
+			++_frameIndex;
+		});
+	recorderLink.execRX();
+	if(emptyLinkReads != 0)
+		return fail("RAM-R DSP2 fabricated an RX edge on an empty serial link");
 
 	std::cout << "Machinedrum UW ROM/RAM firmware test passed; ROM peak="
 		<< peak << ", RAM peak=" << ramPeak << '\n';


### PR DESCRIPTION
Machinedrum's Classic/Extended UI labels were reversed, and RAM recording suffered from malformed sample packing and missing external input on DSP2. This corrects the mode labels, sends an independent copy of the codec ADC input to each MD DSP, prevents empty MD DSP2 ESSI0 links from fabricating receive edges, and advances the DSP submodule for MERGE and 24-bit DMA address wrapping. Monomachine retains its existing DSP2 silence producer.

Input queue telemetry now reports each DSP separately, with consistent summed receiver-frame totals. The firmware regression is organized into mode, silent recording, external recording, and empty-link functions. Distinct A/B saw inputs and both IBAL extremes verify waveform fidelity and input selection, beyond checking for audible output.

Validation:

- Fresh ARM64 Release build: DSP assembler/interpreter/JIT/optimizer suites, mdLibTest, mdAudioQueueTest, mdRamAudioOracleTest, mdUwFirmwareTest, and mdAudioFirmwareTest passed with MD UW OS 1.63.
- RATE 64 silent playback stays below 0.0001. RATE 127 external A/B recordings correlate above 0.99 with the selected source in consecutive windows on both output channels; the other-source correlation remains below 0.20. Both captures have zero input queue underflows/overflows.
- The firmware-free audio-oracle test rejects silence, transients, alternating noise, swapped input waveforms, NaN, and infinity. Its translation unit disables fast-math to retain meaningful non-finite checks.
- Randomized Legacy/MameHq/MameLofi scheduler/resampler soak passed at 44.1, 48, and 96 kHz. DSP suites also passed in an x86-64 Release build under Rosetta, including the expanded MERGE and DMA boundary regressions.

Merge dependency first: https://github.com/joelanders/dsp56300-md-mm/pull/5

`doc/md_ram_audio_validation.md` records the evidence and remaining hardware timing, long-capture/lifecycle, older-firmware, and Monomachine-fixture gaps. Waveform matching allows phase and gain differences; it does not claim calibrated hardware latency or gain.
