### PR TITLE
Fix LCD aspect ratio and add optional crisp panel rendering

### DIFF
--- a/.github/workflows/mdmm-audio-io.yml
+++ b/.github/workflows/mdmm-audio-io.yml
@@ -204,7 +204,7 @@ jobs:
           cmake --build build --config Release --parallel 4
           --target midiLearnTest midiOutputDispatcherTest mdAutomationParameterTest
           mdAutomationRobustnessTest mdAudioIoLayoutTest
-          mdFrontPanelPresentationTest pluginTester
+          mdFrontPanelPresentationTest mdPanelRenderingTest pluginTester
           mdJucePlugin_VST3 mmJucePlugin_VST3 mdAudioProbePlugin_VST3
           synthLibAudioTest mdAudioQueueTest mdAudioFirmwareTest
           mdUwFirmwareTest
@@ -212,4 +212,4 @@ jobs:
       - name: Run processor and built-plugin tests
         run: >-
           ctest --test-dir build -C Release --output-on-failure
-          --tests-regex "^(midiLearnTests|midiOutputDispatcherTest|mdAutomationParameterTest|mdAutomationArchitectureTest|mdAudioIoLayoutTest|mdFrontPanelPresentationTests|mdJucePlugin_VST3AudioIoTest|mmJucePlugin_VST3AudioIoTest|mdAudioProbePluginVST3IdentityTest|synthLibAudioTest|mdAudioQueueTest|mdAudioFirmwareTest|mdUwFirmwareTest)$"
+          --tests-regex "^(midiLearnTests|midiOutputDispatcherTest|mdAutomationParameterTest|mdAutomationArchitectureTest|mdAudioIoLayoutTest|mdFrontPanelPresentationTests|mdPanelRenderingTest|mdJucePlugin_VST3AudioIoTest|mmJucePlugin_VST3AudioIoTest|mdAudioProbePluginVST3IdentityTest|synthLibAudioTest|mdAudioQueueTest|mdAudioFirmwareTest|mdUwFirmwareTest)$"

--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCES
 	mdController.cpp mdController.h
 	mdEditor.cpp mdEditor.h
 	mdFrontPanelPresentation.h
+	mdPixelPerfectPanel.h
 	mdPanelAffordances.h
 	mdPluginEditorState.cpp mdPluginEditorState.h
 	mdProductSkinPolicy.h

--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -18,7 +18,7 @@ set(SOURCES
 	mdController.cpp mdController.h
 	mdEditor.cpp mdEditor.h
 	mdFrontPanelPresentation.h
-	mdPixelPerfectPanel.h
+	mdPixelPerfectPanel.cpp mdPixelPerfectPanel.h
 	mdPanelAffordances.h
 	mdPluginEditorState.cpp mdPluginEditorState.h
 	mdProductSkinPolicy.h
@@ -88,6 +88,13 @@ endif()
 target_compile_definitions(mmJucePlugin PRIVATE MD_JUCEPLUGIN_MONOMACHINE=1)
 
 if(BUILD_TESTING)
+	add_executable(mdPanelRenderingTest mdPanelRenderingTest.cpp mdPixelPerfectPanel.cpp)
+	target_link_libraries(mdPanelRenderingTest PRIVATE juceRmlUi juceUiLib juce_plugin_modules juce::juce_opengl)
+	target_compile_definitions(mdPanelRenderingTest PRIVATE JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1)
+	add_test(NAME mdPanelRenderingTest COMMAND mdPanelRenderingTest)
+	set_tests_properties(mdPanelRenderingTest PROPERTIES LABELS "UnitTest;Rendering")
+	set_property(TARGET mdPanelRenderingTest PROPERTY FOLDER "Elektron/test")
+
 	juce_add_plugin(mdAudioProbePlugin
 		COMPANY_NAME "Gearmulator"
 		IS_SYNTH TRUE

--- a/source/elektron/md/mdJucePlugin/PANEL_RENDERING_EXPERIMENT.md
+++ b/source/elektron/md/mdJucePlugin/PANEL_RENDERING_EXPERIMENT.md
@@ -1,0 +1,46 @@
+# Crisp panel rendering experiment
+
+`PixelPerfectPanel` owns the experiment's state, helper elements and LCD drawing
+policy. Its only editor hooks are `applyPixelPerfectPanel()` and the optional
+`paintLcd()` call before normal aspect-fit drawing. It has no audio/DSP, firmware,
+panel-input or state-chunk dependencies.
+
+The config key and default live in `mdPixelPerfectPanel.h`. The checkbox and editor
+both use those constants, so changing the default cannot make their states disagree.
+Explicitly saved choices take precedence. The experiment defaults off.
+
+Only static, flat rules marked `elektronPixelRule` in the bundled skins participate.
+Unmarked 1dp elements are untouched. The controller tracks helpers with RML observer
+pointers so deleting a marked element does not leave a dangling pointer. Destruction
+restores original backgrounds, removes helpers and disables its canvas/density options.
+The controller must be destroyed before its RML core, as it is in `Editor`.
+
+## Promote
+
+Change `PixelPerfectPanel::defaultEnabled` and the experimental checkbox wording.
+Keep the opt-out initially and preserve explicit saved choices. Before promotion,
+validate GPU output, actual monitor migration and rendering CPU cost on older Intel
+machines. At 2x density, software rendering covers four times as many pixels.
+
+## Remove
+
+Remove the two editor hooks, controller member/forward declaration, settings binding
+and checkbox markup; remove `mdPixelPerfectPanel.{h,cpp}` and its CMake entry.
+The `elektronPixelRule` markers can also be removed (they have no style or behavior
+by themselves). Existing saved config keys become inert and need no migration.
+Remove the experiment-specific parts of `mdPanelRenderingTest` with the controller.
+
+Keep the independent LCD aspect-ratio correction and stable settings-template
+suffix fix. Neither depends on `PixelPerfectPanel`. Shared canvas pixel alignment,
+optional backing-density support and configurable checkbox defaults are reusable
+capabilities with existing behavior as their default; they can remain without an
+MD/MM caller. The queued-frame scale fix is independently useful and should stay.
+
+## Verification
+
+`mdPanelRenderingTest` is a firmware-free software-renderer integration test. It
+checks already queued frames during toggles/density changes, exact integer LCD
+blocks, restoration of baseline pixels, pointer mapping, padded-texture fallback,
+explicit rule selection, DOM removal and controller teardown. The macOS VST3 CI
+job builds and runs it. Full MD/MM embedded-skin comparisons are additionally
+recorded in the local durable review notes; GPU screenshots are not covered here.

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -4,6 +4,7 @@
 #include "mdPanelAffordances.h"
 #include "mdPluginProcessor.h"
 #include "mdSettingsPanelFeel.h"
+#include "mdPixelPerfectPanel.h"
 
 #include "jucePluginEditorLib/pluginProcessor.h"
 #include "jucePluginEditorLib/fileChooserFlow.h"
@@ -32,6 +33,7 @@
 
 #include "RmlUi/Core/Element.h"
 #include "RmlUi/Core/ElementDocument.h"
+#include "RmlUi/Core/Factory.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -279,6 +281,7 @@ namespace mdJucePlugin
 		applyPanelSpeeds();
 		createLeds();
 		createPanelAffordances();
+		applyPixelPerfectPanel();
 
 		// A transfer belongs to the emulated machine, not the lifetime of one
 		// editor window. Reattach progress monitoring after a reopen, or reclaim a
@@ -328,6 +331,55 @@ namespace mdJucePlugin
 		startTimer(g_presentationTimerId,
 			g_presentationTimerIntervalMilliseconds);
 		startTimer(g_panelTimerId, g_panelTimerIntervalMilliseconds);
+	}
+
+	void Editor::applyPixelPerfectPanel()
+	{
+		m_pixelPerfectPanel = getProcessor().getConfig().getBoolValue("pixelPerfectPanel", false);
+		if (m_lcdCanvas)
+			m_lcdCanvas->setPixelAligned(m_pixelPerfectPanel);
+
+		auto* doc = getDocument();
+		if (m_pixelPerfectPanel && m_pixelPanelRules.empty() && doc)
+		{
+			static Rml::ElementInstancerGeneric<PixelPanelRule> instancer;
+			doc->GetCoreInstance().factory->RegisterElementInstancer("pixelpanelrule", &instancer);
+			Rml::ElementList elements;
+			doc->GetElementsByTagName(elements, "div");
+			for (auto* element : elements)
+			{
+				// Opt in only leaf rectangles authored as 1dp rules in the panel.
+				// Exclude controls, images, borders and rounded decorations.
+				if (element->GetNumChildren() || !element->IsClassSet("jucePos"))
+					continue;
+				const auto isHairline = [&](Rml::PropertyId _id)
+				{
+					const auto* p = element->GetLocalProperty(_id);
+					return p && p->unit == Rml::Unit::DP && p->Get<float>(doc->GetCoreInstance()) == 1.f;
+				};
+				if (!isHairline(Rml::PropertyId::Width) && !isHairline(Rml::PropertyId::Height))
+					continue;
+				const auto& values = element->GetComputedValues();
+				if (values.background_color().alpha == 0)
+					continue;
+				const auto& box = element->GetBox();
+				bool flat = true;
+				for (int edge = 0; edge < 4; ++edge)
+					flat &= box.GetEdge(Rml::BoxArea::Border, Rml::BoxEdge(edge)) == 0 && values.border_radius()[edge] == 0;
+				if (!flat)
+					continue;
+				auto* rule = static_cast<PixelPanelRule*>(element->AppendChild(doc->CreateElement("pixelpanelrule")));
+				rule->init(*element);
+				m_pixelPanelRules.push_back(rule);
+			}
+		}
+		for (auto* rule : m_pixelPanelRules)
+			rule->setEnabled(m_pixelPerfectPanel);
+		if (auto* component = getRmlComponent())
+		{
+			component->setUseNativePixelDensity(m_pixelPerfectPanel);
+			component->enqueueUpdate();
+		}
 	}
 
 	void Editor::createButtons()
@@ -881,6 +933,11 @@ namespace mdJucePlugin
 		m_soundEncoder = findChild<juceRmlUi::ElemKnob>("encSound", false);
 		configureEncoder(m_soundEncoder, md::PanelEncoder::SoundSelection,
 			m_soundLast, m_soundAccum);
+	}
+
+	std::string Editor::getSettingsTemplateSuffix() const
+	{
+		return getModel() == md::MachineModel::Monomachine ? "Monomachine" : "Machinedrum";
 	}
 
 	std::unique_ptr<jucePluginEditorLib::SettingsDeviceSpecific> Editor::createDeviceSpecificSettings(
@@ -1711,6 +1768,22 @@ namespace mdJucePlugin
 		}
 
 		_g.setImageResamplingQuality(juce::Graphics::lowResamplingQuality);
+		if (m_pixelPerfectPanel)
+		{
+			const auto size = m_lcdCanvas->getPaintSize();
+			const auto scale = std::min(size.x / static_cast<int>(md::FrontPanel::g_lcdWidth),
+				size.y / static_cast<int>(md::FrontPanel::g_lcdHeight));
+			if (scale >= 1)
+			{
+				const auto w = scale * static_cast<int>(md::FrontPanel::g_lcdWidth);
+				const auto h = scale * static_cast<int>(md::FrontPanel::g_lcdHeight);
+				_g.drawImage(lcd, (size.x - w) / 2, (size.y - h) / 2, w, h,
+					0, 0, md::FrontPanel::g_lcdWidth, md::FrontPanel::g_lcdHeight);
+				return;
+			}
+			// Very small windows cannot fit even one native framebuffer. Preserve
+			// all content and its aspect ratio instead of clipping it.
+		}
 		_g.drawImageWithin(lcd,
 			0, 0, _target.getWidth(), _target.getHeight(),
 			juce::RectanglePlacement::centred);

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -1690,11 +1690,11 @@ namespace mdJucePlugin
 		const auto lcdOff = isMonomachine ? g_mmLcdOff : g_mdLcdOff;
 		const auto lcdOn = isMonomachine ? g_mmLcdOn : g_mdLcdOn;
 
+		// The skin's display surround need not have the framebuffer's 2:1 aspect.
+		// Keep spare space the LCD background colour instead of stretching pixels.
+		_g.fillAll(juce::Colour(lcdOff));
 		if(!m_frontPanelSnapshotValid)
-		{
-			_g.fillAll(juce::Colour(lcdOff));
 			return;
-		}
 
 		const auto& fp = m_frontPanelSnapshot;
 
@@ -1710,10 +1710,10 @@ namespace mdJucePlugin
 			}
 		}
 
-		_g.setImageResamplingQuality(juce::Graphics::lowResamplingQuality);	// crisp pixels, no blur
-		_g.drawImage(lcd,
+		_g.setImageResamplingQuality(juce::Graphics::lowResamplingQuality);
+		_g.drawImageWithin(lcd,
 			0, 0, _target.getWidth(), _target.getHeight(),
-			0, 0, static_cast<int>(md::FrontPanel::g_lcdWidth), static_cast<int>(md::FrontPanel::g_lcdHeight));
+			juce::RectanglePlacement::centred);
 	}
 
 	void Editor::timerCallback(const int _timerId)

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -33,7 +33,6 @@
 
 #include "RmlUi/Core/Element.h"
 #include "RmlUi/Core/ElementDocument.h"
-#include "RmlUi/Core/Factory.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -335,50 +334,12 @@ namespace mdJucePlugin
 
 	void Editor::applyPixelPerfectPanel()
 	{
-		m_pixelPerfectPanel = getProcessor().getConfig().getBoolValue("pixelPerfectPanel", false);
-		if (m_lcdCanvas)
-			m_lcdCanvas->setPixelAligned(m_pixelPerfectPanel);
-
-		auto* doc = getDocument();
-		if (m_pixelPerfectPanel && m_pixelPanelRules.empty() && doc)
-		{
-			static Rml::ElementInstancerGeneric<PixelPanelRule> instancer;
-			doc->GetCoreInstance().factory->RegisterElementInstancer("pixelpanelrule", &instancer);
-			Rml::ElementList elements;
-			doc->GetElementsByTagName(elements, "div");
-			for (auto* element : elements)
-			{
-				// Opt in only leaf rectangles authored as 1dp rules in the panel.
-				// Exclude controls, images, borders and rounded decorations.
-				if (element->GetNumChildren() || !element->IsClassSet("jucePos"))
-					continue;
-				const auto isHairline = [&](Rml::PropertyId _id)
-				{
-					const auto* p = element->GetLocalProperty(_id);
-					return p && p->unit == Rml::Unit::DP && p->Get<float>(doc->GetCoreInstance()) == 1.f;
-				};
-				if (!isHairline(Rml::PropertyId::Width) && !isHairline(Rml::PropertyId::Height))
-					continue;
-				const auto& values = element->GetComputedValues();
-				if (values.background_color().alpha == 0)
-					continue;
-				const auto& box = element->GetBox();
-				bool flat = true;
-				for (int edge = 0; edge < 4; ++edge)
-					flat &= box.GetEdge(Rml::BoxArea::Border, Rml::BoxEdge(edge)) == 0 && values.border_radius()[edge] == 0;
-				if (!flat)
-					continue;
-				auto* rule = static_cast<PixelPanelRule*>(element->AppendChild(doc->CreateElement("pixelpanelrule")));
-				rule->init(*element);
-				m_pixelPanelRules.push_back(rule);
-			}
-		}
-		for (auto* rule : m_pixelPanelRules)
-			rule->setEnabled(m_pixelPerfectPanel);
 		if (auto* component = getRmlComponent())
 		{
-			component->setUseNativePixelDensity(m_pixelPerfectPanel);
-			component->enqueueUpdate();
+			if (!m_pixelPerfectPanel)
+				m_pixelPerfectPanel = std::make_unique<PixelPerfectPanel>();
+			m_pixelPerfectPanel->apply(*component, m_lcdCanvas,
+				getProcessor().getConfig().getBoolValue(PixelPerfectPanel::configKey, PixelPerfectPanel::defaultEnabled));
 		}
 	}
 
@@ -1768,22 +1729,8 @@ namespace mdJucePlugin
 		}
 
 		_g.setImageResamplingQuality(juce::Graphics::lowResamplingQuality);
-		if (m_pixelPerfectPanel)
-		{
-			const auto size = m_lcdCanvas->getPaintSize();
-			const auto scale = std::min(size.x / static_cast<int>(md::FrontPanel::g_lcdWidth),
-				size.y / static_cast<int>(md::FrontPanel::g_lcdHeight));
-			if (scale >= 1)
-			{
-				const auto w = scale * static_cast<int>(md::FrontPanel::g_lcdWidth);
-				const auto h = scale * static_cast<int>(md::FrontPanel::g_lcdHeight);
-				_g.drawImage(lcd, (size.x - w) / 2, (size.y - h) / 2, w, h,
-					0, 0, md::FrontPanel::g_lcdWidth, md::FrontPanel::g_lcdHeight);
-				return;
-			}
-			// Very small windows cannot fit even one native framebuffer. Preserve
-			// all content and its aspect ratio instead of clipping it.
-		}
+		if (m_pixelPerfectPanel && m_pixelPerfectPanel->paintLcd(lcd, _g))
+			return;
 		_g.drawImageWithin(lcd,
 			0, 0, _target.getWidth(), _target.getHeight(),
 			juce::RectanglePlacement::centred);

--- a/source/elektron/md/mdJucePlugin/mdEditor.h
+++ b/source/elektron/md/mdJucePlugin/mdEditor.h
@@ -42,6 +42,7 @@ namespace md
 namespace mdJucePlugin
 {
 	class Controller;
+	class PixelPanelRule;
 	struct EditorIdentityTestAccess;
 
 	class Editor final : public jucePluginEditorLib::Editor, juce::MultiTimer,
@@ -62,10 +63,12 @@ namespace mdJucePlugin
 
 		std::unique_ptr<jucePluginEditorLib::SettingsDeviceSpecific> createDeviceSpecificSettings(
 			const std::string& _templateName, Rml::Element* _root) override;
+		std::string getSettingsTemplateSuffix() const override;
 
 		// Reapplies the configured wheel/encoder drag-speed percentages to the
 		// panel knobs. Called on create and from the settings page.
 		void applyPanelSpeeds();
+		void applyPixelPerfectPanel();
 		void loadInstalledFactoryStorage();
 		void chooseStorageImage();
 		void restorePreviousStorage();
@@ -151,6 +154,8 @@ namespace mdJucePlugin
 		Controller& m_controller;
 		const md::MachineModel m_model;
 		juceRmlUi::ElemCanvas* m_lcdCanvas = nullptr;
+		bool m_pixelPerfectPanel = false;
+		std::vector<PixelPanelRule*> m_pixelPanelRules;
 		md::FrontPanel m_frontPanelSnapshot;
 		bool m_frontPanelSnapshotValid = false;
 		bool m_lcdChanged = true;

--- a/source/elektron/md/mdJucePlugin/mdEditor.h
+++ b/source/elektron/md/mdJucePlugin/mdEditor.h
@@ -42,7 +42,7 @@ namespace md
 namespace mdJucePlugin
 {
 	class Controller;
-	class PixelPanelRule;
+	class PixelPerfectPanel;
 	struct EditorIdentityTestAccess;
 
 	class Editor final : public jucePluginEditorLib::Editor, juce::MultiTimer,
@@ -154,8 +154,7 @@ namespace mdJucePlugin
 		Controller& m_controller;
 		const md::MachineModel m_model;
 		juceRmlUi::ElemCanvas* m_lcdCanvas = nullptr;
-		bool m_pixelPerfectPanel = false;
-		std::vector<PixelPanelRule*> m_pixelPanelRules;
+		std::unique_ptr<PixelPerfectPanel> m_pixelPerfectPanel;
 		md::FrontPanel m_frontPanelSnapshot;
 		bool m_frontPanelSnapshotValid = false;
 		bool m_lcdChanged = true;

--- a/source/elektron/md/mdJucePlugin/mdPanelRenderingTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPanelRenderingTest.cpp
@@ -1,0 +1,198 @@
+#include "mdPixelPerfectPanel.h"
+
+#include "juceRmlUi/juceRmlComponent.h"
+#include "juceRmlUi/juceRmlLookAndFeel.h"
+#include "juceRmlUi/rmlDataProvider.h"
+#include "juceRmlUi/rmlElemCanvas.h"
+#include "RmlUi/Core/Context.h"
+#include "RmlUi/Core/ElementDocument.h"
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+
+namespace juceRmlUi
+{
+	struct RenderingTestAccess
+	{
+		static void update(RmlComponent& _component) { _component.update(); }
+		static void requirePaddedTextures(RmlComponent& _component)
+		{
+			_component.m_renderProxy->setTextureParameters(4096, false);
+		}
+	};
+}
+
+namespace
+{
+	void require(bool _condition, const char* _message)
+	{
+		if (!_condition)
+			throw std::runtime_error(_message);
+	}
+
+	class Resources : public juceRmlUi::DataProvider
+	{
+		const std::string rml = R"(<rml><head ><style>
+			body { width: 512dp; height: 256dp; background-color: #8899aa; }
+			div { position: absolute; }
+			</style></head><body>
+			<div id="lcd" style="left: 30.25dp; top: 40.25dp; width: 220.5dp; height: 116.5dp;"/>
+			<div id="rule" class="elektronPixelRule" style="left: 300.25dp; top: 50.25dp; width: 51.25dp; height: 1dp; background-color: #345678;"/>
+			<div id="unmarked" style="left: 300.25dp; top: 60.25dp; width: 51.25dp; height: 1dp; background-color: #345678;"/>
+			<div id="teardown" class="elektronPixelRule" style="left: 300.25dp; top: 70.25dp; width: 51.25dp; height: 1dp; background-color: #345678;"/>
+			<div id="sentinel" style="left: 400dp; top: 200dp; width: 20dp; height: 20dp; background-color: #ff0000;"/>
+			</body></rml>)";
+	public:
+		const char* getResourceByFilename(const std::string& _name, uint32_t& _size) override
+		{
+			_size = static_cast<uint32_t>(rml.size());
+			return _name == "test.rml" ? rml.data() : nullptr;
+		}
+		std::vector<std::string> getAllFilenames() override { return {}; }
+	};
+
+	void samePixels(const juce::Image& _a, const juce::Image& _b)
+	{
+		require(_a.getBounds() == _b.getBounds(), "toggle changed output dimensions");
+		for (int y = 0; y < _a.getHeight(); ++y)
+			for (int x = 0; x < _a.getWidth(); ++x)
+				require(_a.getPixelAt(x, y) == _b.getPixelAt(x, y), "toggle changed a pending frame or failed to restore baseline");
+	}
+
+	void testRendering()
+	{
+		Resources resources;
+		juceRmlUi::RmlInterfaces interfaces(resources);
+		juceRmlUi::RmlComponentConfig config;
+		config.forceSoftwareRenderer = juceRmlUi::SoftwareRendererMode::ForceOn;
+		juceRmlUi::LookAndFeel lookAndFeel;
+		juceRmlUi::RmlComponent component(interfaces, resources, "test.rml", 1.f, {}, {}, config);
+		component.setLookAndFeel(&lookAndFeel);
+		auto* doc = component.getDocument();
+		auto* area = doc->GetElementById("lcd");
+		auto* canvas = juceRmlUi::ElemCanvas::create(area);
+		auto experiment = std::make_unique<mdJucePlugin::PixelPerfectPanel>();
+		juce::Image lcd(juce::Image::ARGB, 128, 64, false);
+		for (int y = 0; y < 64; ++y)
+			for (int x = 0; x < 128; ++x)
+				lcd.setPixelAt(x, y, (x + y) % 2 ? juce::Colours::white : juce::Colours::black);
+		canvas->setRepaintGraphicsCallback([&](juce::Image& _target, juce::Graphics& _g)
+		{
+			_g.fillAll(juce::Colours::green);
+			_g.setImageResamplingQuality(juce::Graphics::lowResamplingQuality);
+			if (!experiment || !experiment->paintLcd(lcd, _g))
+				_g.drawImageWithin(lcd, 0, 0, _target.getWidth(), _target.getHeight(), juce::RectanglePlacement::centred);
+		});
+		auto paint = [&](float _dpi)
+		{
+			juce::Image result(juce::Image::ARGB, static_cast<int>(std::ceil(component.getWidth() * _dpi)),
+				static_cast<int>(std::ceil(component.getHeight() * _dpi)), true);
+			// Exercise both the legacy direct image-copy shortcut and its guarded
+			// fallback when the backing image has a different pixel size.
+			lookAndFeel.getCurrentImage() = result;
+			juce::Graphics g(result);
+			g.addTransform(juce::AffineTransform::scale(_dpi));
+			component.paint(g);
+			return result;
+		};
+		auto settle = [&](float _dpi)
+		{
+			juce::Image result;
+			for (int frame = 0; frame < 6; ++frame)
+			{
+				juceRmlUi::RenderingTestAccess::update(component);
+				result = paint(_dpi);
+			}
+			return result;
+		};
+		for (float dpi : {1.f, 1.25f, 2.f})
+		{
+			const auto baseline = settle(dpi);
+			experiment->apply(component, canvas, true);
+			samePixels(baseline, paint(dpi)); // Paint already queued geometry before any layout update.
+			const auto crisp = settle(dpi);
+			require(doc->GetElementById("unmarked")->GetNumChildren() == 0, "unmarked hairline was altered");
+			require(doc->GetElementById("rule")->GetNumChildren() == 1, "explicit rule was not attached exactly once");
+			const auto size = canvas->getPaintSize();
+			const auto pos = canvas->GetAbsoluteOffset(Rml::BoxArea::Border).Round();
+			const int k = std::min(size.x / 128, size.y / 64);
+			require(k > 0, "test framebuffer should fit");
+			const int ox = static_cast<int>(pos.x) + (size.x - 128 * k) / 2;
+			const int oy = static_cast<int>(pos.y) + (size.y - 64 * k) / 2;
+			const auto black = crisp.getPixelAt(ox, oy), white = crisp.getPixelAt(ox + k, oy);
+			require(black.getBrightness() < .02f && white.getBrightness() > .98f, "LCD palette lost");
+			for (int y = 0; y < 64 * k; ++y)
+				for (int x = 0; x < 128 * k; ++x)
+					require(crisp.getPixelAt(ox + x, oy + y) == ((x / k + y / k) % 2 ? white : black), "unequal or filtered LCD pixels");
+			experiment->apply(component, canvas, false);
+			samePixels(crisp, paint(dpi));
+			samePixels(baseline, settle(dpi));
+		}
+
+		// Display changes can produce another paint before RML lays out a new frame.
+		experiment->apply(component, canvas, true);
+		settle(1.f);
+		const auto firstRetinaPaint = paint(2.f);
+		require(firstRetinaPaint.getPixelAt(820, 420) == juce::Colours::red, "pending frame moved the panel");
+		samePixels(firstRetinaPaint, paint(2.f));
+		settle(2.f);
+		require(component.toRmlPosition(410, 210) == juce::Point<int>(820, 420), "pointer mapping did not follow backing density");
+
+		// Simulate a renderer requiring power-of-two textures and a sub-native LCD.
+		juceRmlUi::RenderingTestAccess::requirePaddedTextures(component);
+		area->SetProperty("width", "80.5dp");
+		area->SetProperty("height", "40.5dp");
+		for (int y = 0; y < 64; ++y)
+			for (int x = 0; x < 128; ++x)
+				lcd.setPixelAt(x, y, y >= 56 ? juce::Colours::blue : x >= 120 ? juce::Colours::red : juce::Colours::white);
+		canvas->repaint();
+		const auto small = settle(1.f);
+		const auto pos = canvas->GetAbsoluteOffset(Rml::BoxArea::Border).Round();
+		const auto right = small.getPixelAt(static_cast<int>(pos.x) + 79, static_cast<int>(pos.y) + 10);
+		const auto bottom = small.getPixelAt(static_cast<int>(pos.x) + 10, static_cast<int>(pos.y) + 39);
+		require(right.getRed() > 250 && right.getGreen() < 5 && right.getBlue() < 5, "padded fallback cropped right edge");
+		require(bottom.getBlue() > 250 && bottom.getRed() < 5 && bottom.getGreen() < 5, "padded fallback cropped bottom edge");
+
+		// Removing a marked node must not leave a dangling pointer in the controller.
+		auto* rule = doc->GetElementById("rule");
+		rule->GetParentNode()->RemoveChild(rule).reset();
+		experiment->apply(component, canvas, false);
+		experiment->apply(component, canvas, true);
+		settle(1.f);
+		// A detached element can remain alive in a caller-owned ElementPtr.
+		auto* remaining = doc->GetElementById("teardown");
+		auto detachedHelper = remaining->RemoveChild(remaining->GetChild(0));
+		experiment->apply(component, canvas, false);
+		detachedHelper.reset();
+		// Re-enable with an intact authored background so teardown also exercises
+		// restoring and removing an attached helper.
+		remaining->SetProperty("background-color", "#345678");
+		experiment->apply(component, canvas, true);
+		settle(1.f);
+		auto detachedCanvas = area->RemoveChild(canvas);
+		experiment.reset();
+		settle(1.f);
+		Rml::ElementList helpers;
+		doc->GetElementsByTagName(helpers, "pixelpanelrule");
+		require(helpers.empty(), "removing experiment left helper elements behind");
+		require(doc->GetElementById("teardown")->GetProperty("background-color")->Get<Rml::Colourb>(doc->GetCoreInstance())
+			== Rml::Colourb(0x34, 0x56, 0x78), "removing experiment did not restore the authored rule");
+	}
+}
+
+int main()
+{
+	try
+	{
+		juce::ScopedJuceInitialiser_GUI gui;
+		testRendering();
+		std::cout << "Panel rendering: toggles, density transitions, integer LCD, padded fallback, and removal passed\n";
+		return 0;
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << e.what() << '\n';
+		return 1;
+	}
+}

--- a/source/elektron/md/mdJucePlugin/mdPixelPerfectPanel.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPixelPerfectPanel.cpp
@@ -1,0 +1,178 @@
+#include "mdPixelPerfectPanel.h"
+
+#include "RmlUi/Core/ComputedValues.h"
+#include "RmlUi/Core/Element.h"
+#include "RmlUi/Core/Geometry.h"
+#include "RmlUi/Core/MeshUtilities.h"
+#include "RmlUi/Core/RenderManager.h"
+
+#include "juceRmlUi/juceRmlComponent.h"
+#include "juceRmlUi/rmlElemCanvas.h"
+#include "RmlUi/Core/ElementDocument.h"
+#include "RmlUi/Core/Factory.h"
+
+#include <algorithm>
+#include <cmath>
+#include <optional>
+
+namespace mdJucePlugin
+{
+	namespace
+	{
+		// Attached only to explicitly authored 1dp, flat, non-interactive panel
+		// rules. Leave the parent's layout alone, including connections to labels.
+		class PixelPanelRule final : public Rml::Element
+		{
+		public:
+			PixelPanelRule(Rml::CoreInstance& _core, const Rml::String& _tag) : Element(_core, _tag) {}
+
+			void init(Rml::Element& _parent)
+			{
+				m_color = _parent.GetComputedValues().background_color();
+				if (const auto* property = _parent.GetLocalProperty(Rml::PropertyId::BackgroundColor))
+					m_originalBackground = *property;
+				SetProperty("position", "absolute");
+				SetProperty("left", "0px");
+				SetProperty("top", "0px");
+				SetProperty("width", "100%");
+				SetProperty("height", "100%");
+				SetProperty("pointer-events", "none");
+				setEnabled(false);
+			}
+
+			void setEnabled(bool _enabled)
+			{
+				auto* parent = GetParentNode();
+				if (!parent)
+					return;
+				SetProperty("display", _enabled ? "block" : "none");
+				if (_enabled)
+					parent->SetProperty("background-color", "transparent");
+				else if (m_originalBackground)
+					parent->SetProperty(Rml::PropertyId::BackgroundColor, *m_originalBackground);
+				else
+					parent->RemoveProperty(Rml::PropertyId::BackgroundColor);
+			}
+
+		private:
+			void OnRender() override
+			{
+				auto* parent = GetParentNode();
+				const auto size = parent->GetBox().GetSize(Rml::BoxArea::Content);
+				if (size.x <= 0 || size.y <= 0)
+					return;
+				const Rml::Vector2f snappedSize(std::max(1.f, std::round(size.x)), std::max(1.f, std::round(size.y)));
+				const auto color = m_color.ToPremultiplied(parent->GetComputedValues().opacity());
+				if (!m_geometry || snappedSize != m_size || color != m_renderColor)
+				{
+					auto mesh = m_geometry.Release(Rml::Geometry::ReleaseMode::ClearMesh);
+					Rml::MeshUtilities::GenerateQuad(mesh, {}, snappedSize, color);
+					m_geometry = GetRenderManager()->MakeGeometry(std::move(mesh));
+					m_size = snappedSize;
+					m_renderColor = color;
+				}
+				m_geometry.Render(parent->GetAbsoluteOffset(Rml::BoxArea::Content).Round());
+			}
+
+			Rml::Colourb m_color;
+			Rml::ColourbPremultiplied m_renderColor;
+			std::optional<Rml::Property> m_originalBackground;
+			Rml::Vector2f m_size;
+			Rml::Geometry m_geometry;
+		};
+	}
+
+	struct PixelPerfectPanel::Impl
+	{
+		bool enabled = false;
+		juce::Component::SafePointer<juceRmlUi::RmlComponent> component;
+		Rml::ObserverPtr<Rml::Element> canvas;
+		std::vector<Rml::ObserverPtr<Rml::Element>> rules;
+
+		~Impl()
+		{
+			// Also support removing the experiment while the document is alive.
+			for (auto& observer : rules)
+				if (auto* rule = static_cast<PixelPanelRule*>(observer.get()); rule && rule->GetParentNode())
+				{
+					rule->setEnabled(false);
+					rule->GetParentNode()->RemoveChild(rule);
+				}
+			if (auto* c = static_cast<juceRmlUi::ElemCanvas*>(canvas.get()))
+				c->setPixelAligned(false);
+			if (component)
+				component->setUseNativePixelDensity(false);
+		}
+	};
+
+	PixelPerfectPanel::PixelPerfectPanel() : m_impl(std::make_unique<Impl>()) {}
+	PixelPerfectPanel::~PixelPerfectPanel() = default;
+
+	void PixelPerfectPanel::apply(juceRmlUi::RmlComponent& _component, juceRmlUi::ElemCanvas* _canvas, const bool _enabled)
+	{
+		auto& state = *m_impl;
+		state.enabled = _enabled;
+		state.component = &_component;
+		state.canvas = _canvas ? _canvas->GetObserverPtr(_canvas->GetCoreInstance()) : nullptr;
+		if (_canvas)
+			_canvas->setPixelAligned(_enabled);
+
+		state.rules.erase(std::remove_if(state.rules.begin(), state.rules.end(),
+			[](const auto& _rule) { return !_rule; }), state.rules.end());
+		if (auto* doc = _component.getDocument(); _enabled && doc)
+		{
+			static Rml::ElementInstancerGeneric<PixelPanelRule> instancer;
+			doc->GetCoreInstance().factory->RegisterElementInstancer("pixelpanelrule", &instancer);
+			Rml::ElementList elements;
+			doc->GetElementsByClassName(elements, ruleClass);
+			for (auto* element : elements)
+			{
+				// Only explicitly marked, flat, static rules participate. Inserting
+				// unrelated 1dp controls into a skin must never opt them in implicitly.
+				if (element->GetNumChildren() || element->GetTagName() != "div")
+					continue;
+				const auto& values = element->GetComputedValues();
+				if (values.background_color().alpha == 0)
+					continue;
+				const auto& box = element->GetBox();
+				bool flat = true;
+				for (int edge = 0; edge < 4; ++edge)
+					flat &= box.GetEdge(Rml::BoxArea::Border, Rml::BoxEdge(edge)) == 0 && values.border_radius()[edge] == 0;
+				if (!flat)
+					continue;
+				auto* rule = static_cast<PixelPanelRule*>(element->AppendChild(doc->CreateElement("pixelpanelrule")));
+				rule->init(*element);
+				state.rules.push_back(rule->GetObserverPtr(rule->GetCoreInstance()));
+			}
+		}
+		for (const auto& observer : state.rules)
+			if (auto* rule = static_cast<PixelPanelRule*>(observer.get()))
+				rule->setEnabled(_enabled);
+		_component.setUseNativePixelDensity(_enabled);
+		_component.enqueueUpdate();
+	}
+
+	bool PixelPerfectPanel::paintLcd(const juce::Image& _lcd, juce::Graphics& _graphics) const
+	{
+		const auto* canvas = static_cast<juceRmlUi::ElemCanvas*>(m_impl->canvas.get());
+		if (!m_impl->enabled || !canvas || !_lcd.isValid())
+			return false;
+		_graphics.setImageResamplingQuality(juce::Graphics::lowResamplingQuality);
+		const auto size = canvas->getPaintSize();
+		const auto scale = std::min(size.x / _lcd.getWidth(), size.y / _lcd.getHeight());
+		if (scale >= 1)
+		{
+			const auto w = scale * _lcd.getWidth();
+			const auto h = scale * _lcd.getHeight();
+			_graphics.drawImage(_lcd, (size.x - w) / 2, (size.y - h) / 2, w, h,
+				0, 0, _lcd.getWidth(), _lcd.getHeight());
+		}
+		else
+		{
+			// Fit the visible canvas, not its possibly larger power-of-two texture.
+			// Otherwise small windows crop the right/bottom of the LCD contents.
+			_graphics.drawImageWithin(_lcd, 0, 0, size.x, size.y, juce::RectanglePlacement::centred);
+		}
+		return true;
+	}
+}

--- a/source/elektron/md/mdJucePlugin/mdPixelPerfectPanel.h
+++ b/source/elektron/md/mdJucePlugin/mdPixelPerfectPanel.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "RmlUi/Core/ComputedValues.h"
+#include "RmlUi/Core/Element.h"
+#include "RmlUi/Core/Geometry.h"
+#include "RmlUi/Core/MeshUtilities.h"
+#include "RmlUi/Core/RenderManager.h"
+
+#include <algorithm>
+#include <cmath>
+#include <optional>
+
+namespace mdJucePlugin
+{
+	// Attached only to explicitly authored 1dp, flat, non-interactive panel
+	// rules. Leave the parent's layout alone, including connections to labels.
+	class PixelPanelRule final : public Rml::Element
+	{
+	public:
+		PixelPanelRule(Rml::CoreInstance& _core, const Rml::String& _tag) : Element(_core, _tag) {}
+
+		void init(Rml::Element& _parent)
+		{
+			m_color = _parent.GetComputedValues().background_color();
+			if (const auto* property = _parent.GetLocalProperty(Rml::PropertyId::BackgroundColor))
+				m_originalBackground = *property;
+			SetProperty("position", "absolute");
+			SetProperty("left", "0px");
+			SetProperty("top", "0px");
+			SetProperty("width", "100%");
+			SetProperty("height", "100%");
+			SetProperty("pointer-events", "none");
+			setEnabled(false);
+		}
+
+		void setEnabled(bool _enabled)
+		{
+			SetProperty("display", _enabled ? "block" : "none");
+			auto* parent = GetParentNode();
+			if (_enabled)
+				parent->SetProperty("background-color", "transparent");
+			else if (m_originalBackground)
+				parent->SetProperty(Rml::PropertyId::BackgroundColor, *m_originalBackground);
+			else
+				parent->RemoveProperty(Rml::PropertyId::BackgroundColor);
+		}
+
+	private:
+		void OnRender() override
+		{
+			auto* parent = GetParentNode();
+			const auto size = parent->GetBox().GetSize(Rml::BoxArea::Content);
+			if (size.x <= 0 || size.y <= 0)
+				return;
+			const Rml::Vector2f snappedSize(std::max(1.f, std::round(size.x)), std::max(1.f, std::round(size.y)));
+			const auto color = m_color.ToPremultiplied(parent->GetComputedValues().opacity());
+			if (!m_geometry || snappedSize != m_size || color != m_renderColor)
+			{
+				auto mesh = m_geometry.Release(Rml::Geometry::ReleaseMode::ClearMesh);
+				Rml::MeshUtilities::GenerateQuad(mesh, {}, snappedSize, color);
+				m_geometry = GetRenderManager()->MakeGeometry(std::move(mesh));
+				m_size = snappedSize;
+				m_renderColor = color;
+			}
+			m_geometry.Render(parent->GetAbsoluteOffset(Rml::BoxArea::Content).Round());
+		}
+
+		Rml::Colourb m_color;
+		Rml::ColourbPremultiplied m_renderColor;
+		std::optional<Rml::Property> m_originalBackground;
+		Rml::Vector2f m_size;
+		Rml::Geometry m_geometry;
+	};
+}

--- a/source/elektron/md/mdJucePlugin/mdPixelPerfectPanel.h
+++ b/source/elektron/md/mdJucePlugin/mdPixelPerfectPanel.h
@@ -1,74 +1,29 @@
 #pragma once
 
-#include "RmlUi/Core/ComputedValues.h"
-#include "RmlUi/Core/Element.h"
-#include "RmlUi/Core/Geometry.h"
-#include "RmlUi/Core/MeshUtilities.h"
-#include "RmlUi/Core/RenderManager.h"
+#include <memory>
 
-#include <algorithm>
-#include <cmath>
-#include <optional>
+namespace juce { class Image; class Graphics; }
+namespace juceRmlUi { class RmlComponent; class ElemCanvas; }
 
 namespace mdJucePlugin
 {
-	// Attached only to explicitly authored 1dp, flat, non-interactive panel
-	// rules. Leave the parent's layout alone, including connections to labels.
-	class PixelPanelRule final : public Rml::Element
+	// Single owner/gate for the removable rendering experiment. The permanent
+	// aspect-ratio and settings-resource identity fixes do not depend on it.
+	class PixelPerfectPanel
 	{
 	public:
-		PixelPanelRule(Rml::CoreInstance& _core, const Rml::String& _tag) : Element(_core, _tag) {}
+		static constexpr const char* configKey = "pixelPerfectPanel";
+		static constexpr bool defaultEnabled = false;
+		static constexpr const char* ruleClass = "elektronPixelRule";
 
-		void init(Rml::Element& _parent)
-		{
-			m_color = _parent.GetComputedValues().background_color();
-			if (const auto* property = _parent.GetLocalProperty(Rml::PropertyId::BackgroundColor))
-				m_originalBackground = *property;
-			SetProperty("position", "absolute");
-			SetProperty("left", "0px");
-			SetProperty("top", "0px");
-			SetProperty("width", "100%");
-			SetProperty("height", "100%");
-			SetProperty("pointer-events", "none");
-			setEnabled(false);
-		}
-
-		void setEnabled(bool _enabled)
-		{
-			SetProperty("display", _enabled ? "block" : "none");
-			auto* parent = GetParentNode();
-			if (_enabled)
-				parent->SetProperty("background-color", "transparent");
-			else if (m_originalBackground)
-				parent->SetProperty(Rml::PropertyId::BackgroundColor, *m_originalBackground);
-			else
-				parent->RemoveProperty(Rml::PropertyId::BackgroundColor);
-		}
+		PixelPerfectPanel();
+		~PixelPerfectPanel();
+		void apply(juceRmlUi::RmlComponent& _component, juceRmlUi::ElemCanvas* _canvas, bool _enabled);
+		// Returns false to use the editor's normal aspect-fit painter.
+		bool paintLcd(const juce::Image& _lcd, juce::Graphics& _graphics) const;
 
 	private:
-		void OnRender() override
-		{
-			auto* parent = GetParentNode();
-			const auto size = parent->GetBox().GetSize(Rml::BoxArea::Content);
-			if (size.x <= 0 || size.y <= 0)
-				return;
-			const Rml::Vector2f snappedSize(std::max(1.f, std::round(size.x)), std::max(1.f, std::round(size.y)));
-			const auto color = m_color.ToPremultiplied(parent->GetComputedValues().opacity());
-			if (!m_geometry || snappedSize != m_size || color != m_renderColor)
-			{
-				auto mesh = m_geometry.Release(Rml::Geometry::ReleaseMode::ClearMesh);
-				Rml::MeshUtilities::GenerateQuad(mesh, {}, snappedSize, color);
-				m_geometry = GetRenderManager()->MakeGeometry(std::move(mesh));
-				m_size = snappedSize;
-				m_renderColor = color;
-			}
-			m_geometry.Render(parent->GetAbsoluteOffset(Rml::BoxArea::Content).Round());
-		}
-
-		Rml::Colourb m_color;
-		Rml::ColourbPremultiplied m_renderColor;
-		std::optional<Rml::Property> m_originalBackground;
-		Rml::Vector2f m_size;
-		Rml::Geometry m_geometry;
+		struct Impl;
+		std::unique_ptr<Impl> m_impl;
 	};
 }

--- a/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.cpp
+++ b/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.cpp
@@ -3,6 +3,7 @@
 #include "mdEditor.h"
 
 #include "jucePluginEditorLib/pluginProcessor.h"
+#include "jucePluginEditorLib/settingsPlugin.h"
 
 #include "juceRmlUi/rmlElemButton.h"
 #include "juceRmlUi/rmlEventListener.h"
@@ -14,6 +15,11 @@ namespace mdJucePlugin
 {
 	SettingsPanelFeel::SettingsPanelFeel(Editor& _editor, Rml::Element* _root) : m_editor(_editor)
 	{
+		jucePluginEditorLib::SettingsPlugin::createToggleButton(_root, "btPixelPerfectPanel",
+			m_editor.getProcessor().getConfig(), "pixelPerfectPanel", [this](bool)
+			{
+				m_editor.applyPixelPerfectPanel();
+			});
 		bindGroup(_root, "btWheelSpeed", "panelWheelSpeedPercent");
 		bindGroup(_root, "btEncoderSpeed", "panelEncoderSpeedPercent");
 

--- a/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.cpp
+++ b/source/elektron/md/mdJucePlugin/mdSettingsPanelFeel.cpp
@@ -1,6 +1,7 @@
 #include "mdSettingsPanelFeel.h"
 
 #include "mdEditor.h"
+#include "mdPixelPerfectPanel.h"
 
 #include "jucePluginEditorLib/pluginProcessor.h"
 #include "jucePluginEditorLib/settingsPlugin.h"
@@ -16,10 +17,10 @@ namespace mdJucePlugin
 	SettingsPanelFeel::SettingsPanelFeel(Editor& _editor, Rml::Element* _root) : m_editor(_editor)
 	{
 		jucePluginEditorLib::SettingsPlugin::createToggleButton(_root, "btPixelPerfectPanel",
-			m_editor.getProcessor().getConfig(), "pixelPerfectPanel", [this](bool)
+			m_editor.getProcessor().getConfig(), PixelPerfectPanel::configKey, [this](bool)
 			{
 				m_editor.applyPixelPerfectPanel();
-			});
+			}, PixelPerfectPanel::defaultEnabled);
 		bindGroup(_root, "btWheelSpeed", "panelWheelSpeedPercent");
 		bindGroup(_root, "btEncoderSpeed", "panelEncoderSpeedPercent");
 

--- a/source/elektron/md/mdJucePlugin/skins/mdDefault/mdDefault.rml
+++ b/source/elektron/md/mdJucePlugin/skins/mdDefault/mdDefault.rml
@@ -21,46 +21,46 @@
 		<div class="jucePos juceLabel mdPortLabel" style="left: 340dp; top: 3dp; width: 40dp; height: 13dp; line-height: 13dp;">D</div>
 		<div class="jucePos juceLabel mdPortLabel" style="left: 400dp; top: 3dp; width: 40dp; height: 13dp; line-height: 13dp;">E</div>
 		<div class="jucePos juceLabel mdPortLabel" style="left: 459dp; top: 3dp; width: 40dp; height: 13dp; line-height: 13dp;">F</div>
-		<div class="jucePos mdPortGuide" style="left: 164dp; top: 20dp; width: 22dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdPortGuide" style="left: 164dp; top: 20dp; width: 22dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mdPortLabel" style="left: 188dp; top: 17dp; width: 46dp; height: 13dp; line-height: 13dp;">MAIN OUT</div>
-		<div class="jucePos mdPortGuide" style="left: 236dp; top: 20dp; width: 20dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdPortGuide" style="left: 236dp; top: 20dp; width: 20dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mdPortLabel" style="left: 519dp; top: 3dp; width: 34dp; height: 13dp; line-height: 13dp;">A</div>
 		<div class="jucePos juceLabel mdPortLabel" style="left: 579dp; top: 3dp; width: 34dp; height: 13dp; line-height: 13dp;">B</div>
-		<div class="jucePos mdPortGuide" style="left: 524dp; top: 20dp; width: 28dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdPortGuide" style="left: 524dp; top: 20dp; width: 28dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mdPortLabel" style="left: 554dp; top: 17dp; width: 30dp; height: 13dp; line-height: 13dp;">INPUT</div>
-		<div class="jucePos mdPortGuide" style="left: 586dp; top: 20dp; width: 28dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdPortGuide" style="left: 586dp; top: 20dp; width: 28dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mdPortLabel" style="left: 689dp; top: 3dp; width: 42dp; height: 13dp; line-height: 13dp;">IN</div>
 		<div class="jucePos juceLabel mdPortLabel" style="left: 755dp; top: 3dp; width: 42dp; height: 13dp; line-height: 13dp;">OUT</div>
 		<div class="jucePos juceLabel mdPortLabel" style="left: 818dp; top: 3dp; width: 48dp; height: 13dp; line-height: 13dp;">THRU</div>
-		<div class="jucePos mdPortGuide" style="left: 694dp; top: 20dp; width: 68dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdPortGuide" style="left: 694dp; top: 20dp; width: 68dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mdPortLabel" style="left: 764dp; top: 17dp; width: 24dp; height: 13dp; line-height: 13dp;">MIDI</div>
-		<div class="jucePos mdPortGuide" style="left: 790dp; top: 20dp; width: 68dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdPortGuide" style="left: 790dp; top: 20dp; width: 68dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mdPortLabel" style="left: 937dp; top: 3dp; width: 56dp; height: 13dp; line-height: 13dp;">DC IN</div>
 		<div class="jucePos juceLabel mdPortLabel" style="left: 1039dp; top: 3dp; width: 61dp; height: 13dp; line-height: 13dp;">POWER</div>
 
 		<!-- Chassis fasteners and the measured major hardware boundaries. -->
 
 		<div class="jucePos mdScrew" style="left: 30dp; top: 18dp; width: 10dp; height: 10dp;"/>
-		<div class="jucePos mdScrewSlot" style="left: 33dp; top: 22dp; width: 4dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdScrewSlot" style="left: 33dp; top: 22dp; width: 4dp; height: 1dp;"/>
 		<div class="jucePos mdScrew" style="left: 653dp; top: 18dp; width: 10dp; height: 10dp;"/>
-		<div class="jucePos mdScrewSlot" style="left: 656dp; top: 22dp; width: 4dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdScrewSlot" style="left: 656dp; top: 22dp; width: 4dp; height: 1dp;"/>
 		<div class="jucePos mdScrew" style="left: 1072dp; top: 18dp; width: 10dp; height: 10dp;"/>
-		<div class="jucePos mdScrewSlot" style="left: 1075dp; top: 22dp; width: 4dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdScrewSlot" style="left: 1075dp; top: 22dp; width: 4dp; height: 1dp;"/>
 		<div class="jucePos mdScrew" style="left: 18dp; top: 546dp; width: 10dp; height: 10dp;"/>
-		<div class="jucePos mdScrewSlot" style="left: 21dp; top: 550dp; width: 4dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdScrewSlot" style="left: 21dp; top: 550dp; width: 4dp; height: 1dp;"/>
 		<div class="jucePos mdScrew" style="left: 545dp; top: 546dp; width: 10dp; height: 10dp;"/>
-		<div class="jucePos mdScrewSlot" style="left: 548dp; top: 550dp; width: 4dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdScrewSlot" style="left: 548dp; top: 550dp; width: 4dp; height: 1dp;"/>
 		<div class="jucePos mdScrew" style="left: 1072dp; top: 546dp; width: 10dp; height: 10dp;"/>
-		<div class="jucePos mdScrewSlot" style="left: 1075dp; top: 550dp; width: 4dp; height: 1dp;"/>
-		<div class="jucePos elektronPanelGroove mdRuleV" style="left: 0dp; top: 0dp; width: 1dp; height: 570dp;"/>
-		<div class="jucePos elektronPanelGroove mdRuleV" style="left: 1099dp; top: 0dp; width: 1dp; height: 570dp;"/>
-		<div class="jucePos elektronPanelGroove mdRuleV" style="left: 332dp; top: 36dp; width: 1dp; height: 398dp;"/>
-		<div class="jucePos elektronPanelGroove mdRuleV" style="left: 655dp; top: 36dp; width: 1dp; height: 398dp;"/>
-		<div class="jucePos elektronPanelGroove mdRuleV" style="left: 907dp; top: 311dp; width: 1dp; height: 123dp;"/>
-		<div class="jucePos elektronPanelGrooveShadow mdRuleHShadow" style="left: 0dp; top: 310dp; width: 1100dp; height: 1dp;"/>
-		<div class="jucePos elektronPanelGrooveHighlight mdRuleHHighlight" style="left: 0dp; top: 311dp; width: 1100dp; height: 1dp;"/>
-		<div class="jucePos elektronPanelGrooveShadow mdRuleHShadow" style="left: 0dp; top: 433dp; width: 1100dp; height: 1dp;"/>
-		<div class="jucePos elektronPanelGrooveHighlight mdRuleHHighlight" style="left: 0dp; top: 434dp; width: 1100dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdScrewSlot" style="left: 1075dp; top: 550dp; width: 4dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGroove mdRuleV" style="left: 0dp; top: 0dp; width: 1dp; height: 570dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGroove mdRuleV" style="left: 1099dp; top: 0dp; width: 1dp; height: 570dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGroove mdRuleV" style="left: 332dp; top: 36dp; width: 1dp; height: 398dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGroove mdRuleV" style="left: 655dp; top: 36dp; width: 1dp; height: 398dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGroove mdRuleV" style="left: 907dp; top: 311dp; width: 1dp; height: 123dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGrooveShadow mdRuleHShadow" style="left: 0dp; top: 310dp; width: 1100dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGrooveHighlight mdRuleHHighlight" style="left: 0dp; top: 311dp; width: 1100dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGrooveShadow mdRuleHShadow" style="left: 0dp; top: 433dp; width: 1100dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGrooveHighlight mdRuleHHighlight" style="left: 0dp; top: 434dp; width: 1100dp; height: 1dp;"/>
 
 		<!-- Left panel: master, two-row sound selection, mode, wheel and function. -->
 
@@ -161,14 +161,14 @@
 
 		<!-- The recessed display is joined to the black fascia by four printed rails. -->
 
-		<div class="jucePos mdScreenStripe" style="left: 333dp; top: 213dp; width: 47dp; height: 1dp;"/>
-		<div class="jucePos mdScreenStripe" style="left: 608dp; top: 213dp; width: 47dp; height: 1dp;"/>
-		<div class="jucePos mdScreenStripe" style="left: 333dp; top: 218dp; width: 47dp; height: 1dp;"/>
-		<div class="jucePos mdScreenStripe" style="left: 608dp; top: 218dp; width: 47dp; height: 1dp;"/>
-		<div class="jucePos mdScreenStripe" style="left: 333dp; top: 223dp; width: 47dp; height: 1dp;"/>
-		<div class="jucePos mdScreenStripe" style="left: 608dp; top: 223dp; width: 47dp; height: 1dp;"/>
-		<div class="jucePos mdScreenStripe" style="left: 333dp; top: 228dp; width: 47dp; height: 1dp;"/>
-		<div class="jucePos mdScreenStripe" style="left: 608dp; top: 228dp; width: 47dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdScreenStripe" style="left: 333dp; top: 213dp; width: 47dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdScreenStripe" style="left: 608dp; top: 213dp; width: 47dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdScreenStripe" style="left: 333dp; top: 218dp; width: 47dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdScreenStripe" style="left: 608dp; top: 218dp; width: 47dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdScreenStripe" style="left: 333dp; top: 223dp; width: 47dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdScreenStripe" style="left: 608dp; top: 223dp; width: 47dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdScreenStripe" style="left: 333dp; top: 228dp; width: 47dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mdScreenStripe" style="left: 608dp; top: 228dp; width: 47dp; height: 1dp;"/>
 
 		<!-- Right panel: LEVEL/TEMPO and the hardware 4x2 DATA ENTRY matrix. -->
 
@@ -222,10 +222,10 @@
 				</div>
 			</div>
 		</div>
-		<div class="jucePos elektronConnectorRail mdPrintedGuide" style="left: 820dp; top: 275dp; width: 180dp; height: 1dp;"/>
-		<div class="jucePos elektronConnectorDrop mdPrintedGuide" style="left: 820dp; top: 275dp; width: 1dp; height: 8dp;"/>
-		<div class="jucePos elektronConnectorDrop mdPrintedGuide" style="left: 878dp; top: 275dp; width: 1dp; height: 8dp;"/>
-		<div class="jucePos elektronConnectorDrop mdPrintedGuide" style="left: 936dp; top: 275dp; width: 1dp; height: 8dp;"/>
+		<div class="elektronPixelRule jucePos elektronConnectorRail mdPrintedGuide" style="left: 820dp; top: 275dp; width: 180dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos elektronConnectorDrop mdPrintedGuide" style="left: 820dp; top: 275dp; width: 1dp; height: 8dp;"/>
+		<div class="elektronPixelRule jucePos elektronConnectorDrop mdPrintedGuide" style="left: 878dp; top: 275dp; width: 1dp; height: 8dp;"/>
+		<div class="elektronPixelRule jucePos elektronConnectorDrop mdPrintedGuide" style="left: 936dp; top: 275dp; width: 1dp; height: 8dp;"/>
 		<div id="stSynth" class="jucePos elektronLed mdModeLed" style="left: 815dp; top: 282dp;"/>
 		<div id="pageSynthesis" class="jucePos juceLabel mdDataPageLabel mdAffordance" title="Open Synthesis page" style="left: 828dp; top: 280dp; width: 44dp; height: 15dp; line-height: 15dp;">SYNTHESIS</div>
 		<div id="stFx" class="jucePos elektronLed mdModeLed" style="left: 873dp; top: 282dp;"/>
@@ -244,7 +244,7 @@
 		</div>
 		<button id="btBankGrp" class="jucePos juceButton elektronButton elektronKey" isToggle="0" style="left: 23dp; top: 328dp;"/>
 		<div class="jucePos juceLabel elektronSecondary plain" style="left: 20dp; top: 365dp; width: 68dp; height: 13dp; line-height: 13dp;">BANK GROUP</div>
-		<div class="jucePos elektronIndicatorGuide mdPrintedGuide" style="left: 83dp; top: 341dp; width: 215dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos elektronIndicatorGuide mdPrintedGuide" style="left: 83dp; top: 341dp; width: 215dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mdBankLetter" style="left: 83dp; top: 324dp; width: 48dp; height: 13dp; line-height: 13dp;">A</div>
 		<div class="jucePos juceLabel mdBankLetter" style="left: 143dp; top: 324dp; width: 48dp; height: 13dp; line-height: 13dp;">B</div>
 		<div class="jucePos juceLabel mdBankLetter" style="left: 202dp; top: 324dp; width: 48dp; height: 13dp; line-height: 13dp;">C</div>
@@ -255,10 +255,10 @@
 		<div class="jucePos juceLabel mdBankLetter" style="left: 262dp; top: 344dp; width: 48dp; height: 13dp; line-height: 13dp;">H</div>
 		<div id="ledBankAD" class="jucePos elektronLed mdBankIndicator mdBankIndicatorTop" style="left: 304dp; top: 327dp;"/>
 		<div id="ledBankEH" class="jucePos elektronLed mdBankIndicator" style="left: 304dp; top: 346dp;"/>
-		<div class="jucePos mdPrintedGuide" style="left: 107dp; top: 358dp; width: 1dp; height: 17dp;"/>
-		<div class="jucePos mdPrintedGuide" style="left: 167dp; top: 358dp; width: 1dp; height: 17dp;"/>
-		<div class="jucePos mdPrintedGuide" style="left: 226dp; top: 358dp; width: 1dp; height: 17dp;"/>
-		<div class="jucePos mdPrintedGuide" style="left: 286dp; top: 358dp; width: 1dp; height: 17dp;"/>
+		<div class="elektronPixelRule jucePos mdPrintedGuide" style="left: 107dp; top: 358dp; width: 1dp; height: 17dp;"/>
+		<div class="elektronPixelRule jucePos mdPrintedGuide" style="left: 167dp; top: 358dp; width: 1dp; height: 17dp;"/>
+		<div class="elektronPixelRule jucePos mdPrintedGuide" style="left: 226dp; top: 358dp; width: 1dp; height: 17dp;"/>
+		<div class="elektronPixelRule jucePos mdPrintedGuide" style="left: 286dp; top: 358dp; width: 1dp; height: 17dp;"/>
 		<div class="jucePos elektronCaptionedKey" style="left: 82dp; top: 379dp;">
 			<button id="btBankA" class="juceButton elektronButton elektronKey" isToggle="0"/>
 			<div id="altMute" class="juceLabel elektronButtonCaption elektronSecondary mdAffordance" title="FUNCTION + A/E: Mute">MUTE</div>

--- a/source/elektron/md/mdJucePlugin/skins/mmSfx60/mmSfx60.rml
+++ b/source/elektron/md/mdJucePlugin/skins/mmSfx60/mmSfx60.rml
@@ -17,7 +17,7 @@
 
 		<!-- Rear connector rail. -->
 
-		<div class="jucePos elektronPanelGroove mmRuleH" style="left: 0dp; top: 35dp; width: 1100dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGroove mmRuleH" style="left: 0dp; top: 35dp; width: 1100dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 80dp; top: 3dp; width: 45dp; height: 13dp; line-height: 13dp;">PHONES</div>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 137dp; top: 3dp; width: 50dp; height: 13dp; line-height: 13dp;">A / LEFT</div>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 195dp; top: 3dp; width: 50dp; height: 13dp; line-height: 13dp;">B / RIGHT</div>
@@ -25,46 +25,46 @@
 		<div class="jucePos juceLabel mmPortLabel" style="left: 317dp; top: 3dp; width: 40dp; height: 13dp; line-height: 13dp;">D</div>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 375dp; top: 3dp; width: 40dp; height: 13dp; line-height: 13dp;">E</div>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 434dp; top: 3dp; width: 40dp; height: 13dp; line-height: 13dp;">F</div>
-		<div class="jucePos mmPortGuide" style="left: 143dp; top: 20dp; width: 21dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmPortGuide" style="left: 143dp; top: 20dp; width: 21dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 166dp; top: 17dp; width: 46dp; height: 13dp; line-height: 13dp;">MAIN OUT</div>
-		<div class="jucePos mmPortGuide" style="left: 214dp; top: 20dp; width: 15dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmPortGuide" style="left: 214dp; top: 20dp; width: 15dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 496dp; top: 3dp; width: 34dp; height: 13dp; line-height: 13dp;">A</div>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 555dp; top: 3dp; width: 34dp; height: 13dp; line-height: 13dp;">B</div>
-		<div class="jucePos mmPortGuide" style="left: 501dp; top: 20dp; width: 25dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmPortGuide" style="left: 501dp; top: 20dp; width: 25dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 528dp; top: 17dp; width: 30dp; height: 13dp; line-height: 13dp;">INPUT</div>
-		<div class="jucePos mmPortGuide" style="left: 560dp; top: 20dp; width: 25dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmPortGuide" style="left: 560dp; top: 20dp; width: 25dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 660dp; top: 3dp; width: 42dp; height: 13dp; line-height: 13dp;">IN</div>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 723dp; top: 3dp; width: 42dp; height: 13dp; line-height: 13dp;">OUT</div>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 783dp; top: 3dp; width: 48dp; height: 13dp; line-height: 13dp;">THRU</div>
-		<div class="jucePos mmPortGuide" style="left: 670dp; top: 20dp; width: 64dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmPortGuide" style="left: 670dp; top: 20dp; width: 64dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 736dp; top: 17dp; width: 22dp; height: 13dp; line-height: 13dp;">MIDI</div>
-		<div class="jucePos mmPortGuide" style="left: 760dp; top: 20dp; width: 67dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmPortGuide" style="left: 760dp; top: 20dp; width: 67dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 916dp; top: 3dp; width: 56dp; height: 13dp; line-height: 13dp;">DC IN</div>
 		<div class="jucePos juceLabel mmPortLabel" style="left: 1010dp; top: 3dp; width: 61dp; height: 13dp; line-height: 13dp;">POWER</div>
 
 		<!-- Chassis fasteners and continuous faceplate rules. -->
 
 		<div class="jucePos mmScrew" style="left: 25dp; top: 20dp; width: 10dp; height: 10dp;"/>
-		<div class="jucePos mmScrewSlot" style="left: 28dp; top: 24dp; width: 4dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmScrewSlot" style="left: 28dp; top: 24dp; width: 4dp; height: 1dp;"/>
 		<div class="jucePos mmScrew" style="left: 631dp; top: 20dp; width: 10dp; height: 10dp;"/>
-		<div class="jucePos mmScrewSlot" style="left: 634dp; top: 24dp; width: 4dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmScrewSlot" style="left: 634dp; top: 24dp; width: 4dp; height: 1dp;"/>
 		<div class="jucePos mmScrew" style="left: 1063dp; top: 20dp; width: 10dp; height: 10dp;"/>
-		<div class="jucePos mmScrewSlot" style="left: 1066dp; top: 24dp; width: 4dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmScrewSlot" style="left: 1066dp; top: 24dp; width: 4dp; height: 1dp;"/>
 		<div class="jucePos mmScrew" style="left: 20dp; top: 542dp; width: 10dp; height: 10dp;"/>
-		<div class="jucePos mmScrewSlot" style="left: 23dp; top: 546dp; width: 4dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmScrewSlot" style="left: 23dp; top: 546dp; width: 4dp; height: 1dp;"/>
 		<div class="jucePos mmScrew" style="left: 545dp; top: 542dp; width: 10dp; height: 10dp;"/>
-		<div class="jucePos mmScrewSlot" style="left: 548dp; top: 546dp; width: 4dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmScrewSlot" style="left: 548dp; top: 546dp; width: 4dp; height: 1dp;"/>
 		<div class="jucePos mmScrew" style="left: 1070dp; top: 542dp; width: 10dp; height: 10dp;"/>
-		<div class="jucePos mmScrewSlot" style="left: 1073dp; top: 546dp; width: 4dp; height: 1dp;"/>
-		<div class="jucePos elektronPanelGroove mmRuleV" style="left: 151dp; top: 35dp; width: 1dp; height: 277dp;"/>
-		<div class="jucePos elektronPanelGroove mmRuleV" style="left: 821dp; top: 35dp; width: 1dp; height: 277dp;"/>
-		<div class="jucePos elektronPanelGroove mmRuleV" style="left: 944dp; top: 35dp; width: 1dp; height: 277dp;"/>
-		<div class="jucePos elektronPanelGroove mmRuleH" style="left: 0dp; top: 311dp; width: 945dp; height: 1dp;"/>
-		<div class="jucePos elektronPanelGroove mmRuleH" style="left: 0dp; top: 439dp; width: 1100dp; height: 1dp;"/>
-		<div class="jucePos elektronPanelGroove mmRuleV" style="left: 151dp; top: 312dp; width: 1dp; height: 127dp;"/>
-		<div class="jucePos elektronPanelGroove mmRuleV" style="left: 416dp; top: 312dp; width: 1dp; height: 127dp;"/>
-		<div class="jucePos elektronPanelGroove mmRuleV" style="left: 743dp; top: 312dp; width: 1dp; height: 127dp;"/>
-		<div class="jucePos elektronPanelGroove mmRuleV" style="left: 944dp; top: 312dp; width: 1dp; height: 127dp;"/>
+		<div class="elektronPixelRule jucePos mmScrewSlot" style="left: 1073dp; top: 546dp; width: 4dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGroove mmRuleV" style="left: 151dp; top: 35dp; width: 1dp; height: 277dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGroove mmRuleV" style="left: 821dp; top: 35dp; width: 1dp; height: 277dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGroove mmRuleV" style="left: 944dp; top: 35dp; width: 1dp; height: 277dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGroove mmRuleH" style="left: 0dp; top: 311dp; width: 945dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGroove mmRuleH" style="left: 0dp; top: 439dp; width: 1100dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGroove mmRuleV" style="left: 151dp; top: 312dp; width: 1dp; height: 127dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGroove mmRuleV" style="left: 416dp; top: 312dp; width: 1dp; height: 127dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGroove mmRuleV" style="left: 743dp; top: 312dp; width: 1dp; height: 127dp;"/>
+		<div class="elektronPixelRule jucePos elektronPanelGroove mmRuleV" style="left: 944dp; top: 312dp; width: 1dp; height: 127dp;"/>
 
 		<!-- Master, tempo and function. Labels sit on the faceplate, not inside oversized keys. -->
 
@@ -131,38 +131,38 @@
 		<!-- Page-position marks printed on the black fascia. -->
 
 		<div id="mmPageLed0" class="jucePos elektronLed mmPageLed mmDarkPageDot" style="left: 782dp; top: 130dp;"/>
-		<div class="jucePos mmDarkPageRule" style="left: 794dp; top: 134dp; width: 24dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmDarkPageRule" style="left: 794dp; top: 134dp; width: 24dp; height: 1dp;"/>
 		<div id="mmPageLed1" class="jucePos elektronLed mmPageLed mmDarkPageDot" style="left: 782dp; top: 148dp;"/>
-		<div class="jucePos mmDarkPageRule" style="left: 794dp; top: 152dp; width: 24dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmDarkPageRule" style="left: 794dp; top: 152dp; width: 24dp; height: 1dp;"/>
 		<div id="mmPageLed2" class="jucePos elektronLed mmPageLed mmDarkPageDot" style="left: 782dp; top: 166dp;"/>
-		<div class="jucePos mmDarkPageRule" style="left: 794dp; top: 170dp; width: 24dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmDarkPageRule" style="left: 794dp; top: 170dp; width: 24dp; height: 1dp;"/>
 		<div id="mmPageLed3" class="jucePos elektronLed mmPageLed mmDarkPageDot" style="left: 782dp; top: 184dp;"/>
-		<div class="jucePos mmDarkPageRule" style="left: 794dp; top: 188dp; width: 24dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmDarkPageRule" style="left: 794dp; top: 188dp; width: 24dp; height: 1dp;"/>
 		<div id="mmPageLed4" class="jucePos elektronLed mmPageLed mmDarkPageDot" style="left: 782dp; top: 202dp;"/>
-		<div class="jucePos mmDarkPageRule" style="left: 794dp; top: 206dp; width: 24dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmDarkPageRule" style="left: 794dp; top: 206dp; width: 24dp; height: 1dp;"/>
 		<div id="mmPageLed5" class="jucePos elektronLed mmPageLed mmDarkPageDot" style="left: 782dp; top: 220dp;"/>
-		<div class="jucePos mmDarkPageRule" style="left: 794dp; top: 224dp; width: 24dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmDarkPageRule" style="left: 794dp; top: 224dp; width: 24dp; height: 1dp;"/>
 		<div id="mmPageLed6" class="jucePos elektronLed mmPageLed mmDarkPageDot" style="left: 782dp; top: 238dp;"/>
-		<div class="jucePos mmDarkPageRule" style="left: 794dp; top: 242dp; width: 24dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmDarkPageRule" style="left: 794dp; top: 242dp; width: 24dp; height: 1dp;"/>
 
 		<!-- Silver DATA PAGE column. -->
 
 		<div class="jucePos mmPageStrip" style="left: 821dp; top: 35dp; width: 123dp; height: 276dp;"/>
 		<div class="jucePos juceLabel mmPageHeading" style="left: 858dp; top: 61dp; width: 50dp; height: 13dp; line-height: 13dp;">EDIT</div>
 		<button id="btDataPrev" class="jucePos juceButton elektronButton elektronKey elektronKey--light mmDataArrow" isToggle="0" style="left: 857dp; top: 99dp;"/>
-		<div class="jucePos mmPageRule" style="left: 828dp; top: 134dp; width: 27dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmPageRule" style="left: 828dp; top: 134dp; width: 27dp; height: 1dp;"/>
 		<div id="pageSynthesis" class="jucePos juceLabel mmPageLabel mmAffordance" title="Open Synthesis page" style="left: 858dp; top: 127dp; width: 78dp; height: 14dp; line-height: 14dp;">SYNTHESIS</div>
-		<div class="jucePos mmPageRule" style="left: 828dp; top: 152dp; width: 27dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmPageRule" style="left: 828dp; top: 152dp; width: 27dp; height: 1dp;"/>
 		<div id="pageAmplification" class="jucePos juceLabel mmPageLabel mmAffordance" title="Open Amplification page" style="left: 858dp; top: 145dp; width: 78dp; height: 14dp; line-height: 14dp;">AMPLIFICATION</div>
-		<div class="jucePos mmPageRule" style="left: 828dp; top: 170dp; width: 27dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmPageRule" style="left: 828dp; top: 170dp; width: 27dp; height: 1dp;"/>
 		<div id="pageFilter" class="jucePos juceLabel mmPageLabel mmAffordance" title="Open Filter page" style="left: 858dp; top: 163dp; width: 78dp; height: 14dp; line-height: 14dp;">FILTER</div>
-		<div class="jucePos mmPageRule" style="left: 828dp; top: 188dp; width: 27dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmPageRule" style="left: 828dp; top: 188dp; width: 27dp; height: 1dp;"/>
 		<div id="pageEffects" class="jucePos juceLabel mmPageLabel mmAffordance" title="Open Effects page" style="left: 858dp; top: 181dp; width: 78dp; height: 14dp; line-height: 14dp;">EFFECTS</div>
-		<div class="jucePos mmPageRule" style="left: 828dp; top: 206dp; width: 27dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmPageRule" style="left: 828dp; top: 206dp; width: 27dp; height: 1dp;"/>
 		<div id="pageLfo1" class="jucePos juceLabel mmPageLabel mmAffordance" title="Open LFO 1 page" style="left: 858dp; top: 199dp; width: 78dp; height: 14dp; line-height: 14dp;">LFO 1</div>
-		<div class="jucePos mmPageRule" style="left: 828dp; top: 224dp; width: 27dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmPageRule" style="left: 828dp; top: 224dp; width: 27dp; height: 1dp;"/>
 		<div id="pageLfo2" class="jucePos juceLabel mmPageLabel mmAffordance" title="Open LFO 2 page" style="left: 858dp; top: 217dp; width: 78dp; height: 14dp; line-height: 14dp;">LFO 2</div>
-		<div class="jucePos mmPageRule" style="left: 828dp; top: 242dp; width: 27dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmPageRule" style="left: 828dp; top: 242dp; width: 27dp; height: 1dp;"/>
 		<div id="pageLfo3" class="jucePos juceLabel mmPageLabel mmAffordance" title="Open LFO 3 page" style="left: 858dp; top: 235dp; width: 78dp; height: 14dp; line-height: 14dp;">LFO 3</div>
 		<button id="btDataNext" class="jucePos juceButton elektronButton elektronKey elektronKey--light mmDataArrow" isToggle="0" style="left: 857dp; top: 254dp;"/>
 
@@ -215,18 +215,18 @@
 
 		<!-- Lower strip: hardware mode pair and navigation matrix. -->
 
-		<div class="jucePos mmLowerBracket" style="left: 74dp; top: 330dp; width: 1dp; height: 21dp;"/>
-		<div class="jucePos mmLowerBracket" style="left: 74dp; top: 330dp; width: 10dp; height: 1dp;"/>
-		<div class="jucePos mmLowerBracket" style="left: 74dp; top: 350dp; width: 10dp; height: 1dp;"/>
-		<div class="jucePos mmLowerBracket" style="left: 74dp; top: 357dp; width: 1dp; height: 3dp;"/>
-		<div class="jucePos mmLowerBracket" style="left: 74dp; top: 365dp; width: 1dp; height: 3dp;"/>
-		<div class="jucePos mmLowerBracket" style="left: 74dp; top: 373dp; width: 1dp; height: 3dp;"/>
-		<div class="jucePos mmLowerBracket" style="left: 74dp; top: 381dp; width: 1dp; height: 3dp;"/>
-		<div class="jucePos mmLowerBracket" style="left: 74dp; top: 389dp; width: 1dp; height: 3dp;"/>
-		<div class="jucePos mmLowerBracket" style="left: 74dp; top: 397dp; width: 1dp; height: 3dp;"/>
-		<div class="jucePos mmLowerBracket" style="left: 74dp; top: 405dp; width: 1dp; height: 3dp;"/>
-		<div class="jucePos mmLowerBracket" style="left: 74dp; top: 413dp; width: 1dp; height: 3dp;"/>
-		<div class="jucePos mmLowerBracket" style="left: 74dp; top: 414dp; width: 9dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmLowerBracket" style="left: 74dp; top: 330dp; width: 1dp; height: 21dp;"/>
+		<div class="elektronPixelRule jucePos mmLowerBracket" style="left: 74dp; top: 330dp; width: 10dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmLowerBracket" style="left: 74dp; top: 350dp; width: 10dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmLowerBracket" style="left: 74dp; top: 357dp; width: 1dp; height: 3dp;"/>
+		<div class="elektronPixelRule jucePos mmLowerBracket" style="left: 74dp; top: 365dp; width: 1dp; height: 3dp;"/>
+		<div class="elektronPixelRule jucePos mmLowerBracket" style="left: 74dp; top: 373dp; width: 1dp; height: 3dp;"/>
+		<div class="elektronPixelRule jucePos mmLowerBracket" style="left: 74dp; top: 381dp; width: 1dp; height: 3dp;"/>
+		<div class="elektronPixelRule jucePos mmLowerBracket" style="left: 74dp; top: 389dp; width: 1dp; height: 3dp;"/>
+		<div class="elektronPixelRule jucePos mmLowerBracket" style="left: 74dp; top: 397dp; width: 1dp; height: 3dp;"/>
+		<div class="elektronPixelRule jucePos mmLowerBracket" style="left: 74dp; top: 405dp; width: 1dp; height: 3dp;"/>
+		<div class="elektronPixelRule jucePos mmLowerBracket" style="left: 74dp; top: 413dp; width: 1dp; height: 3dp;"/>
+		<div class="elektronPixelRule jucePos mmLowerBracket" style="left: 74dp; top: 414dp; width: 9dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mmKeyLabel mmSetupLabel" style="left: 16dp; top: 339dp; width: 60dp; height: 28dp; line-height: 12dp;">KIT / SONG<br/>SETUP</div>
 		<div class="jucePos elektronStatusList" style="left: 84dp; top: 321dp; width: 65dp; height: 36dp;">
 			<div class="elektronStatusItem">
@@ -262,7 +262,7 @@
 			<button id="btBankGrp" class="juceButton elektronButton elektronKey mmBankGroup" isToggle="0"/>
 			<div id="altMuteMode" class="juceLabel elektronButtonCaption elektronSecondary compact mmAffordance" title="FUNCTION + BANK: Mute mode">MUTE MODE</div>
 		</div>
-		<div class="jucePos mmBankLetterRule" style="left: 494dp; top: 340dp; width: 230dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmBankLetterRule" style="left: 494dp; top: 340dp; width: 230dp; height: 1dp;"/>
 		<div class="jucePos juceLabel mmBankLetter" style="left: 495dp; top: 315dp; width: 49dp; height: 10dp; line-height: 10dp;">A</div>
 		<div class="jucePos juceLabel mmBankLetter" style="left: 555dp; top: 315dp; width: 49dp; height: 10dp; line-height: 10dp;">B</div>
 		<div class="jucePos juceLabel mmBankLetter" style="left: 615dp; top: 315dp; width: 49dp; height: 10dp; line-height: 10dp;">C</div>
@@ -310,13 +310,13 @@
 
 		<!-- Vertical trig-mode list and compact software utility. -->
 
-		<div class="jucePos mmTrigBracket" style="left: 960dp; top: 349dp; width: 1dp; height: 65dp;"/>
-		<div class="jucePos mmTrigBracket" style="left: 960dp; top: 349dp; width: 9dp; height: 1dp;"/>
-		<div class="jucePos mmTrigBracket" style="left: 960dp; top: 413dp; width: 8dp; height: 1dp;"/>
-		<div class="jucePos mmTrigBracketDot" style="left: 971dp; top: 413dp; width: 3dp; height: 1dp;"/>
-		<div class="jucePos mmTrigBracketDot" style="left: 978dp; top: 413dp; width: 3dp; height: 1dp;"/>
-		<div class="jucePos mmTrigBracketDot" style="left: 985dp; top: 413dp; width: 3dp; height: 1dp;"/>
-		<div class="jucePos mmTrigBracketDot" style="left: 992dp; top: 413dp; width: 3dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmTrigBracket" style="left: 960dp; top: 349dp; width: 1dp; height: 65dp;"/>
+		<div class="elektronPixelRule jucePos mmTrigBracket" style="left: 960dp; top: 349dp; width: 9dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmTrigBracket" style="left: 960dp; top: 413dp; width: 8dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmTrigBracketDot" style="left: 971dp; top: 413dp; width: 3dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmTrigBracketDot" style="left: 978dp; top: 413dp; width: 3dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmTrigBracketDot" style="left: 985dp; top: 413dp; width: 3dp; height: 1dp;"/>
+		<div class="elektronPixelRule jucePos mmTrigBracketDot" style="left: 992dp; top: 413dp; width: 3dp; height: 1dp;"/>
 		<div id="mmTrigAmp" class="jucePos elektronLed mmModeDot" style="left: 970dp; top: 354dp;"/>
 		<div id="trigModeAmp" class="jucePos juceLabel mmTrigModeLabel mmAffordance" title="Select AMP trig mode" style="left: 981dp; top: 349dp; width: 42dp; height: 14dp; line-height: 14dp;">AMP</div>
 		<div id="mmTrigFilter" class="jucePos elektronLed mmModeDot" style="left: 970dp; top: 373dp;"/>

--- a/source/elektron/md/mdJucePlugin/tus_settings_gui_Machinedrum.rml
+++ b/source/elektron/md/mdJucePlugin/tus_settings_gui_Machinedrum.rml
@@ -3,6 +3,16 @@
 </head>
 <body>
 	<settingsspacer1/>
+	<h1>Panel Rendering</h1>
+	<settingsspacer1/>
+	<div id="btPixelPerfectPanel" class="settings-checkboxwithlabel">
+		<button id="button" class="settings-checkbox"/>
+		<label>Crisp LCD and panel lines (experimental)</label>
+	</div>
+	<settingsspacer1/>
+	<label>Use whole-pixel LCD enlargement and align thin panel lines to pixels. Changes immediately; the LCD may appear smaller with more space around it.</label>
+
+	<settingsspacer1/>
 	<div class="settings-advanced">
 		<h1>Panel Feel</h1>
 		<settingsspacer1/>

--- a/source/elektron/md/mdJucePlugin/tus_settings_gui_Monomachine.rml
+++ b/source/elektron/md/mdJucePlugin/tus_settings_gui_Monomachine.rml
@@ -19,6 +19,16 @@
 </head>
 <body>
 	<settingsspacer1/>
+	<h1>Panel Rendering</h1>
+	<settingsspacer1/>
+	<div id="btPixelPerfectPanel" class="settings-checkboxwithlabel">
+		<button id="button" class="settings-checkbox"/>
+		<label>Crisp LCD and panel lines (experimental)</label>
+	</div>
+	<settingsspacer1/>
+	<label>Use whole-pixel LCD enlargement and align thin panel lines to pixels. Changes immediately; the LCD may appear smaller with more space around it.</label>
+
+	<settingsspacer1/>
 	<h1>Machine Storage</h1>
 	<settingsspacer1/>
 	<label>Load a complete 1 MiB storage image. Content is not bundled; the Factory button remembers the file you choose. Ordinary source files are never modified.</label>

--- a/source/jucePluginEditorLib/pluginEditor.cpp
+++ b/source/jucePluginEditorLib/pluginEditor.cpp
@@ -824,6 +824,11 @@ namespace jucePluginEditorLib
 		_plugins.push_back(std::make_unique<SettingsDspBridge>(getProcessor()));
 	}
 
+	std::string Editor::getSettingsTemplateSuffix() const
+	{
+		return getProcessor().getProperties().name;
+	}
+
 	juce::Component* Editor::createRmlUiComponent(const std::string& _rmlFile)
 	{
 		if (!m_rmlPlugin)
@@ -832,7 +837,7 @@ namespace jucePluginEditorLib
 		juceRmlUi::RmlComponentConfig config;
 
 		// add product specific settings template files
-		const auto productName = getProcessor().getProductName();
+		const auto productName = getSettingsTemplateSuffix();
 
 		auto files = getAllFilenames();
 

--- a/source/jucePluginEditorLib/pluginEditor.h
+++ b/source/jucePluginEditorLib/pluginEditor.h
@@ -160,6 +160,8 @@ namespace jucePluginEditorLib
 		void registerSettings(std::vector<std::unique_ptr<SettingsPlugin>>& _plugins);
 
 		virtual std::unique_ptr<SettingsDeviceSpecific> createDeviceSpecificSettings(const std::string& _templateName, Rml::Element* _root) { return nullptr; }
+		// Resource identity can remain stable when a product's display name changes.
+		virtual std::string getSettingsTemplateSuffix() const;
 
 		juce::Component* createRmlUiComponent(const std::string& _rmlFile);
 

--- a/source/jucePluginEditorLib/settingsCategory.cpp
+++ b/source/jucePluginEditorLib/settingsCategory.cpp
@@ -26,7 +26,7 @@ namespace jucePluginEditorLib
 		// add device specific settings if available
 		if (auto* containerDeviceSpecific = juceRmlUi::helper::findChild(m_page, "containerDeviceSpecific", false))
 		{
-			const auto templateName = _plugin->getTemplateName() + '_' + _settings.getEditor().getProcessor().getProperties().name;
+			const auto templateName = _plugin->getTemplateName() + '_' + _settings.getEditor().getSettingsTemplateSuffix();
 
 			if (juceRmlUi::helper::hasTemplate(templateName, containerDeviceSpecific))
 			{

--- a/source/jucePluginEditorLib/settingsPlugin.cpp
+++ b/source/jucePluginEditorLib/settingsPlugin.cpp
@@ -21,7 +21,7 @@ namespace jucePluginEditorLib
 		return true;
 	}
 
-	bool SettingsPlugin::createToggleButton(Rml::Element* _root, const std::string& _buttonName, juce::PropertiesFile& _config, const std::string& _configName, const std::function<void(bool)>& _changeCallback)
+	bool SettingsPlugin::createToggleButton(Rml::Element* _root, const std::string& _buttonName, juce::PropertiesFile& _config, const std::string& _configName, const std::function<void(bool)>& _changeCallback, const bool _defaultEnabled)
 	{
 		auto* btRoot = juceRmlUi::helper::findChild(_root, _buttonName, false);
 
@@ -30,13 +30,13 @@ namespace jucePluginEditorLib
 
 		auto* bt = juceRmlUi::helper::findChild(btRoot, "button");
 
-		const auto enabled = _config.getBoolValue(_configName, false);
+		const auto enabled = _config.getBoolValue(_configName, _defaultEnabled);
 		juceRmlUi::ElemButton::setChecked(bt, enabled);
 
-		juceRmlUi::EventListener::AddClick(btRoot, [bt, &_config, _changeCallback, _configName]
+		juceRmlUi::EventListener::AddClick(btRoot, [bt, &_config, _changeCallback, _configName, _defaultEnabled]
 		{
 			auto& c = _config;
-			const auto enabled = c.getBoolValue(_configName, false);
+			const auto enabled = c.getBoolValue(_configName, _defaultEnabled);
 			juceRmlUi::ElemButton::setChecked(bt, !enabled);
 			c.setValue(_configName, !enabled);
 			c.saveIfNeeded();

--- a/source/jucePluginEditorLib/settingsPlugin.h
+++ b/source/jucePluginEditorLib/settingsPlugin.h
@@ -38,7 +38,8 @@ namespace jucePluginEditorLib
 			const std::string& _buttonName,
 			juce::PropertiesFile& _config,
 			const std::string& _configName,
-			const std::function<void(bool)>& _changeCallback);
+			const std::function<void(bool)>& _changeCallback,
+			bool _defaultEnabled = false);
 
 	protected:
 		bool createToggleButton(Rml::Element* _root,

--- a/source/juceRmlUi/juceRmlComponent.cpp
+++ b/source/juceRmlUi/juceRmlComponent.cpp
@@ -811,6 +811,14 @@ namespace juceRmlUi
 		std::fputc('\n', stderr);
 	}
 
+	void RmlComponent::setUseNativePixelDensity(const bool _enabled)
+	{
+		if (m_useNativePixelDensity == _enabled)
+			return;
+		m_useNativePixelDensity = _enabled;
+		enqueueUpdate();
+	}
+
 	float RmlComponent::getOpenGLRenderingScale() const
 	{
 		if (m_openGLContext)
@@ -820,6 +828,9 @@ namespace juceRmlUi
 		if (m_metalContext)
 			return static_cast<float>(m_metalContext->getRenderingScale());
 #endif
+
+		if (m_useNativePixelDensity)
+			return m_softwarePixelScale;
 
 		float scale = 1.0f;
 		const Component* t = this;
@@ -1090,7 +1101,7 @@ namespace juceRmlUi
 		const auto clipOrigin = _g.getClipBounds().getPosition();
 		const auto areaInRoot = rootComp->getLocalArea(this, getLocalBounds());
 		const bool coversRoot = areaInRoot == rootComp->getLocalBounds();
-		const bool useDirectPath = img.isValid() && clipOrigin.isOrigin() && coversRoot;
+		const bool useDirectPath = !m_useNativePixelDensity && img.isValid() && clipOrigin.isOrigin() && coversRoot;
 
 		const auto size = getRenderSize();
 
@@ -1104,6 +1115,17 @@ namespace juceRmlUi
 			m_screenshotState = ScreenshotState::ScreenshotReady;
 
 		m_renderDone = true;
+
+		// Read the effective backing scale from the actual drawing context, not
+		// just component transforms. Rebuild on the next frame when moving between
+		// displays; the already queued frame must finish at its original scale.
+		const auto pixelScale = _g.getInternalContext().getPhysicalPixelScaleFactor();
+		if (pixelScale > 0 && std::abs(pixelScale - m_softwarePixelScale) > 0.001f)
+		{
+			m_softwarePixelScale = pixelScale;
+			if (m_useNativePixelDensity)
+				enqueueUpdate();
+		}
 	}
 
 	juce::Component* RmlComponent::getComponentAt(const juce::Point<float> _position)

--- a/source/juceRmlUi/juceRmlComponent.cpp
+++ b/source/juceRmlUi/juceRmlComponent.cpp
@@ -938,6 +938,9 @@ namespace juceRmlUi
 			evPreUpdate(this);
 
 			m_rmlContext->Update();
+			// The queued geometry must retain its own scale until it is painted,
+			// even if a setting or the display density changes in between.
+			m_softwareFrameScale = getOpenGLRenderingScale();
 			m_rmlContext->Render();
 
 			m_renderProxy->finishFrame();
@@ -1101,15 +1104,15 @@ namespace juceRmlUi
 		const auto clipOrigin = _g.getClipBounds().getPosition();
 		const auto areaInRoot = rootComp->getLocalArea(this, getLocalBounds());
 		const bool coversRoot = areaInRoot == rootComp->getLocalBounds();
-		const bool useDirectPath = !m_useNativePixelDensity && img.isValid() && clipOrigin.isOrigin() && coversRoot;
-
-		const auto size = getRenderSize();
+		const auto size = m_rmlContext->GetDimensions();
+		const bool useDirectPath = !m_useNativePixelDensity && img.isValid() && clipOrigin.isOrigin() && coversRoot
+			&& img.getWidth() == size.x && img.getHeight() == size.y;
 
 		r->beginFrame(_g, size);
 
 		m_renderProxy->executeRenderFunctions();
 
-		r->endFrame(useDirectPath ? img : juce::Image(), getOpenGLRenderingScale());
+		r->endFrame(useDirectPath ? img : juce::Image(), m_softwareFrameScale);
 
 		if (m_screenshotState == ScreenshotState::RequestScreenshot && r->captureFrame(m_screenshot))
 			m_screenshotState = ScreenshotState::ScreenshotReady;

--- a/source/juceRmlUi/juceRmlComponent.h
+++ b/source/juceRmlUi/juceRmlComponent.h
@@ -123,6 +123,7 @@ namespace juceRmlUi
 		juce::Point<int> toRmlPosition(int _x, int _y) const;
 
 		float getOpenGLRenderingScale() const;
+		void setUseNativePixelDensity(bool _enabled);
 
 		Rml::Vector2i getDocumentSize() const { return m_documentSize; }
 
@@ -183,6 +184,8 @@ namespace juceRmlUi
 		std::vector<juce::KeyPress> m_pressedKeys;
 		float m_contentScale = 1.0f;
 		float m_currentRenderScale = 0.0f;
+		bool m_useNativePixelDensity = false;
+		float m_softwarePixelScale = 1.0f;
 
 		std::mutex m_timerMutex;
 		std::mutex m_contextRenderMutex;

--- a/source/juceRmlUi/juceRmlComponent.h
+++ b/source/juceRmlUi/juceRmlComponent.h
@@ -149,6 +149,7 @@ namespace juceRmlUi
 		Rml::Element* getLastElementByGetComponentAt() const { return m_lastGetComponentAt.get(); }
 
 	private:
+		friend struct RenderingTestAccess;
 		void update();
 		void createRmlContext(const ContextCreatedCallback& _contextCreatedCallback);
 		void destroyRmlContext();
@@ -186,6 +187,7 @@ namespace juceRmlUi
 		float m_currentRenderScale = 0.0f;
 		bool m_useNativePixelDensity = false;
 		float m_softwarePixelScale = 1.0f;
+		float m_softwareFrameScale = 1.0f;
 
 		std::mutex m_timerMutex;
 		std::mutex m_contextRenderMutex;

--- a/source/juceRmlUi/rmlElemCanvas.cpp
+++ b/source/juceRmlUi/rmlElemCanvas.cpp
@@ -40,8 +40,8 @@ namespace juceRmlUi
 		auto* comp = RmlComponent::fromElement(this);
 		if (comp)
 			comp->enqueueUpdate();
-		else
-			GetContext()->RequestNextUpdate(0);
+		else if (auto* context = GetContext())
+			context->RequestNextUpdate(0);
 	}
 
 	void ElemCanvas::setClearEveryFrame(const bool _clearEveryFrame)

--- a/source/juceRmlUi/rmlElemCanvas.cpp
+++ b/source/juceRmlUi/rmlElemCanvas.cpp
@@ -49,6 +49,15 @@ namespace juceRmlUi
 		m_clearEveryFrame = _clearEveryFrame;
 	}
 
+	void ElemCanvas::setPixelAligned(const bool _enabled)
+	{
+		if (m_pixelAligned == _enabled)
+			return;
+		m_pixelAligned = _enabled;
+		m_geometryDirty = true;
+		repaint();
+	}
+
 	ElemCanvas* ElemCanvas::create(Rml::Element* _parent)
 	{
 		auto canvas = _parent->GetOwnerDocument()->CreateElement("canvas");
@@ -73,8 +82,8 @@ namespace juceRmlUi
 		const auto quadColour = computed.image_color().ToPremultiplied(computed.opacity());
 		const auto renderBox = GetRenderBox(BoxArea::Content);
 
-		const auto origin = renderBox.GetFillOffset();
-		const auto size = renderBox.GetFillSize();
+		auto origin = renderBox.GetFillOffset();
+		auto size = renderBox.GetFillSize();
 
 		const auto* comp = RmlComponent::fromElement(this);
 
@@ -89,7 +98,20 @@ namespace juceRmlUi
 			m_textureDirty = true;
 		}
 
-		MeshUtilities::GenerateQuad(mesh, origin, size, quadColour, Vector2f(0,0), Vector2f(1,1));
+		auto uvEnd = Vector2f(1, 1);
+		if (m_pixelAligned)
+		{
+			// Keep a one-to-one mapping between the canvas pixels and the render
+			// target, including backends which pad textures to powers of two.
+			const Vector2i paintSize(std::min(static_cast<int>(size.x), w), std::min(static_cast<int>(size.y), h));
+			if (paintSize != m_paintSize)
+				m_textureDirty = true;
+			m_paintSize = paintSize;
+			size = Vector2f(m_paintSize);
+			origin = origin.Round();
+			uvEnd = {w > 0 ? size.x / w : 0, h > 0 ? size.y / h : 0};
+		}
+		MeshUtilities::GenerateQuad(mesh, origin, size, quadColour, Vector2f(0,0), uvEnd);
 
 		if (RenderManager* rm = GetRenderManager())
 			m_geometry = rm->MakeGeometry(std::move(mesh));
@@ -128,7 +150,10 @@ namespace juceRmlUi
 			generateTexture();
 
 		if (m_textureSize.x > 0 && m_textureSize.y > 0)
-			m_geometry.Render(GetAbsoluteOffset(BoxArea::Border), m_texture);
+		{
+			auto offset = GetAbsoluteOffset(BoxArea::Border);
+			m_geometry.Render(m_pixelAligned ? offset.Round() : offset, m_texture);
+		}
 	}
 
 	void ElemCanvas::OnResize()

--- a/source/juceRmlUi/rmlElemCanvas.h
+++ b/source/juceRmlUi/rmlElemCanvas.h
@@ -31,6 +31,8 @@ namespace juceRmlUi
 		void repaint();
 
 		void setClearEveryFrame(bool _clearEveryFrame);
+		void setPixelAligned(bool _enabled);
+		Rml::Vector2i getPaintSize() const { return m_pixelAligned ? m_paintSize : m_textureSize; }
 
 		static ElemCanvas* create(Rml::Element* _parent);
 
@@ -58,5 +60,7 @@ namespace juceRmlUi
 		RepaintGraphicsCallback m_repaintGraphicsCallback;
 
 		bool m_clearEveryFrame = false;
+		bool m_pixelAligned = false;
+		Rml::Vector2i m_paintSize{0, 0};
 	};
 }


### PR DESCRIPTION
The MD/MM LCD was stretched independently in each direction, and fractional GUI scaling could produce unequal LCD pixel widths and soft panel hairlines. This preserves the LCD's 2:1 aspect ratio and adds a default-off **Crisp LCD and panel lines (experimental)** checkbox under Escape → GUI → Panel Rendering for immediate comparison at the same window size.

With the option enabled, the LCD uses the largest integer enlargement that fits, centered on rendering pixels with spare background space. Explicitly marked flat panel rules snap to whole pixels; text, curves and knob artwork retain normal rendering. Software rendering uses the actual backing density, and the LCD canvas avoids a second fractional resampling. Tiny windows use an aspect-fit fallback bounded by the visible canvas, including when textures require padding.

The setting is saved and reapplied when reopening the editor. Existing percentage presets and window dimensions are unchanged. Both modes include the aspect-ratio correction.

The experiment is owned by `PixelPerfectPanel`, with two small editor hooks and one shared config key/default for the checkbox and editor. It uses explicit skin markers and observer pointers, and restores backgrounds/removes helpers on teardown. `PANEL_RENDERING_EXPERIMENT.md` documents how to promote or remove it while keeping the independent aspect-ratio and settings-template fixes.

Other correctness fixes:

- Queued software geometry retains the scale at which it was generated, so toggling or changing display density cannot resize an already queued frame. The direct image-copy shortcut also checks destination dimensions.
- Detached canvases can be invalidated safely without dereferencing a missing context.
- Product-specific templates use Machinedrum/Monomachine while the public names are Gearmulator MD/MM. A stable settings-template suffix makes those resources reachable in the actual overlay.

Validation:

- Native arm64 Release MD and MM builds and actual embedded-skin rendering probes passed. Across 50/100/125/150/200% GUI sizes and simulated backing densities 1/1.25/2 (30 combinations), final output confirms equal LCD blocks, solid snapped hairlines, unchanged window dimensions and exact baseline restoration when disabled. The product probes were rerun after controller extraction and explicit skin marking.
- Actual checkbox clicks and saved-on skin reload passed for both products.
- New firmware-free `mdPanelRenderingTest` runs in the macOS VST3 CI job. It covers pending-frame toggles, density changes, direct-copy bounds, pointer mapping, integer LCD output, padded-texture fallback, unmarked-element isolation, removed/detached elements and controller teardown.
- The regression test fails when linked with the original frame implementation. Restoring the old padded-size fallback also fails the edge-visibility check.
- The user accepted the initial installed build (`7bb666bc`) in Live. The subsequent review fixes have local regression coverage; they have not yet replaced that installed build.

Remaining limits: GPU visual behavior, actual monitor migration and Windows/Linux runtime behavior have not been validated locally. Native-density software rendering may cost more CPU; rendering CPU cost has not been benchmarked. The option remains experimental and off by default.
