### PR TITLE
Add opt-in Apple ThinLTO and PGO for MD/MM

### DIFF
--- a/doc/mdmm-apple-optimization.md
+++ b/doc/mdmm-apple-optimization.md
@@ -1,0 +1,51 @@
+# MD/MM Apple compiler optimization
+
+MD/MM provides opt-in compiler settings for Release builds on macOS. The
+default configuration uses the existing compiler settings. The options apply
+to shared emulation libraries, so other products linked to those libraries
+also consume the selected build.
+
+| CMake option | Default | Effect |
+| --- | --- | --- |
+| `GEARMULATOR_MDMM_APPLE_THINLTO` | `OFF` | Build `mdLib` and `68kEmu` with ThinLTO and propagate the option to their final executable/plugin links. |
+| `GEARMULATOR_MDMM_APPLE_OPTIMIZE_DSP` | `OFF` | Extend the selected optimization to `dsp56kEmu` and `dsp56kBase`. |
+| `GEARMULATOR_MDMM_APPLE_PGO_MODE` | `none` | Select `none`, `generate`, or `use` for profile-guided optimization. |
+| `GEARMULATOR_MDMM_APPLE_PGO_PROFILE` | Empty | Path to the merged profile for `use` mode. |
+
+Add these options to the normal MD/MM build configuration. PGO requires
+ThinLTO and one explicit `CMAKE_OSX_ARCHITECTURES` value. Train and build each
+architecture separately. ThinLTO alone can also be used in a universal build.
+The flags apply only to Release configurations.
+
+## Profile generation and use
+
+1. Pin the parent and submodule revisions, compiler, architecture, and build
+   definitions. Keep a record of these and the workload used for training.
+2. Configure an instrumented Release build with
+   `GEARMULATOR_MDMM_APPLE_THINLTO=ON` and
+   `GEARMULATOR_MDMM_APPLE_PGO_MODE=generate`. Select the same DSP option for
+   generation and use.
+3. Create an empty profile directory. Launch the instrumented executable
+   directly with `LLVM_PROFILE_FILE` set to an absolute path such as
+   `/path/to/profiles/arm64-%p.profraw`. Exercise representative workloads in
+   both instruments, including the buffer sizes and sample rates being
+   targeted. Quit cleanly to flush the profile. Instrumented builds have
+   additional CPU overhead and are intended for training.
+4. Merge those files with the matching compiler's tool:
+   `xcrun llvm-profdata merge -o /path/to/arm64.profdata /path/to/profiles/*.profraw`.
+5. Configure a separate Release build with the same options and source,
+   `GEARMULATOR_MDMM_APPLE_PGO_MODE=use`, and
+   `GEARMULATOR_MDMM_APPLE_PGO_PROFILE=/path/to/arm64.profdata`.
+6. Verify audio, emulated timing, and callback performance against an ordinary
+   Release control before using the result as a release candidate. A profile
+   specialized to one workload can hurt another workload.
+
+Profile-use builds reject structural profile mismatches. Regenerate the
+profile when source, compiler, architecture, or relevant definitions change;
+absence of a mismatch warning does not establish that an old profile still
+represents the intended workload. An unprofiled-file warning can occur for
+translation units not reached by the training executable and should be
+assessed separately from a structural mismatch.
+
+Keep generated `.profraw` and `.profdata` files as local build inputs. The
+resulting optimized executable does not require the profile at runtime.

--- a/doc/mdmm-apple-optimization.md
+++ b/doc/mdmm-apple-optimization.md
@@ -40,12 +40,18 @@ The flags apply only to Release configurations.
    Release control before using the result as a release candidate. A profile
    specialized to one workload can hurt another workload.
 
-Profile-use builds reject structural profile mismatches. Regenerate the
-profile when source, compiler, architecture, or relevant definitions change;
-absence of a mismatch warning does not establish that an old profile still
-represents the intended workload. An unprofiled-file warning can occur for
-translation units not reached by the training executable and should be
-assessed separately from a structural mismatch.
+Replacing the merged profile at the same path automatically rebuilds the
+optimized Release libraries when the profile contents change.
+
+Profile-use builds treat Clang's out-of-date profile diagnostics as errors.
+Regenerate the profile when source, compiler, architecture, or relevant
+definitions change; some function-hash mismatches can be treated as missing
+data without an out-of-date warning. A successful build does not establish
+that an old profile still represents the intended workload. An unprofiled-file
+warning can occur for translation units not reached by the training executable,
+or when none of a file's function hashes match. Review these warnings for stale
+profiles as well as gaps in training; this compiler diagnostic alone cannot
+validate a profile.
 
 Keep generated `.profraw` and `.profdata` files as local build inputs. The
 resulting optimized executable does not require the profile at runtime.

--- a/source/elektron/md/CMakeLists.txt
+++ b/source/elektron/md/CMakeLists.txt
@@ -19,3 +19,5 @@ endif()
 if(${CMAKE_PROJECT_NAME}_BUILD_JUCEPLUGIN)
 	add_subdirectory(mdJucePlugin)
 endif()
+
+include(optimization.cmake)

--- a/source/elektron/md/optimization.cmake
+++ b/source/elektron/md/optimization.cmake
@@ -44,6 +44,11 @@ elseif(GEARMULATOR_MDMM_APPLE_PGO_MODE STREQUAL "use")
 	endif()
 	get_filename_component(_mdmm_profile "${GEARMULATOR_MDMM_APPLE_PGO_PROFILE}" ABSOLUTE)
 	set(_mdmm_pgo_option "-fprofile-instr-use=${_mdmm_profile}")
+	# Clang does not include the profile in its compiler dependency files.
+	# Reconfigure when it changes, then change the private compile command so
+	# every optimized object is rebuilt when new training replaces the file.
+	set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${_mdmm_profile}")
+	file(SHA256 "${_mdmm_profile}" _mdmm_profile_sha256)
 endif()
 
 set(_mdmm_optimization_targets mdLib 68kEmu)
@@ -59,6 +64,8 @@ foreach(_mdmm_target IN LISTS _mdmm_optimization_targets)
 		target_compile_options(${_mdmm_target} PRIVATE "$<$<CONFIG:Release>:${_mdmm_pgo_option}>")
 		target_link_options(${_mdmm_target} INTERFACE "$<$<CONFIG:Release>:${_mdmm_pgo_option}>")
 		if(GEARMULATOR_MDMM_APPLE_PGO_MODE STREQUAL "use")
+			target_compile_definitions(${_mdmm_target} PRIVATE
+				"$<$<CONFIG:Release>:GEARMULATOR_MDMM_PGO_PROFILE_SHA256=\"${_mdmm_profile_sha256}\">")
 			# A mismatched profile is not a validated optimization build.
 			target_compile_options(${_mdmm_target} PRIVATE
 				"$<$<CONFIG:Release>:-Werror=profile-instr-out-of-date>")

--- a/source/elektron/md/optimization.cmake
+++ b/source/elektron/md/optimization.cmake
@@ -1,0 +1,69 @@
+# Apply optimization to the measured emulation libraries after their targets
+# exist. Defaults preserve the ordinary build on every platform.
+option(GEARMULATOR_MDMM_APPLE_THINLTO
+	"Enable Apple Clang ThinLTO for MD/MM core Release builds" OFF)
+option(GEARMULATOR_MDMM_APPLE_OPTIMIZE_DSP
+	"Include DSP libraries in the selected MD/MM Apple optimizations" OFF)
+set(GEARMULATOR_MDMM_APPLE_PGO_MODE "none" CACHE STRING
+	"MD/MM Apple profile-guided optimization: none, generate, or use")
+set_property(CACHE GEARMULATOR_MDMM_APPLE_PGO_MODE PROPERTY STRINGS none generate use)
+set(GEARMULATOR_MDMM_APPLE_PGO_PROFILE "" CACHE FILEPATH
+	"Merged profile from the same source, compiler and architecture")
+
+if(NOT GEARMULATOR_MDMM_APPLE_PGO_MODE MATCHES "^(none|generate|use)$")
+	message(FATAL_ERROR "GEARMULATOR_MDMM_APPLE_PGO_MODE must be none, generate, or use")
+endif()
+
+if(NOT GEARMULATOR_MDMM_APPLE_THINLTO
+	AND GEARMULATOR_MDMM_APPLE_PGO_MODE STREQUAL "none")
+	return()
+endif()
+
+if(NOT APPLE OR NOT CMAKE_C_COMPILER_ID MATCHES "^(AppleClang|Clang)$"
+	OR NOT CMAKE_CXX_COMPILER_ID MATCHES "^(AppleClang|Clang)$")
+	message(FATAL_ERROR "MD/MM Apple optimization requires Clang on macOS")
+endif()
+
+if(NOT GEARMULATOR_MDMM_APPLE_PGO_MODE STREQUAL "none")
+	if(NOT GEARMULATOR_MDMM_APPLE_THINLTO)
+		message(FATAL_ERROR "Enable GEARMULATOR_MDMM_APPLE_THINLTO for MD/MM PGO")
+	endif()
+	list(LENGTH CMAKE_OSX_ARCHITECTURES _mdmm_arch_count)
+	if(NOT _mdmm_arch_count EQUAL 1)
+		message(FATAL_ERROR "MD/MM PGO requires one explicit CMAKE_OSX_ARCHITECTURES value; train and build each architecture separately")
+	endif()
+endif()
+
+set(_mdmm_pgo_option "")
+if(GEARMULATOR_MDMM_APPLE_PGO_MODE STREQUAL "generate")
+	set(_mdmm_pgo_option "-fprofile-instr-generate")
+elseif(GEARMULATOR_MDMM_APPLE_PGO_MODE STREQUAL "use")
+	if(NOT EXISTS "${GEARMULATOR_MDMM_APPLE_PGO_PROFILE}"
+		OR IS_DIRECTORY "${GEARMULATOR_MDMM_APPLE_PGO_PROFILE}")
+		message(FATAL_ERROR "GEARMULATOR_MDMM_APPLE_PGO_PROFILE must name an existing merged profile")
+	endif()
+	get_filename_component(_mdmm_profile "${GEARMULATOR_MDMM_APPLE_PGO_PROFILE}" ABSOLUTE)
+	set(_mdmm_pgo_option "-fprofile-instr-use=${_mdmm_profile}")
+endif()
+
+set(_mdmm_optimization_targets mdLib 68kEmu)
+if(GEARMULATOR_MDMM_APPLE_OPTIMIZE_DSP)
+	list(APPEND _mdmm_optimization_targets dsp56kEmu dsp56kBase)
+endif()
+
+foreach(_mdmm_target IN LISTS _mdmm_optimization_targets)
+	target_compile_options(${_mdmm_target} PRIVATE "$<$<CONFIG:Release>:-flto=thin>")
+	# Static libraries propagate the matching options to their final consumer.
+	target_link_options(${_mdmm_target} INTERFACE "$<$<CONFIG:Release>:-flto=thin>")
+	if(_mdmm_pgo_option)
+		target_compile_options(${_mdmm_target} PRIVATE "$<$<CONFIG:Release>:${_mdmm_pgo_option}>")
+		target_link_options(${_mdmm_target} INTERFACE "$<$<CONFIG:Release>:${_mdmm_pgo_option}>")
+		if(GEARMULATOR_MDMM_APPLE_PGO_MODE STREQUAL "use")
+			# A mismatched profile is not a validated optimization build.
+			target_compile_options(${_mdmm_target} PRIVATE
+				"$<$<CONFIG:Release>:-Werror=profile-instr-out-of-date>")
+		endif()
+	endif()
+endforeach()
+
+message(STATUS "MD/MM Apple Release optimization: ThinLTO, PGO=${GEARMULATOR_MDMM_APPLE_PGO_MODE}, targets=${_mdmm_optimization_targets}")


### PR DESCRIPTION
MD/MM's corrected emulation timing raises CPU cost. Add opt-in Apple Release ThinLTO and profile-guided optimization for the measured emulation libraries, with matching options propagated to final plugin/executable links. The scheduling implementation and default compiler settings remain unchanged.

The options cover `mdLib` and `68kEmu`, optionally extending to `dsp56kEmu` and `dsp56kBase`. PGO requires ThinLTO, one explicit architecture, and an existing merged profile for use mode. The documentation covers representative training, retraining, shared-library effects and the limits of Clang's profile diagnostics.

The DSP gitlink includes the disabled-assertion normalization required for consistent inline-function profile hashes. The same header-only change is submitted upstream as [dsp56300/dsp56300#12](https://github.com/dsp56300/dsp56300/pull/12); the integration pins the already-published fork commit `20617369`.

The branch now incorporates release commit `b6d516c2`. The updated DSP dependency preserves release DSP commit `30c9f730` and adds only the identical assertion fix, resolving the dependency conflict after the release branch advanced. The optimization code and documentation are unchanged. Performance measurements below describe the original alpha.10-based candidate; profiles must be regenerated and validated before enabling optimization with newer source revisions.

Review found and fixed profile replacement leaving stale optimized objects: CMake now tracks the profile and includes its content fingerprint in private Release compile definitions. Changed contents rebuild the selected libraries; identical contents avoid unnecessary recompilation.

Validation:

- The selected arm64 production candidate passed 19 CTests with zero failures/skips, including firmware coverage, plus both MD/MM VST3 smoke checks. Across 48 headless and 66 native/crossed-pacing runs, 32 headless and 42 native candidate/control comparisons matched their recorded audio/timing oracles. All 118 checked production core compile commands matched the measured candidate.
- Five invalid configurations were rejected; 1,290 default/Debug compile entries contained no unexpected optimization flags.
- The later profile-dependency correction passed six focused C/C++ consumer-build checks: universal ThinLTO build/link with native arm64 execution, Release generation and ordinary Debug, profile paths with spaces, unchanged-profile reuse, changed-profile rebuilding of all four selected libraries, and PGO-use Debug flag isolation. The replacement test failed against the original module with zero objects rebuilt, and passed after the correction.
- [Windows/MSVC downstream validation](https://github.com/joelanders/gearmulator-md-mm/actions/runs/34131969007) passed 24 DSP CTest invocations, 15 ordinary integration tests and both VST3 smoke checks; two firmware-dependent integration tests were skipped. Apple options stayed disabled. This run and the full Mac suite predate the profile-dependency correction; the six focused build checks validate that correction.

Performance against the published alpha.10 VST3 on one M2 Pro with Apple Clang 16:

| Instrument | Continuous rendering CPU reduction | Paced CLI CPU reduction |
| --- | ---: | ---: |
| Monomachine | 12.6–13.3% | 3.1–4.4% |
| Machinedrum | 24.1–24.3% | 19.9% |

Paced CLI tests sleep between callbacks and do not reproduce a DAW's audio-thread scheduling. Actual Ableton gains, Intel Mac performance and native Windows PGO remain unestablished. The new options default to off; release adoption requires current per-architecture profiles and validation of the resulting products.

This PR contains the production options, documentation, DSP pin and profile-rebuild correction. The diagnostic CI harness is on a separate branch. Profiles, firmware and generated binaries are local validation inputs and are not included.
