### PR TITLE
Test Monomachine legacy project migration and DigiPRO flash restore

### DIFF
--- a/source/elektron/md/mdJucePlugin/mdProjectStateRestoreTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdProjectStateRestoreTest.cpp
@@ -780,9 +780,10 @@ int main()
 			"concurrent Monomachine restore published an invalid device envelope");
 		std::vector<uint8_t> mmWinningPayload(mmWinningState.begin() + 2,
 			mmWinningState.end());
-		std::vector<uint8_t> mmWinningPatch;
-		require(md::decodeState(mmWinningPatch, mmWinningPayload,
-			md::MachineModel::Monomachine, synthLib::StateTypeGlobal),
+		md::DecodedState mmWinningDecoded;
+		require(md::decodeState(mmWinningDecoded, mmWinningPayload, {},
+			md::MachineModel::Monomachine, synthLib::StateTypeGlobal)
+			&& mmWinningDecoded.containsFlash,
 			"concurrent Monomachine restore published a torn or corrupt state");
 		mmCold.processor.getPlugin().withDeviceLocked(
 			[&](synthLib::Device* const _device)
@@ -790,7 +791,8 @@ int main()
 				auto* const device = dynamic_cast<md::Device*>(_device);
 				require(device && device->getModel() == md::MachineModel::Monomachine
 					&& device->projectStateRestoreStatus() == RestoreStatus::Idle
-					&& device->getHardware().getUC().copyPatchRam() == mmWinningPatch,
+					&& device->getHardware().copyPatchRam() == mmWinningDecoded.patchRam
+					&& device->getHardware().copyUserFlash() == mmWinningDecoded.userFlash,
 					"Monomachine serialization did not match the committed live machine");
 				require(md::DevicePreparedStateTestAccess::publisher(device->getHardware())
 					== md::DevicePreparedStateTestAccess::livePublisher(*device),

--- a/source/elektron/md/mdJucePlugin/mdProjectStateRestoreTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdProjectStateRestoreTest.cpp
@@ -2,6 +2,7 @@
 
 #include "mdLib/mddevice.h"
 #include "mdLib/mdhardware.h"
+#include "mdLib/mdmemorymap.h"
 #include "mdLib/mdromloader.h"
 #include "mdLib/mdstate.h"
 #include "mdLib/mdtypes.h"
@@ -97,11 +98,16 @@ namespace
 		return result;
 	}
 
-	std::vector<uint8_t> mmPluginState(const std::vector<uint8_t>& _patch)
+	std::vector<uint8_t> mmPluginState(const std::vector<uint8_t>& _patch,
+		const std::vector<uint8_t>& _userFlash = {})
 	{
 		std::vector<uint8_t> state;
-		require(md::encodeState(state, _patch, md::MachineModel::Monomachine,
-			synthLib::StateTypeGlobal),
+		const auto encoded = _userFlash.empty()
+			? md::encodeState(state, _patch, md::MachineModel::Monomachine,
+				synthLib::StateTypeGlobal)
+			: md::encodeState(state, _patch, md::MachineModel::Monomachine,
+				synthLib::StateTypeGlobal, _userFlash);
+		require(encoded,
 			"could not encode Monomachine processor restore fixture");
 		std::vector<uint8_t> result{1, synthLib::StateTypeGlobal};
 		result.insert(result.end(), state.begin(), state.end());
@@ -701,8 +707,38 @@ int main()
 			&& mmRestoredBeforeAudio.hardwareEpoch == mmBefore.hardwareEpoch + 1
 			&& mmRestoredBeforeAudio.liveHardware != mmBefore.liveHardware,
 			"Monomachine cold state was not committed before audio startup");
-		require(serializedPluginState(mmCold.processor) == mmStateA,
-			"Monomachine cold-start serialization lost the restored project");
+		// Version-1 projects contain only patch RAM. Saving them upgrades to the
+		// current format, adding the ROM's DigiPRO flash window. Compare against
+		// that complete expected state, including every patch and flash byte.
+		const auto mmFlashBegin = mmRom.begin() + md::memorymap::g_flashFull.offset(
+			md::memorymap::g_mmUserFlash.begin);
+		const std::vector<uint8_t> mmDefaultFlash(mmFlashBegin,
+			mmFlashBegin + md::g_mmUserFlashStateSize);
+		require(serializedPluginState(mmCold.processor)
+			== mmPluginState(mmPatchA, mmDefaultFlash),
+			"Monomachine legacy restore changed patch RAM or default DigiPRO flash");
+		require(mmRestoredBeforeAudio.liveHardware->copyPatchRam() == mmPatchA
+			&& mmRestoredBeforeAudio.liveHardware->copyUserFlash() == mmDefaultFlash,
+			"Monomachine legacy restore did not initialize the live machine");
+
+		// Current projects must also restore their private flash, rather than
+		// replacing it with ROM bytes during the cold-start hardware transaction.
+		auto mmProjectFlash = mmDefaultFlash;
+		mmProjectFlash.front() ^= 0x31;
+		mmProjectFlash[mmProjectFlash.size() / 2] ^= 0x52;
+		mmProjectFlash.back() ^= 0x73;
+		const auto mmCompleteStateA = mmPluginState(mmPatchA, mmProjectFlash);
+		setHostState(mmCold, mmCompleteStateA);
+		const auto mmCompleteRestore = mmCold.snapshot();
+		require(mmCompleteRestore.status == RestoreStatus::Idle
+			&& mmCompleteRestore.hardwareEpoch == mmRestoredBeforeAudio.hardwareEpoch + 1
+			&& mmCompleteRestore.liveHardware != mmRestoredBeforeAudio.liveHardware,
+			"Monomachine complete state was not committed before audio startup");
+		require(serializedPluginState(mmCold.processor) == mmCompleteStateA,
+			"Monomachine cold-start serialization lost patch RAM or DigiPRO flash");
+		require(mmCompleteRestore.liveHardware->copyPatchRam() == mmPatchA
+			&& mmCompleteRestore.liveHardware->copyUserFlash() == mmProjectFlash,
+			"Monomachine complete restore did not initialize the live machine");
 		mmCold.prepareAudio();
 		mmCold.process(128);
 


### PR DESCRIPTION
The local alpha.10 firmware gate fails after restoring a legacy Monomachine project because the test expects the original version-1 patch-only byte stream. Production saves now use version 2 and also include the 2 MiB DigiPRO flash window. The concurrent-restore check also uses the version-1-only decoder, which rejects valid current saves.

Update the test to require the complete expected migrated state (all patch bytes plus the ROM user-flash window) and the same contents in live hardware. Add a current-format cold restore with changed flash bytes and require exact serialized and live-memory equality. Decode concurrent saves with the full-state API and compare both memories to the committed live machine. Production code and dependency pins are unchanged.

Validation: the complete universal macOS `mdProjectStateRestoreTest` passes with both pinned private firmware images (62.59 s, exit 0, no skip). This exercises MD and MM cold-start lifecycle, legacy migration, modified DigiPRO flash, concurrent replacement while audio runs, live publisher rebinding, and malformed-state diagnostics. The source delta is confined to this test; runtime code and dependency pins are unchanged. All three final-head PR checks pass: Windows headless core, Linux core, and macOS JUCE/built-VST3 tests. Final release packages will be rebuilt and verified after merge.
