### PR TITLE
Fix performance report event loss during stop

### DIFF
--- a/source/synthLib/performanceReport.cpp
+++ b/source/synthLib/performanceReport.cpp
@@ -182,6 +182,10 @@ namespace synthLib
 			bool limited = false;
 			for(;;)
 			{
+				// Only exit for stop after draining with the request already observed.
+				// A request arriving during this pass needs another pass to capture
+				// events queued after we last checked either queue.
+				const bool stopping = m_stop.load(std::memory_order_acquire);
 				// Keep actions independent of slow-callback volume. Timestamps, not
 				// JSONL row order, define ordering between the two bounded queues.
 				for(size_t drained = 0; drained < RealtimeInstrumentation::TimelineCapacity
@@ -207,7 +211,7 @@ namespace synthLib
 				else write(summary);
 				if(std::fflush(file.get()) != 0) throw std::runtime_error("Cannot flush performance report");
 				limited |= std::chrono::steady_clock::now() - begin >= _limits.duration;
-				if(limited || m_stop.load(std::memory_order_acquire)) break;
+				if(limited || stopping) break;
 				std::unique_lock lock(m_waitMutex);
 				m_wake.wait_for(lock, _limits.flushInterval, [this]{ return m_stop.load(std::memory_order_acquire); });
 			}

--- a/source/synthLib/performanceReport.h
+++ b/source/synthLib/performanceReport.h
@@ -40,6 +40,7 @@ namespace synthLib
 		static std::string formatCallback(const RealtimeSlowCallback& _callback);
 		static std::string formatTimelineEvent(const RealtimeEvent& _event, const Context& _details = {});
 	private:
+		friend struct PerformanceReportTestAccess;
 		void run(const std::string& _filename, const Context& _context, Limits _limits) noexcept;
 		RealtimeInstrumentation& m_instrumentation;
 		EventDetails m_eventDetails;

--- a/source/synthLib/synthLibTest/performanceReportTest.cpp
+++ b/source/synthLib/synthLibTest/performanceReportTest.cpp
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <cstdio>
 #include <fstream>
+#include <future>
 #include <iostream>
 #include <stdexcept>
 #include <thread>
@@ -13,6 +14,12 @@
 
 namespace synthLib
 {
+	struct PerformanceReportTestAccess
+	{
+		static bool stopRequested(const PerformanceReport& report)
+		{ return report.m_stop.load(std::memory_order_acquire); }
+	};
+
 	struct RealtimeInstrumentationTestAccess
 	{
 		static void record(RealtimeInstrumentation& owner, RealtimeSlowCallback callback)
@@ -250,6 +257,57 @@ namespace
 		return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
 	}
 
+	void checkStopDuringDrain(const std::string& path)
+	{
+		RI ri;
+		std::promise<void> atDrainLimit, resumeDrain;
+		auto atDrainLimitFuture = atDrainLimit.get_future();
+		auto resumeDrainFuture = resumeDrain.get_future();
+		size_t formatted = 0;
+		bool workerTimedOut = false;
+		Report report(ri, [&](const synthLib::RealtimeEvent&) {
+			// Keep this pass busy until its last permitted timeline event, then
+			// pause so the caller can queue more work and request a real stop.
+			if(++formatted < RI::TimelineCapacity)
+				ri.beginPanelInput(1, 0x25, 0);
+			else if(formatted == RI::TimelineCapacity)
+			{
+				atDrainLimit.set_value();
+				workerTimedOut = resumeDrainFuture.wait_for(std::chrono::seconds(5))
+					!= std::future_status::ready;
+			}
+			return Report::Context{};
+		});
+		report.start(path, {});
+		waitFor(report, Report::Status::Recording);
+		ri.beginPanelInput(1, 0x25, 0);
+		require(atDrainLimitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready,
+			"report worker did not reach the drain boundary");
+		const auto input = ri.beginPanelInput(1, 0x25, 1);
+		ri.endPanelInput(input, 1, 0x25, 1, true);
+		{
+			RI::CallbackScope callback(ri, 64, 48000);
+			RI::recordCurrentCallbackJitCompilation();
+		}
+		auto stopped = std::async(std::launch::async, [&] { report.stop(); });
+		const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+		while(!synthLib::PerformanceReportTestAccess::stopRequested(report)
+			&& std::chrono::steady_clock::now() < deadline)
+			std::this_thread::yield();
+		const bool stopRequested = synthLib::PerformanceReportTestAccess::stopRequested(report);
+		resumeDrain.set_value();
+		stopped.get();
+		require(stopRequested && !workerTimedOut, "stop/drain synchronization timed out");
+		require(report.status() == Report::Status::Stopped && !ri.isEnabled(), "report did not stop");
+		const auto content = read(path);
+		require(formatted == RI::TimelineCapacity + 2
+			&& content.find("\"accepted\":true") != std::string::npos
+			&& content.find("\"liveJitCompilations\":1") != std::string::npos
+			&& content.find("\"reason\":\"stopped\"") != std::string::npos,
+			"stop during drain lost queued report events");
+		std::remove(path.c_str());
+	}
+
 	void checkReport(const std::string& path)
 	{
 		RI ri;
@@ -327,6 +385,7 @@ int main(int argc, char** argv)
 		checkEventTimeline();
 		checkConcurrentEventProducers();
 		checkProcessingIntegration();
+		checkStopDuringDrain(std::string(argv[1]) + ".stop-drain");
 		checkReport(argv[1]);
 		std::cout << "performance report: PASS\n";
 		return 0;


### PR DESCRIPTION
Stopping a performance report while its worker is draining can discard events queued after the worker last checked a queue. This caused the intermittent `synthLibPerformanceReportTest` failure on the default branch: [failed ASan/UBSan job](https://github.com/joelanders/gearmulator-md-mm/actions/runs/34245863112/job/102127538433).

Read the stop request before each drain pass, and only exit for stop after a pass that observed the request. A stop arriving during a pass therefore causes another drain before the final summary and stop marker. Capture size and duration limits still apply.

The regression test pauses the worker at its timeline drain limit, queues additional events, calls the real `stop()`, and then resumes the worker. It verifies the pending events reach the report. A private friend accessor lets the test observe the stop request without changing the public API.

Validation on macOS arm64 using a focused CMake build of the repository's synthLib targets and their dependencies:
- `synthLibPerformanceReportTest`, `synthLibAudioInstrumentationTest`, and `synthLibRealtimeInstrumentationTest`: passed in Release and with ASan/UBSan.
- The new regression test linked against the original report writer fails with `stop during drain lost queued report events`.
- `git diff --check`: passed.

GitHub CI will provide the Linux validation.
