### PR TITLE
Pace Machinedrum front-panel UART transmission

### DIFF
--- a/source/elektron/md/mdLib/mdmc.cpp
+++ b/source/elektron/md/mdLib/mdmc.cpp
@@ -459,14 +459,16 @@ namespace md
 			|| m_externalIrq4Pending || readImm16(cpu.pc) != 0x60fe)
 			return 0;
 
-		// Stop strictly before a timer can inject an interrupt. The normal
-		// single-instruction path crosses that event and delivers it as before.
-		const auto timer = m_sim.cyclesUntilNextTimerInterrupt();
-		if(timer != Sim::g_noTimerInterruptDeadline)
+		// Stop strictly before a timer interrupt or panel-UART character completion.
+		// The normal single-instruction path crosses that event and materializes it.
+		for(const auto deadline : {m_sim.cyclesUntilNextTimerInterrupt(),
+			m_sim.cyclesUntilNextUartTransmit()})
 		{
-			if(!timer)
+			if(deadline == Sim::g_noTimerInterruptDeadline)
+				continue;
+			if(!deadline)
 				return 0;
-			_maxCycles = std::min(_maxCycles, timer - 1);
+			_maxCycles = std::min(_maxCycles, deadline - 1);
 		}
 		uint32_t instructions = _maxCycles / 2;
 		if(m_panelDisplayReady)

--- a/source/elektron/md/mdLib/mdsim.cpp
+++ b/source/elektron/md/mdLib/mdsim.cpp
@@ -41,6 +41,14 @@ namespace md
 		{
 			u.rx.clear();
 			u.rxOverflows = 0;
+			u.mode = {};
+			u.modePointer = 0;
+			u.txEnabled = false;
+			u.txHoldingFull = false;
+			u.txHolding = 0;
+			u.txShiftBusy = false;
+			u.txShift = 0;
+			u.txCyclesRemaining = 0;
 			// u.txCallback is wiring, deliberately preserved across reset.
 		}
 	}
@@ -136,12 +144,12 @@ namespace md
 			return;
 		}
 
-		// UART interrupt-mask (UIMR, base+$14 on write): arm the transmitter-ready interrupt
-		// when the firmware enables it (TxRDY). Our transmitter is always ready, so from here
-		// the ISR is driven to drain the UART's transmit ring one byte per interrupt.
-		if(_offset == g_uart1Base + g_uartIsr && (_value & g_uimrTxRdy))
+		// UIMR enabling an already-asserted TxRDY source makes it serviceable.
+		if(_offset == g_uart1Base + g_uartIsr && (_value & g_uimrTxRdy)
+			&& (computeUartStatus(g_uartMidi) & g_usrTxRdy))
 			m_uartTxIrqArmed[g_uartMidi] = true;
-		if(_offset == g_uart2Base + g_uartIsr && (_value & g_uimrTxRdy))
+		if(_offset == g_uart2Base + g_uartIsr && (_value & g_uimrTxRdy)
+			&& (computeUartStatus(g_uartPanel) & g_usrTxRdy))
 			m_uartTxIrqArmed[g_uartPanel] = true;
 
 		// RX readiness is retained by queue/pop independently of UIMR (UM 12.4.1.11).
@@ -152,6 +160,11 @@ namespace md
 		// UART mode/clock/command config, interrupt controller, ...) is stored so a
 		// subsequent read returns what was written.
 		m_mem[_offset] = _value;
+
+		if(_offset == g_uart2Base + g_uartMr)
+			writeUartMode(g_uartPanel, _value);
+		else if(_offset == g_uart2Base + g_uartCr)
+			writeUartCommand(g_uartPanel, _value);
 
 		const auto refreshIfTimerConfig = [this, _offset](const unsigned _index,
 			const uint32_t _base)
@@ -213,14 +226,24 @@ namespace md
 
 	uint8_t Sim::computeUartStatus(const unsigned _uart) const
 	{
-		// UM 12.4.1.3 Status Register. We always advertise the transmitter as ready
-		// (holding register empty AND fully drained) so the firmware's poll loop can
-		// always send. Receiver flags follow the modelled RX FIFO.
-		uint8_t usr = g_usrTxEmp | g_usrTxRdy;
+		// UM 12.4.1.3 Status Register. UART1 retains immediate legacy delivery.
+		// Once UART2 uses its internal baud generator, TxRDY describes the holding
+		// register and TxEMP additionally requires an idle shift register.
+		uint8_t usr = 0;
 
 		if(_uart < g_uartCount)
 		{
-			const auto& rx = m_uart[_uart].rx;
+			const auto& uart = m_uart[_uart];
+			if(_uart != g_uartPanel || !panelTransmitTimingActive())
+				usr |= g_usrTxEmp | g_usrTxRdy;
+			else if(uart.txEnabled)
+			{
+				if(!uart.txHoldingFull)
+					usr |= g_usrTxRdy;
+				if(!uart.txHoldingFull && !uart.txShiftBusy)
+					usr |= g_usrTxEmp;
+			}
+			const auto& rx = uart.rx;
 			if(!rx.empty())
 				usr |= g_usrRxRdy;
 			if(rx.size() >= 3)		// FIFO depth is 3 (UM 12.4.1.3 FFULL)
@@ -267,6 +290,18 @@ namespace md
 			return;
 
 		auto& u = m_uart[_uart];
+		if(_uart == g_uartPanel && panelTransmitTimingActive())
+		{
+			// UTB ignores writes while disabled or while its one-byte holding register
+			// is occupied (UM 12.4.1.7).
+			if(!u.txEnabled || u.txHoldingFull)
+				return;
+			u.txHolding = _value;
+			u.txHoldingFull = true;
+			startPanelShiftRegister();
+			return;
+		}
+
 		if(u.txCallback)
 			u.txCallback(_value);
 
@@ -278,6 +313,115 @@ namespace md
 			m_uartTxIrqArmed[_uart] = true;
 			m_interruptCheckNeeded = true;
 		}
+	}
+
+	void Sim::writeUartMode(const unsigned _uart, const uint8_t _value)
+	{
+		if(_uart >= g_uartCount)
+			return;
+		auto& uart = m_uart[_uart];
+		uart.mode[uart.modePointer] = _value;
+		if(uart.modePointer == 0)
+			uart.modePointer = 1;
+	}
+
+	void Sim::writeUartCommand(const unsigned _uart, const uint8_t _value)
+	{
+		if(_uart >= g_uartCount)
+			return;
+		auto& uart = m_uart[_uart];
+		switch((_value >> 4) & 7)
+		{
+			case 1:
+				uart.modePointer = 0;
+				break;
+			case 3:
+				uart.txEnabled = false;
+				uart.txHoldingFull = false;
+				uart.txShiftBusy = false;
+				uart.txCyclesRemaining = 0;
+				m_uartTxIrqArmed[_uart] = false;
+				break;
+			default:
+				break;
+		}
+
+		switch((_value >> 2) & 3)
+		{
+			case 1:
+				uart.txEnabled = true;
+				if(computeUartStatus(_uart) & g_usrTxRdy)
+					armTransmitReady(_uart);
+				break;
+			case 2:
+				uart.txEnabled = false;
+				uart.txHoldingFull = false;
+				m_uartTxIrqArmed[_uart] = false;
+				break;
+			default:
+				break;
+		}
+	}
+
+	bool Sim::panelTransmitTimingActive() const
+	{
+		const auto divisor = static_cast<uint16_t>(
+			(static_cast<uint16_t>(m_mem[g_uart2Base + g_uartBg1]) << 8)
+			| m_mem[g_uart2Base + g_uartBg2]);
+		return (m_mem[g_uart2Base + g_uartUsr] & 0x0f) == 0x0d && divisor >= 2;
+	}
+
+	uint32_t Sim::panelCharacterCycles() const
+	{
+		const auto& uart = m_uart[g_uartPanel];
+		const uint32_t divisor =
+			(static_cast<uint32_t>(m_mem[g_uart2Base + g_uartBg1]) << 8)
+			| m_mem[g_uart2Base + g_uartBg2];
+		const uint32_t dataBits = 5 + (uart.mode[0] & 3);
+		const uint32_t parityBits = ((uart.mode[0] >> 3) & 3) == 2 ? 0 : 1;
+		const uint32_t stopSixteenths = 9 + (uart.mode[1] & 0x0f);
+		const uint32_t frameSixteenths = 16 + dataBits * 16 + parityBits * 16
+			+ stopSixteenths;
+		return frameSixteenths * 2 * divisor;
+	}
+
+	void Sim::armTransmitReady(const unsigned _uart)
+	{
+		const auto base = _uart == g_uartPanel ? g_uart2Base : g_uart1Base;
+		if((m_mem[base + g_uartIsr] & g_uimrTxRdy)
+			&& (computeUartStatus(_uart) & g_usrTxRdy))
+		{
+			m_uartTxIrqArmed[_uart] = true;
+			m_interruptCheckNeeded = true;
+		}
+	}
+
+	void Sim::startPanelShiftRegister()
+	{
+		auto& uart = m_uart[g_uartPanel];
+		if(!uart.txEnabled || uart.txShiftBusy || !uart.txHoldingFull)
+			return;
+		uart.txShift = uart.txHolding;
+		uart.txHoldingFull = false;
+		uart.txShiftBusy = true;
+		uart.txCyclesRemaining = panelCharacterCycles();
+		armTransmitReady(g_uartPanel);
+	}
+
+	void Sim::stepPanelTransmitter(uint32_t _cycles)
+	{
+		auto& uart = m_uart[g_uartPanel];
+		while(uart.txShiftBusy && _cycles >= uart.txCyclesRemaining)
+		{
+			_cycles -= uart.txCyclesRemaining;
+			uart.txCyclesRemaining = 0;
+			uart.txShiftBusy = false;
+			if(uart.txCallback)
+				uart.txCallback(uart.txShift);
+			startPanelShiftRegister();
+		}
+		if(uart.txShiftBusy)
+			uart.txCyclesRemaining -= _cycles;
 	}
 
 	void Sim::setTransmitCallback(const unsigned _uart, TransmitCallback _callback)
@@ -378,6 +522,13 @@ namespace md
 	{
 		stepTimer(0, g_timer1Base, _cycles);
 		stepTimer(1, g_timer2Base, _cycles);
+		stepPanelTransmitter(_cycles);
+	}
+
+	uint32_t Sim::cyclesUntilNextUartTransmit() const
+	{
+		const auto& uart = m_uart[g_uartPanel];
+		return uart.txShiftBusy ? uart.txCyclesRemaining : g_noTimerInterruptDeadline;
 	}
 
 	uint32_t Sim::cyclesUntilNextTimerInterrupt() const

--- a/source/elektron/md/mdLib/mdsim.h
+++ b/source/elektron/md/mdLib/mdsim.h
@@ -19,10 +19,10 @@ namespace md
 	// Modelled behaviourally (everything else is store/return-stored backing RAM):
 	//   * Parallel port PPDDR/PPDAT (UM Section 10) - PPDAT reads return input pins
 	//     idle-HIGH, output-driven bits reflect the last written value.
-	//   * UART1 ($140, MIDI) and UART2 ($180, panel) status register (USR, +$04) -
-	//     the transmitter is always reported ready (TxEMP/TxRDY) so the firmware can
-	//     poll-and-send; RxRDY is set only while a byte is queued via queueRx().
-	//     Transmit-buffer (UTB) writes are captured for later MIDI/panel wiring.
+	//   * UART1 ($140, MIDI) and UART2 ($180, panel) status register (USR, +$04).
+	//     UART2 uses its programmed mode/baud registers to pace a holding register
+	//     and shift register; UART1 retains legacy immediate delivery. RxRDY is set
+	//     only while a byte is queued via queueRx().
 	//   * Chip-select, timer and interrupt-controller registers are stored so reads
 	//     return what was written (they define the memory map, hard-coded elsewhere).
 	//
@@ -210,6 +210,10 @@ namespace md
 		// instruction that reaches the deadline. It must not execute a later
 		// instruction first.
 		uint32_t cyclesUntilNextTimerInterrupt() const;
+		// Master-clock cycles until the panel UART finishes its current character.
+		// The callback and any newly-ready holding register must be materialized at
+		// this boundary even when its interrupt is masked.
+		uint32_t cyclesUntilNextUartTransmit() const;
 
 		// Interrupt-controller: hand the next pending interrupt to the parent CPU and
 		// consume it, returning false when none is pending above the mask. Sources modelled:
@@ -282,6 +286,14 @@ namespace md
 			TransmitCallback    txCallback;
 			size_t rxOverflows = 0;
 			uint64_t rxConsumed = 0;
+			std::array<uint8_t, 2> mode{};
+			uint8_t modePointer = 0;
+			bool txEnabled = false;
+			bool txHoldingFull = false;
+			uint8_t txHolding = 0;
+			bool txShiftBusy = false;
+			uint8_t txShift = 0;
+			uint32_t txCyclesRemaining = 0;
 		};
 
 		uint8_t computeParallelData() const;
@@ -289,6 +301,13 @@ namespace md
 		uint8_t computeUartInterruptStatus(unsigned _uart) const;
 		uint8_t popReceiveBuffer(unsigned _uart);
 		void    pushTransmitBuffer(unsigned _uart, uint8_t _value);
+		void    writeUartMode(unsigned _uart, uint8_t _value);
+		void    writeUartCommand(unsigned _uart, uint8_t _value);
+		bool    panelTransmitTimingActive() const;
+		uint32_t panelCharacterCycles() const;
+		void    startPanelShiftRegister();
+		void    stepPanelTransmitter(uint32_t _cycles);
+		void    armTransmitReady(unsigned _uart);
 
 		// --- Timer internals ------------------------------------------------------
 		struct Timer

--- a/source/elektron/md/mdLibTest/idleSelfBranchTest.cpp
+++ b/source/elektron/md/mdLibTest/idleSelfBranchTest.cpp
@@ -77,6 +77,7 @@ namespace
 				require(a.getSim().read16(base + offset) == b.getSim().read16(base + offset),
 					"timer register differs");
 		require(a.getSim().cyclesUntilNextTimerInterrupt() == b.getSim().cyclesUntilNextTimerInterrupt(), "timer deadline differs");
+		require(a.getSim().cyclesUntilNextUartTransmit() == b.getSim().cyclesUntilNextUartTransmit(), "UART deadline differs");
 		require(a.getSim().needsInterruptCheck() == b.getSim().needsInterruptCheck(), "SIM interrupt scan state differs");
 		for(uint32_t p = 0x2ffe80; p < 0x2fff00; p += 2)
 			require(a.read16(p) == b.read16(p), "interrupt stack frame differs");

--- a/source/elektron/md/mdLibTest/uartRegisterTest.cpp
+++ b/source/elektron/md/mdLibTest/uartRegisterTest.cpp
@@ -1,5 +1,6 @@
 #include "mdLib/mdsim.h"
 
+#include <array>
 #include <iostream>
 #include <stdexcept>
 
@@ -143,6 +144,96 @@ namespace
 		require(sim.queuedRxBytes(_uart) == 0, "reset retained receive data");
 		require(!sim.takeNextInterrupt(level, vector), "reset retained a receive request");
 	}
+
+	void panelTransmitPacing()
+	{
+		md::Sim sim;
+		constexpr auto uart = md::Sim::g_uartPanel;
+		constexpr auto base = md::Sim::g_uart2Base;
+		std::array<uint8_t, 3> received{};
+		size_t count = 0;
+		sim.setTransmitCallback(uart, [&](const uint8_t byte)
+		{
+			if(count < received.size())
+				received[count++] = byte;
+		});
+
+		// MD OS 1.63 panel configuration: 8N1, internal baud generator, UBG=8.
+		sim.write8(base + md::Sim::g_uartMr, 0xb3);
+		sim.write8(base + md::Sim::g_uartMr, 0x07);
+		sim.write8(base + md::Sim::g_uartUsr, 0xdd);
+		sim.write8(base + md::Sim::g_uartBg1, 0x00);
+		sim.write8(base + md::Sim::g_uartBg2, 0x08);
+		sim.write8(base + md::Sim::g_uartCr, 0x04);
+		require(sim.read8(base + md::Sim::g_uartUsr)
+			== (md::Sim::g_usrTxEmp | md::Sim::g_usrTxRdy),
+			"enabled empty panel transmitter did not report ready");
+
+		sim.write8(base + md::Sim::g_uartRxTx, 0x11);
+		require(count == 0 && sim.cyclesUntilNextUartTransmit() == 2560,
+			"first panel byte bypassed its configured wire time");
+		require(sim.read8(base + md::Sim::g_uartUsr) == md::Sim::g_usrTxRdy,
+			"shift-register load did not free the holding register");
+		sim.write8(base + md::Sim::g_uartRxTx, 0x22);
+		sim.write8(base + md::Sim::g_uartRxTx, 0x33);
+		require(sim.read8(base + md::Sim::g_uartUsr) == 0,
+			"full panel holding register still reported ready");
+
+		sim.exec(2559);
+		require(count == 0 && sim.cyclesUntilNextUartTransmit() == 1,
+			"panel byte completed before its stop bit");
+		sim.exec(1);
+		require(count == 1 && received[0] == 0x11
+			&& sim.cyclesUntilNextUartTransmit() == 2560,
+			"first completion did not advance the queued holding byte");
+		require(sim.read8(base + md::Sim::g_uartUsr) == md::Sim::g_usrTxRdy,
+			"holding-to-shift transfer did not reassert ready");
+		sim.exec(2560);
+		require(count == 2 && received[1] == 0x22,
+			"second panel byte did not complete at its wire deadline");
+		require(sim.read8(base + md::Sim::g_uartUsr)
+			== (md::Sim::g_usrTxEmp | md::Sim::g_usrTxRdy),
+			"drained panel transmitter did not report empty");
+		require(sim.cyclesUntilNextUartTransmit() == md::Sim::g_noTimerInterruptDeadline,
+			"drained panel transmitter retained a deadline");
+	}
+
+	void panelTransmitInterruptTiming()
+	{
+		md::Sim sim;
+		constexpr auto uart = md::Sim::g_uartPanel;
+		constexpr auto base = md::Sim::g_uart2Base;
+		unsigned received = 0;
+		sim.setTransmitCallback(uart, [&](uint8_t) { ++received; });
+		sim.write8(base + md::Sim::g_uartMr, 0xb3);
+		sim.write8(base + md::Sim::g_uartMr, 0x07);
+		sim.write8(base + md::Sim::g_uartUsr, 0xdd);
+		sim.write8(base + md::Sim::g_uartBg1, 0x00);
+		sim.write8(base + md::Sim::g_uartBg2, 0x08);
+		sim.write8(base + md::Sim::g_uartCr, 0x04);
+		sim.write8(md::Sim::g_icrUart2, 3 << 2);
+		sim.write8(base + md::Sim::g_uartIvr, 0x60);
+		sim.write16(md::Sim::g_imr, 0);
+		sim.write8(base + md::Sim::g_uartIsr, md::Sim::g_uimrTxRdy);
+
+		uint8_t level = 0, vector = 0;
+		require(sim.takeNextInterrupt(level, vector) && level == 3 && vector == 0x60,
+			"enabling an empty panel transmitter did not request its first byte");
+		sim.write8(base + md::Sim::g_uartRxTx, 0x11);
+		require(sim.takeNextInterrupt(level, vector),
+			"loading the shift register did not request a second holding byte");
+		sim.write8(base + md::Sim::g_uartRxTx, 0x22);
+		require(!sim.takeNextInterrupt(level, vector),
+			"full holding register requested another transmit byte");
+		sim.exec(2559);
+		require(received == 0 && !sim.takeNextInterrupt(level, vector),
+			"transmit interrupt arrived before the first stop bit completed");
+		sim.exec(1);
+		require(received == 1 && sim.takeNextInterrupt(level, vector),
+			"character completion did not reassert TxRDY interrupt");
+		require(!sim.takeNextInterrupt(level, vector),
+			"one holding-register transition offered duplicate interrupts");
+	}
 }
 
 int main()
@@ -164,8 +255,18 @@ int main()
 			}
 		}
 	}
+	try
+	{
+		panelTransmitPacing();
+		panelTransmitInterruptTiming();
+	}
+	catch(const std::exception& error)
+	{
+		std::cerr << "panel transmit pacing: " << error.what() << '\n';
+		++failures;
+	}
 	if(failures)
 		return 1;
-	std::cout << "UART source-status and receive-unmask tests passed for both ports\n";
+	std::cout << "UART register, receive-unmask, and panel transmit timing tests passed\n";
 	return 0;
 }


### PR DESCRIPTION
The Machinedrum front-panel UART always reported `TxRDY | TxEMP` and delivered every byte immediately. During boot, firmware therefore sent the 14,110-byte main logo stream in 0.442 seconds even though its programmed 156,250-baud 8N1 link needs at least 0.903 seconds.

Model UART2's mode/baud configuration, transmitter enable/reset commands, one-byte holding register, one-byte shift register, and character-completion deadline. Idle-loop batching now stops before the UART deadline. UART1/MIDI keeps its existing behavior.

The same main logo stream now takes 0.911 seconds and reaches the same final LCD state. Focused UART/deadline tests pass, along with MD UW, MM boot/state restore, MD/MM audio, and MIDI timing firmware tests using the supported MD 1.63 and MM 1.32b images.

Physical-unit UART capture remains the limit on claiming cycle-exact hardware parity; the implementation follows the MCF5206E register semantics and the baud/mode values written by MD 1.63.
