### PR TITLE
Add Alt/Option-click DATA ENTRY encoder presses

### DIFF
--- a/.github/workflows/mdmm-core.yml
+++ b/.github/workflows/mdmm-core.yml
@@ -135,9 +135,9 @@ jobs:
 
       - name: Build and run panel input delivery regression
         run: |
-          cmake --build build-mdmm-core --parallel 4 --target mdLibTest
+          cmake --build build-mdmm-core --parallel 4 --target mdLibTest mdShiftPanelLatchTest
           ctest --test-dir build-mdmm-core -C Release --output-on-failure \
-            --no-tests=error --tests-regex '^mdLibTests$'
+            --no-tests=error --tests-regex '^(mdLibTests|mdShiftPanelLatchTest|mdEncoderPressFirmwareTest|mmEncoderPressFirmwareTest)$'
 
       - name: Build headless gates
         run: >-

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -424,6 +424,8 @@ namespace mdJucePlugin
 			juceRmlUi::EventListener::Add(document, Rml::EventId::Keyup,
 				[this](const Rml::Event& _event)
 				{
+					if(!juceRmlUi::helper::getKeyModAlt(_event))
+						releaseEncoderPress();
 					if(_event.GetParameter<int>("shift_key", 0) == 0
 						&& !m_shiftPanelLatch.empty())
 						releasePanelButtonGestures();
@@ -433,11 +435,20 @@ namespace mdJucePlugin
 				{
 					if(juceRmlUi::helper::getKeyIdentifier(_event) != Rml::Input::KI_ESCAPE
 						|| (m_shiftPanelLatch.empty() && m_activePanelButtons.empty()
-							&& m_panelGesturePackets.empty() && !m_patternBankPacket))
+							&& m_panelGesturePackets.empty() && !m_patternBankPacket
+							&& !m_encoderPress.active()))
 						return;
 					_event.StopPropagation();
 					cancelPanelInputGestures();
 				});
+			juceRmlUi::EventListener::Add(document, Rml::EventId::Mouseup,
+				[this](Rml::Event& _event)
+				{
+					if(juceRmlUi::helper::getMouseButton(_event) == juceRmlUi::MouseButton::Left)
+						releaseEncoderPress();
+				});
+			juceRmlUi::EventListener::Add(document, Rml::EventId::Dragend,
+				[this](Rml::Event&) { releaseEncoderPress(); });
 		}
 	}
 
@@ -638,6 +649,7 @@ namespace mdJucePlugin
 
 	void Editor::releasePanelButtonGestures()
 	{
+		releaseEncoderPress();
 		// Finish every momentary target before its Shift-held modifier. This also
 		// makes a later mouse-up harmless when key-up or focus loss ends the gesture.
 		releaseActivePanelButtons();
@@ -672,6 +684,18 @@ namespace mdJucePlugin
 		releaseAllPanelInputs();
 	}
 
+	void Editor::releaseEncoderPress()
+	{
+		if(const auto packet = m_encoderPress.release())
+		{
+			const auto combined = m_panelRows.release(*packet);
+			(void)sendPanelEvent(combined.row, combined.mask);
+		}
+		if(m_pressedEncoder)
+			m_pressedEncoder->SetClass("encoderPressed", false);
+		m_pressedEncoder = nullptr;
+	}
+
 	void Editor::globalFocusChanged(juce::Component* const _focusedComponent)
 	{
 		auto* const panel = getRmlComponent();
@@ -684,7 +708,7 @@ namespace mdJucePlugin
 
 	void Editor::releaseAllPanelInputs()
 	{
-		for(uint8_t row = 0x20; row <= 0x25; ++row)
+		for(uint8_t row = 0x20; row <= 0x26; ++row)
 			if(m_panelRows.mask(row) != 0)
 				(void)sendPanelEvent(row, 0);
 		m_panelRows.reset();
@@ -1566,6 +1590,26 @@ namespace mdJucePlugin
 		// Shift belongs to the MD/MM panel-hold gesture. Keep normal drag speed
 		// while it is down; Command/Ctrl remains the fine-adjustment modifier.
 		_knob->SetAttribute("speedScaleShift", 1.0f);
+		if(const auto packet = md::panelEncoderPressPacket(getModel(), _encoder))
+		{
+			_knob->SetAttribute("speedScaleAlt", 1.0f);
+			_knob->SetAttribute("title", "Drag to turn; Alt/Option-click to press; Alt/Option-drag to press and turn");
+			juceRmlUi::EventListener::Add(_knob, Rml::EventId::Mousedown,
+				[this, _knob, packet](Rml::Event& _event)
+				{
+					releaseEncoderPress();
+					if(m_encoderPress.begin(packet,
+						juceRmlUi::helper::getMouseButton(_event) == juceRmlUi::MouseButton::Left
+							&& !juceRmlUi::helper::isContextMenu(_event),
+						juceRmlUi::helper::getKeyModAlt(_event)))
+					{
+						m_pressedEncoder = _knob;
+						_knob->SetClass("encoderPressed", true);
+						const auto combined = m_panelRows.press(*packet);
+						(void)sendPanelEvent(combined.row, combined.mask);
+					}
+				});
+		}
 		_knob->setMinValue(0.0f);
 		_knob->setMaxValue(g_encoderRange);
 		_knob->setEndless(true);
@@ -1822,6 +1866,9 @@ namespace mdJucePlugin
 			return;
 
 		const auto nowMilliseconds = juce::Time::getMillisecondCounterHiRes();
+		const auto modifiers = juce::ModifierKeys::getCurrentModifiersRealtime();
+		if(m_encoderPress.active() && (!modifiers.isAltDown() || !modifiers.isLeftButtonDown()))
+			releaseEncoderPress();
 		// Some plugin hosts can lose the modifier key-up when focus changes. Poll
 		// native state as a fail-safe so no panel row remains held indefinitely.
 		if(!m_shiftPanelLatch.empty()

--- a/source/elektron/md/mdJucePlugin/mdEditor.h
+++ b/source/elektron/md/mdJucePlugin/mdEditor.h
@@ -107,6 +107,7 @@ namespace mdJucePlugin
 			std::initializer_list<md::PanelControl> _controls);
 		void endPanelGesture();
 		void releasePanelButtonGestures();
+		void releaseEncoderPress();
 		void cancelPanelInputGestures();
 		void releaseAllPanelInputs();
 		void globalFocusChanged(juce::Component* _focusedComponent) override;
@@ -175,6 +176,8 @@ namespace mdJucePlugin
 		Rml::Element* m_panelGestureElement = nullptr;
 		std::vector<md::PanelPacket> m_panelGesturePackets;
 		panelAffordances::ShiftPanelLatch m_shiftPanelLatch;
+		panelAffordances::EncoderPressGesture m_encoderPress;
+		juceRmlUi::ElemKnob* m_pressedEncoder = nullptr;
 
 		struct ActivePanelButton
 		{

--- a/source/elektron/md/mdJucePlugin/mdPanelAffordances.h
+++ b/source/elektron/md/mdJucePlugin/mdPanelAffordances.h
@@ -11,6 +11,29 @@
 // without building a window or a document.
 namespace mdJucePlugin::panelAffordances
 {
+	// One mouse gesture owns one physical switch. Modifier changes may release
+	// it, but never start a press partway through an ordinary drag.
+	class EncoderPressGesture
+	{
+	public:
+		bool begin(const std::optional<md::PanelPacket>& _packet, bool _left, bool _alt)
+		{
+			if(m_packet || !_packet || !_left || !_alt)
+				return false;
+			m_packet = _packet;
+			return true;
+		}
+		std::optional<md::PanelPacket> release()
+		{
+			const auto result = m_packet;
+			m_packet.reset();
+			return result;
+		}
+		bool active() const { return m_packet.has_value(); }
+	private:
+		std::optional<md::PanelPacket> m_packet;
+	};
+
 	// Applied to every clickable label/LED so the skin can style them as one family.
 	constexpr const char* g_affordanceClass = "panelAffordance";
 

--- a/source/elektron/md/mdJucePlugin/mdShiftPanelLatchTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdShiftPanelLatchTest.cpp
@@ -154,6 +154,30 @@ namespace
 
 int main()
 {
+	for(const auto model : {md::MachineModel::Machinedrum, md::MachineModel::Monomachine})
+	{
+		md::PanelRowState rows;
+		for(unsigned i = 0; i < 8; ++i)
+		{
+			const auto packet = md::panelEncoderPressPacket(model, static_cast<md::PanelEncoder>(i));
+			expect(packet && packet->row == (model == md::MachineModel::Machinedrum ? 0x25 : 0x26)
+				&& packet->mask == (1u << i), "encoder switch mapping changed");
+			mdJucePlugin::panelAffordances::EncoderPressGesture press;
+			expect(!press.begin(packet, true, false), "ordinary drag pressed encoder");
+			expect(!press.begin(packet, false, true), "context-menu click pressed encoder");
+			expect(press.begin(packet, true, true), "Alt-left gesture did not press encoder");
+			expect(!press.begin(packet, true, true), "duplicate press accepted");
+			expect(rows.press(*packet) == *packet, "encoder row was not retained");
+			const auto released = press.release();
+			expect(released == packet && !press.active(), "cancel did not release exact switch");
+			expect(rows.release(*released).mask == 0, "cancel left switch held");
+			expect(!press.release(), "late mouse-up duplicated release");
+		}
+		expect(!md::panelEncoderPressPacket(model, md::PanelEncoder::SoundSelection),
+			"sound wheel must not acquire an unverified switch");
+	}
+	mdJucePlugin::panelAffordances::EncoderPressGesture unsupported;
+	expect(!unsupported.begin({}, true, true), "unmapped encoder acquired press");
 	checkTriggerChordPolicy();
 	checkModifierChordPolicy();
 	checkMonomachineBankPolicy();

--- a/source/elektron/md/mdLib/mdpanel.cpp
+++ b/source/elektron/md/mdLib/mdpanel.cpp
@@ -126,6 +126,18 @@ namespace md
 		}
 	}
 
+	std::optional<PanelPacket> panelEncoderPressPacket(const MachineModel _model,
+		const PanelEncoder _encoder)
+	{
+		// Stock MD 1.63 / MM 1.32b panel-UART behavior is exercised by
+		// encoderPressFirmwareTest through visible parameter-lock inversion.
+		const auto index = static_cast<uint8_t>(_encoder);
+		if(index > static_cast<uint8_t>(PanelEncoder::DataEntryH))
+			return {};
+		return PanelPacket{static_cast<uint8_t>(_model == MachineModel::Machinedrum ? 0x25 : 0x26),
+			static_cast<uint8_t>(1u << index)};
+	}
+
 	std::optional<uint8_t> panelEncoderCommand(const MachineModel _model,
 		const PanelEncoder _encoder)
 	{

--- a/source/elektron/md/mdLib/mdpanel.h
+++ b/source/elektron/md/mdLib/mdpanel.h
@@ -90,6 +90,9 @@ namespace md
 		}
 	};
 
+	// Physical encoder switches are distinct from rotation deltas.
+	std::optional<PanelPacket> panelEncoderPressPacket(MachineModel _model, PanelEncoder _encoder);
+
 	struct PanelInputQueueStatus
 	{
 		size_t pendingPackets = 0;
@@ -125,7 +128,7 @@ namespace md
 
 	private:
 		static constexpr uint8_t g_firstRow = 0x20;
-		static constexpr uint8_t g_lastRow = 0x25;
+		static constexpr uint8_t g_lastRow = 0x26;
 		static constexpr size_t g_rowCount = g_lastRow - g_firstRow + 1;
 
 		std::array<uint8_t, g_rowCount> m_masks{};
@@ -176,7 +179,7 @@ namespace md
 			PanelPacket packet{};
 		};
 		static constexpr uint8_t g_firstRow = 0x20;
-		static constexpr uint8_t g_lastRow = 0x25;
+		static constexpr uint8_t g_lastRow = 0x26;
 		static constexpr size_t g_rowCount = g_lastRow - g_firstRow + 1;
 		static constexpr size_t g_recoveryPending = 1;
 

--- a/source/elektron/md/mdLibTest/CMakeLists.txt
+++ b/source/elektron/md/mdLibTest/CMakeLists.txt
@@ -182,6 +182,14 @@ set_tests_properties(mdAudioFirmwareTest PROPERTIES
 
 set_property(TARGET mdAudioFirmwareTest PROPERTY FOLDER "Elektron/test")
 
+add_executable(encoderPressFirmwareTest encoderPressFirmwareTest.cpp)
+target_link_libraries(encoderPressFirmwareTest PRIVATE mdLib)
+add_test(NAME mdEncoderPressFirmwareTest COMMAND encoderPressFirmwareTest md)
+add_test(NAME mmEncoderPressFirmwareTest COMMAND encoderPressFirmwareTest mm)
+set_tests_properties(mdEncoderPressFirmwareTest mmEncoderPressFirmwareTest PROPERTIES
+	LABELS "Integration;FirmwareTest" SKIP_RETURN_CODE 77 TIMEOUT 300)
+set_property(TARGET encoderPressFirmwareTest PROPERTY FOLDER "Elektron/test")
+
 # Shared external regressions for the independent MM workaround removals.
 add_executable(mmAudioFirmwareTest mmAudioFirmwareTest.cpp)
 target_link_libraries(mmAudioFirmwareTest PRIVATE mdLib)
@@ -205,6 +213,7 @@ set_tests_properties(mmSineOracleTest PROPERTIES
 set_property(TARGET mmAudioFirmwareTest PROPERTY FOLDER "Elektron/test")
 
 if(BUILD_TESTING)
+	add_dependencies(mdLibTest encoderPressFirmwareTest)
 	# Existing core/audio CI selectors must execute the fixture-free oracle.
 	add_dependencies(mdLibTest mmAudioFirmwareTest)
 	add_dependencies(mdAudioQueueTest mmAudioFirmwareTest)

--- a/source/elektron/md/mdLibTest/encoderPressFirmwareTest.cpp
+++ b/source/elektron/md/mdLibTest/encoderPressFirmwareTest.cpp
@@ -1,0 +1,136 @@
+#include "mdLib/mddevice.h"
+#include "mdLib/mdromloader.h"
+#include "baseLib/filesystem.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string_view>
+
+namespace
+{
+	void require(bool condition, const char* message)
+	{
+		if(!condition) throw std::runtime_error(message);
+	}
+	void advance(md::Hardware& hardware, uint32_t frames)
+	{
+		while(frames)
+		{
+			const auto n = std::min(frames, 256u);
+			hardware.advance(n);
+			frames -= n;
+		}
+	}
+	bool locked(md::Hardware& hardware, unsigned encoder)
+	{
+		// Observable LCD lock inversion, not firmware memory. Both stock panel
+		// layouts show the eight parameter cells as four columns and two rows.
+		const auto panel = hardware.getFrontPanelSnapshot();
+		const unsigned x = 51 + 20 * (encoder % 4), y = 13 + 31 * (encoder / 4);
+		return panel.getLcdPixel(x, y) && panel.getLcdPixel(x + 12, y);
+	}
+}
+
+int main(int argc, char** argv)
+{
+	if(argc < 2) return 1;
+	const auto model = std::string_view(argv[1]) == "md"
+		? md::MachineModel::Machinedrum : md::MachineModel::Monomachine;
+	const char* path = std::getenv(model == md::MachineModel::Machinedrum
+		? "GEARMULATOR_MD_FIRMWARE_BIN" : "GEARMULATOR_MM_FIRMWARE_BIN");
+	if(!path || !*path) { std::cout << "SKIP: firmware not supplied\n"; return 77; }
+	const bool dropPress = argc > 2 && std::string_view(argv[2]) == "--drop-press";
+	const bool dropRelease = argc > 2 && std::string_view(argv[2]) == "--drop-release";
+	try
+	{
+		synthLib::DeviceCreateParams params;
+		require(baseLib::filesystem::readFile(params.romData, path), "cannot read firmware");
+		require(md::RomLoader::isRomForModel(params.romData, model), "wrong firmware model");
+		params.romName = path;
+		params.customData = md::deviceCustomData(model);
+		// No homePath: never load or overwrite the user's machine storage.
+		auto device = std::make_unique<md::Device>(params);
+		auto& hardware = device->getHardware();
+		advance(hardware, md::g_samplerate * 25);
+		require(hardware.isAudioReady() && hardware.isFirmwareMidiReady(), "boot incomplete");
+		md::PanelRowState rows;
+		const auto send = [&](const md::PanelPacket packet, bool down)
+		{
+			const auto combined = down ? rows.press(packet) : rows.release(packet);
+			require(hardware.trySendPanelEvent(combined.row, combined.mask), "panel event rejected");
+			advance(hardware, md::g_samplerate / 8);
+		};
+		const auto tap = [&](md::PanelControl control)
+		{
+			const auto packet = md::panelPacket(model, control);
+			require(packet.has_value(), "missing panel button");
+			send(*packet, true); send(*packet, false);
+			advance(hardware, md::g_samplerate / 2);
+		};
+		tap(md::PanelControl::Exit);
+		if(model == md::MachineModel::Monomachine)
+		{
+			tap(md::PanelControl::DataPageForward);
+			tap(md::PanelControl::DataPageForward); // FILTER: eight available parameters.
+		}
+		else
+		{
+			if(!hardware.getFrontPanelSnapshot().getModeLed(md::FrontPanel::ModeLed::Extended))
+				tap(md::PanelControl::ClassicExtended);
+			tap(md::PanelControl::SynthesisEffectsRouting); // EFFECTS.
+		}
+		tap(md::PanelControl::Record);
+		tap(md::PanelControl::Trigger1);
+		const auto trig = *md::panelPacket(model, md::PanelControl::Trigger1);
+		send(trig, true);
+		tap(md::PanelControl::Play); // Clear this step's locks, retaining its trig.
+		const auto click = [&](unsigned encoder)
+		{
+			const auto packet = md::panelEncoderPressPacket(model, static_cast<md::PanelEncoder>(encoder));
+			require(packet.has_value(), "missing encoder switch mapping");
+			if(!dropPress) send(*packet, true);
+			if(!dropRelease) send(*packet, false);
+			advance(hardware, md::g_samplerate / 4);
+		};
+		for(unsigned i = 0; i < 8; ++i)
+		{
+			require(!locked(hardware, i), "initial parameter unexpectedly locked");
+			click(i);
+			require(locked(hardware, i), "encoder press did not create current-value lock");
+			click(i);
+			require(!locked(hardware, i), "encoder press did not clear lock");
+		}
+		click(0); click(7); click(0);
+		require(!locked(hardware, 0) && locked(hardware, 7), "selective clear affected another parameter");
+		click(7);
+		const auto encoder = *md::panelEncoderPressPacket(model, md::PanelEncoder::DataEntryA);
+		send(encoder, true);
+		require(locked(hardware, 0), "held encoder did not lock parameter");
+		send(encoder, true);
+		require(locked(hardware, 0), "repeated held row toggled lock twice");
+		const auto beforeTurn = hardware.getFrontPanelSnapshot();
+		require(hardware.trySendPanelEvent(*md::panelEncoderCommand(model, md::PanelEncoder::DataEntryA), 1),
+			"held encoder turn rejected");
+		advance(hardware, md::g_samplerate / 2);
+		const auto afterTurn = hardware.getFrontPanelSnapshot();
+		bool changed = false;
+		for(unsigned y = 14; y <= 30; ++y)
+			for(unsigned x = 52; x <= 62; ++x)
+				changed |= beforeTurn.getLcdPixel(x, y) != afterTurn.getLcdPixel(x, y);
+		require(changed && locked(hardware, 0), "press-and-turn failed to edit held parameter");
+		send(encoder, false);
+		click(0);
+		require(!locked(hardware, 0), "release failed to rearm the next encoder click");
+		send(trig, false);
+		std::cout << "PASS: all eight physical encoder switches create and selectively clear locks\n";
+		return 0;
+	}
+	catch(const std::exception& error)
+	{
+		std::cerr << error.what() << '\n';
+		return 1;
+	}
+}

--- a/source/elektron/md/mdLibTest/mdRuntimeTest.cpp
+++ b/source/elektron/md/mdLibTest/mdRuntimeTest.cpp
@@ -280,7 +280,7 @@ namespace
 	bool testPanelInputReleaseRecovery()
 	{
 		md::PanelInputQueue queue;
-		const auto held = md::PanelPacket{0x24, 0x02};
+		const auto held = md::PanelPacket{0x26, 0x80};
 		if(!check(queue.tryPush(held.row, held.mask),
 			"panel queue rejected the initial held state"))
 			return false;
@@ -312,7 +312,7 @@ namespace
 			|| !check(status.coalescedRowPackets == 1,
 				"authoritative row coalescing telemetry is wrong")
 			|| !check(queue.size()
-				== (md::PanelInputQueue::g_capacityPackets + 6) * 2,
+				== (md::PanelInputQueue::g_capacityPackets + 7) * 2,
 				"retained row recovery was absent from pending byte telemetry"))
 			return false;
 
@@ -337,7 +337,7 @@ namespace
 		// At this point the simulated Editor/producer is gone. Recovery lives in the
 		// queue, so the next post-restore consumer pass still emits every row.
 		const auto recoveryCount = queue.drain(batch);
-		if(!check(recoveryCount == 6,
+		if(!check(recoveryCount == 7,
 			"panel recovery did not publish one complete row snapshot"))
 			return false;
 		for(size_t i = 0; i < recoveryCount; ++i)
@@ -349,7 +349,7 @@ namespace
 			"authoritative release did not follow the accepted press")
 			&& check(!status.rowRecoveryPending && queue.size() == 0,
 				"panel release recovery did not quiesce")
-			&& check(status.recoveredRowPackets == 6,
+			&& check(status.recoveredRowPackets == 7,
 				"panel recovery telemetry did not report the row snapshot");
 	}
 
@@ -412,7 +412,7 @@ namespace
 
 		md::PanelInputQueueTestAccess::publishFifoSlot(queue, *claimed, held);
 		const auto count = queue.drain(batch);
-		if(!check(count == 7 && batch[0] == held,
+		if(!check(count == 8 && batch[0] == held,
 			"claimed press was not delivered before its recovery snapshot"))
 			return false;
 		bool sawRelease = false;

--- a/source/jucePluginData/elektron_panel.rcss
+++ b/source/jucePluginData/elektron_panel.rcss
@@ -685,3 +685,5 @@
 	top: 81dp;
 	width: 52dp;
 }
+/* Physical push feedback without additional panel controls. */
+.encoderPressed { opacity: 0.75; }


### PR DESCRIPTION
Adds DATA ENTRY A–H switch holds through the panel UART on MD and MM. Alt/Option-click presses; Alt/Option-drag retains the press while turning. Includes tooltip and pressed feedback without extra click targets, release/cancellation paths, and recovery for the MM switch row under queue saturation.

Validation on candidate d9288d405725e7becd878e77148c6dd42e776d3e:
- 12/12 selected local CTests passed without skips, including both stock-firmware regressions.
- LCD-based tests cover all eight lock toggles, selective clearing, held turns, and release/rearm. Suppressing press or release independently fails the regression.
- Gesture/row tests passed ASan/UBSan. Both editor variants passed syntax compilation. CI YAML parses.

Draft pending packaged GUI/host validation of drag capture, focus loss, Shift chords, visual feedback, and context menus. These are emulator-based behavior tests, not physical hardware captures. LEVEL and SOUND SELECTION pushes remain disabled; no unverified switch mapping or exact acceleration factor is claimed. No dependency pins changed. Private research notes and firmware are excluded.