### PR TITLE
Introduce MD/MM README and preserve upstream overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,34 @@
-# Gearmulator
+# Gearmulator MD / MM
 
-[![CMake][s0]][l0] [![Nightly][s1]][l1] ![GPLv3][s2] [![Discord][s3]][l3]
+Machinedrum and Monomachine emulation, built on Gearmulator. Run them as
+standalone apps or VST3 plugins, with a mouse-friendly version of the hardware
+panel.
 
-[s0]: https://github.com/dsp56300/gearmulator/actions/workflows/cmake.yml/badge.svg
-[l0]: https://github.com/dsp56300/gearmulator/actions/workflows/cmake.yml
+My fork of TUS's Gearmulator project, where I add emulations of Elektron's
+Machinedrum and Monomachine.
 
-[s1]: https://github.com/dsp56300/gearmulator/actions/workflows/nightly.yml/badge.svg
-[l1]: https://github.com/dsp56300/gearmulator/actions/workflows/nightly.yml
+[Downloads](https://github.com/joelanders/gearmulator-md-mm/releases) ·
+[Report a bug](https://github.com/joelanders/gearmulator-md-mm/issues)
 
-[s2]: https://img.shields.io/badge/license-GPLv3-blue.svg
+## Using the panel
 
-[s3]: https://img.shields.io/discord/829099347975208970?label=Discord
-[l3]: https://discord.gg/WJ9cxySnsM
+- **Key chording / p-locks:** shift-click one or more buttons to hold them
+  down until you release the shift key.
+- **Secondary functions:** rather than shift-click Function and another button,
+  you can just click the secondary function text label.
+- **Encoder clicking:** Alt/Option-click a DATA ENTRY encoder to press it, or
+  Alt/Option-drag to press and turn. With a trig held, pressing its parameter's
+  encoder toggles that parameter lock. This applies to encoders A–H, not LEVEL
+  or SOUND SELECTION.
+- **SysEx files:** use **Send SysEx File…** to send a `.syx` file to the
+  machine. The menu shows transfer progress and lets you cancel. Follow the
+  machine's normal receive procedure.
+- **Panel feel:** adjust encoder-drag and mouse-wheel sensitivity in settings.
+  An experimental crisp LCD/panel rendering option is also available.
+- **Audio inputs and outputs:** route host audio to the machine's input effects or sampling
+  functions. Additional output pairs are available in a multi-output VST3 host;
+  the standalone apps use stereo output.
 
-## Low Level Emulation of classic VA synths & effects of the late 90s/2000s
-
-This project emulates the used ICs of various musical devices to run the original firmware - aka ROM - as audio plugins.
-
-The supported plugin formats are [FST](https://github.com/pierreguillot/FTS), VST3, AU, [CLAP](https://cleveraudio.org/) and [LV2](https://lv2plug.in/).
-
-Supported architectures: 64 bit x86 aka x64 and ARM aarch64 (Raspberry Pi, Apple Silicon). Note that 32 bit
-architectures are not supported!
-
-Platforms: Windows 7+, macOS 10.13+, Linux
-
-At the moment, the following synthesizers are supported:
-
-* Osirus: Access Virus A,B,C
-* OsTIrus: Access Virus TI/TI2/Snow
-* Vavra: Waldorf microQ
-* Xenia: Waldorf Microwave II/XT
-* Nodal Red 2x: Clavia Nord Lead/Rack 2x
-* JE-8086: Roland JP-8000
-
-### Compiling
-
-The emulator compiles on any platform that supports C++17.
-
-The build system used is [cmake](https://cmake.org/).
-
-#### cmake options
-
-| Variable | Description | Default |
-|--|--|--|
-| gearmulator_BUILD_JUCEPLUGIN | Build Juce based audio plugins | on |
-| gearmulator_BUILD_JUCEPLUGIN_CLAP | Build CLAP plugins | on |
-| gearmulator_BUILD_JUCEPLUGIN_LV2 | Build LV2 plugins | on |
-| gearmulator_BUILD_FX_PLUGIN | Additionally build FX versions of all plugins | off |
-
-Additional options to select which devices to build:
-
-| Variable | Description | Default |
-|--|--|--|
-| gearmulator_SYNTH_OSIRUS | Build Osirus | on |
-| gearmulator_SYNTH_OSTIRUS | Build OsTIrus | on |
-| gearmulator_SYNTH_VAVRA | Build Vavra | on |
-| gearmulator_SYNTH_XENIA | Build Xenia | on |
-| gearmulator_SYNTH_NODALRED2X | Build Nodal Red 2x | on |
-| gearmulator_SYNTH_JE8086 | Build JE-8086 | on |
-
-### Join us on Discord
-
-If you want to help or just want to follow the state of the project, feel free to join us on Discord: https://discord.gg/WJ9cxySnsM
-
-### Visit our Homepage
-
-🎵 Visit our homepage for Audio and Video examples 🎧:
-[The Usual Suspects Website](https://dsp56300.com/)
+Thanks to the upstream Gearmulator contributors whose work makes this fork
+possible. See [the upstream README](README.upstream.md) for the original project
+overview, and [LICENSE.md](LICENSE.md) for licensing.

--- a/README.upstream.md
+++ b/README.upstream.md
@@ -1,0 +1,69 @@
+# Gearmulator
+
+[![CMake][s0]][l0] [![Nightly][s1]][l1] ![GPLv3][s2] [![Discord][s3]][l3]
+
+[s0]: https://github.com/dsp56300/gearmulator/actions/workflows/cmake.yml/badge.svg
+[l0]: https://github.com/dsp56300/gearmulator/actions/workflows/cmake.yml
+
+[s1]: https://github.com/dsp56300/gearmulator/actions/workflows/nightly.yml/badge.svg
+[l1]: https://github.com/dsp56300/gearmulator/actions/workflows/nightly.yml
+
+[s2]: https://img.shields.io/badge/license-GPLv3-blue.svg
+
+[s3]: https://img.shields.io/discord/829099347975208970?label=Discord
+[l3]: https://discord.gg/WJ9cxySnsM
+
+## Low Level Emulation of classic VA synths & effects of the late 90s/2000s
+
+This project emulates the used ICs of various musical devices to run the original firmware - aka ROM - as audio plugins.
+
+The supported plugin formats are [FST](https://github.com/pierreguillot/FTS), VST3, AU, [CLAP](https://cleveraudio.org/) and [LV2](https://lv2plug.in/).
+
+Supported architectures: 64 bit x86 aka x64 and ARM aarch64 (Raspberry Pi, Apple Silicon). Note that 32 bit
+architectures are not supported!
+
+Platforms: Windows 7+, macOS 10.13+, Linux
+
+At the moment, the following synthesizers are supported:
+
+* Osirus: Access Virus A,B,C
+* OsTIrus: Access Virus TI/TI2/Snow
+* Vavra: Waldorf microQ
+* Xenia: Waldorf Microwave II/XT
+* Nodal Red 2x: Clavia Nord Lead/Rack 2x
+* JE-8086: Roland JP-8000
+
+### Compiling
+
+The emulator compiles on any platform that supports C++17.
+
+The build system used is [cmake](https://cmake.org/).
+
+#### cmake options
+
+| Variable | Description | Default |
+|--|--|--|
+| gearmulator_BUILD_JUCEPLUGIN | Build Juce based audio plugins | on |
+| gearmulator_BUILD_JUCEPLUGIN_CLAP | Build CLAP plugins | on |
+| gearmulator_BUILD_JUCEPLUGIN_LV2 | Build LV2 plugins | on |
+| gearmulator_BUILD_FX_PLUGIN | Additionally build FX versions of all plugins | off |
+
+Additional options to select which devices to build:
+
+| Variable | Description | Default |
+|--|--|--|
+| gearmulator_SYNTH_OSIRUS | Build Osirus | on |
+| gearmulator_SYNTH_OSTIRUS | Build OsTIrus | on |
+| gearmulator_SYNTH_VAVRA | Build Vavra | on |
+| gearmulator_SYNTH_XENIA | Build Xenia | on |
+| gearmulator_SYNTH_NODALRED2X | Build Nodal Red 2x | on |
+| gearmulator_SYNTH_JE8086 | Build JE-8086 | on |
+
+### Join us on Discord
+
+If you want to help or just want to follow the state of the project, feel free to join us on Discord: https://discord.gg/WJ9cxySnsM
+
+### Visit our Homepage
+
+🎵 Visit our homepage for Audio and Video examples 🎧:
+[The Usual Suspects Website](https://dsp56300.com/)


### PR DESCRIPTION
Replace the root README with the owner-edited MD/MM overview and panel-gesture guide. Preserve the previous README byte-for-byte as README.upstream.md, keeping attribution and license links.

Documentation only. Verified the new README matches the approved draft exactly and the preserved upstream README matches the original Git blob. git diff --check passes.

Prepared in a separate checkout. The alpha.11 build remains frozen at aeff2547ac9313c7f7b28b98e083f7446c2b286c; this PR does not change its source checkout or packaged candidate.