### PR TITLE
Stop private panel task-list updates for Monomachine only

### DIFF
--- a/source/elektron/md/mdLib/mdmc.cpp
+++ b/source/elektron/md/mdLib/mdmc.cpp
@@ -572,7 +572,7 @@ namespace md
 
 		auto inSram = [](const uint32_t _a) { return !(_a & 3) && _a >= g_sramBase && _a <= (g_sramEnd - 4); };
 
-		// The public driver validates the notification slot before updating it.
+		// Validate the retained workaround's notification slot before updating it.
 		if(readMem32(g_semaphoreSlot) != g_semaphore)
 			return;
 
@@ -605,7 +605,7 @@ namespace md
 				return;
 		}
 
-		// Complete the public driver's bounded panel-ready update.
+		// Apply the retained workaround's bounded task-list update.
 		writeMem32(g_semaphore, count);
 		writeMem32(g_semaphore + 4, 0);
 

--- a/source/elektron/md/mdLib/mdmc.cpp
+++ b/source/elektron/md/mdLib/mdmc.cpp
@@ -542,8 +542,10 @@ namespace md
 		if(m_externalIrq4Pending || m_sim.externalIrq4Asserted())
 			serviceExternalIrq4();
 
-		// Periodically service the public MAME driver's panel-ready notification.
-		if(m_panelDisplayReady && ((m_panelDisplayReadyDivider += _instructions) & 0x3fff) == 0)
+		// Temporary MD firmware task-list workaround, not panel peripheral emulation.
+		// MM boot and continued panel operation do not require these private writes.
+		if(m_model == MachineModel::Machinedrum && m_panelDisplayReady
+			&& ((m_panelDisplayReadyDivider += _instructions) & 0x3fff) == 0)
 			panelDisplayReadyPost();
 	}
 
@@ -560,7 +562,8 @@ namespace md
 
 	void Microcontroller::panelDisplayReadyPost()
 	{
-		// Panel-ready notification compatible with MAME's Elektron driver.
+		// Retained MD firmware task-list manipulation. A hardware-level readiness
+		// replacement is still needed; the original MAME attribution is unverified.
 		constexpr uint32_t g_semaphore       = 0x002899e8;
 		constexpr uint32_t g_semaphoreSlot   = 0x0028d714;
 		constexpr uint32_t g_highestReadyList= 0x01001dc4;

--- a/source/elektron/md/mdLib/mdmc.h
+++ b/source/elektron/md/mdLib/mdmc.h
@@ -211,7 +211,7 @@ namespace md
 		void logPeripheral(uint32_t _addr, uint32_t _value, uint8_t _size, bool _write);
 		void onPanelTransmit(uint8_t _byte);	// startup reply modeled from the public MAME driver
 
-		// Match MAME's panel-ready notification after the startup handshake.
+		// Temporary MD-only firmware task-list workaround, not panel emulation.
 		// Runs on the CPU thread.
 		void panelDisplayReadyPost();
 


### PR DESCRIPTION
## Scope

Stop private panel task-list updates for Monomachine only. The sole executable change restricts the existing update to Machinedrum; the other changes clarify the retained workaround's comments. Two production files, +9/-6 overall. Existing batching logic and its conservative idle cap remain; MM no longer advances a divider for the removed private post.

Targets the shared `release/md-mm-alpha` branch directly. Previously stacked on #49 to reuse its MM boot/edited-kit/state/panel regression; #49 is now merged as `82316d34`. No rebase, cherry-pick, or source-level dependency replacement was needed. Extracted from large draft #43 (`95930077`), adapted to current batching.

**Explicitly partial:** the Machinedrum private task-list workaround remains. Its hardware-level replacement and panel-protocol provenance are unresolved. No guessed panel responses or new private-state workaround are added.

## Focused review and verification

- Reviewed executable change at `f4bae35f`: 13/13 selected/required tests pass on both ARM64 and x86-64/Rosetta, including MM cold boot, edited-kit save/readback, state-restored hardware, further edits and panel/audio behavior, plus MD UW/RAM and both models' audio soaks. No skips.
- An additional panel-initialized six-voice sine/audio check and its oracle self-test pass on both architectures, including audible parameter/SRR burst responses.
- A research-only, firmware-free model/readiness/divider/idle-cap probe passes 100 checks on each architecture. An ARM64 pre-#52 control fails the new expectations as intended and passes the old expectations. No firmware-private addresses were used in that probe.
- Comment-only polish at `dbdce8ee`: replaced three stale MAME/public-driver attributions with neutral wording. Rebuilt ARM64 targets; 6/6 focused fixture-free tests pass. The rebuilt MM boot and idle-self-branch executables are byte-identical to their reviewed pre-polish versions. This was not a new full firmware run.
- Release DSP `8c919d2b` and MCU `1ae33bff` pins remain unchanged. The broader unchanged scheduler test's pre-existing Rosetta timeout was investigated in #49 and was not repeated in the 13-test #52 selection.
- Earlier Linux release/ASan/UBSan core workflow `34131493857` passed; sanitizer needed an unchanged-head retry after an intermittent performance-report assertion. Earlier Linux/Windows plugin rendering failures reproduced on unchanged release control `34132521048`; macOS plugin passed. These historical caveats are not fixes in this PR. New-head automatic CI is separate from the recorded local evidence.

No blocking code-review finding. Keep draft pending owner merge approval; no complete MD panel-remediation, verified protocol-provenance, or hardware-equivalence claim. Original large drafts remain unchanged. Detailed review and probe artifacts stay in the local research tree, not under product `doc/`.
