### PR TITLE
Recover and diagnose MD/MM standalone audio startup

### DIFF
--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.cpp
@@ -17,6 +17,9 @@
 
 #include "baseLib/binarystream.h"
 
+#include "juce_audio_utils/juce_audio_utils.h"
+#include "juce_audio_plugin_client/Standalone/juce_StandaloneFilterWindow.h"
+
 #include <memory>
 #include <utility>
 
@@ -360,7 +363,26 @@ namespace mdJucePlugin
 		getController();
 		const auto latencyBlocks = getConfig().getIntValue("latencyBlocks", static_cast<int>(getPlugin().getLatencyBlocks()));
 		Processor::setLatencyBlocks(latencyBlocks);
-		if(m_model == md::MachineModel::Machinedrum)
+		m_startupDiagnosticsEnabled = !_ephemeralConfig
+			&& juce::JUCEApplicationBase::isStandaloneApp();
+		if(m_startupDiagnosticsEnabled)
+		{
+			const auto folder = performanceDiagnosticsFolder();
+			if(folder.createDirectory().wasOk())
+			{
+				m_startupDiagnosticsFile = folder.getChildFile("standalone-startup-last.log");
+				m_startupDiagnosticsFile.deleteFile();
+				m_startupDiagnosticsStartMilliseconds
+					= juce::Time::getMillisecondCounterHiRes();
+				m_startupDiagnosticsFile.appendText(
+					"time=" + juce::Time::getCurrentTime().toISO8601(true)
+					+ " model=" + productName(m_model)
+					+ " revision=" + juce::String(MDMM_DIAGNOSTICS_REVISION) + "\n");
+			}
+			else
+				m_startupDiagnosticsEnabled = false;
+		}
+		if(m_model == md::MachineModel::Machinedrum || m_startupDiagnosticsEnabled)
 			startTimer(250);
 		m_performanceReport = std::make_unique<synthLib::PerformanceReport>(
 			getPlugin().getRealtimeInstrumentation(), panelEventDetails);
@@ -709,8 +731,55 @@ namespace mdJucePlugin
 				std::string(productName(m_model)) + " state restore", _error);
 	}
 
+	void AudioPluginAudioProcessor::recordStandaloneStartupDiagnostics()
+	{
+		if(!m_startupDiagnosticsEnabled)
+			return;
+		const auto elapsed = juce::Time::getMillisecondCounterHiRes()
+			- m_startupDiagnosticsStartMilliseconds;
+		if(elapsed > 20000.0)
+		{
+			m_startupDiagnosticsEnabled = false;
+			return;
+		}
+
+		auto* const holder = juce::StandalonePluginHolder::getInstance();
+		auto* const audioDevice = holder
+			? holder->deviceManager.getCurrentAudioDevice() : nullptr;
+		uint64_t cycles = 0;
+		uint64_t epoch = 0;
+		uint32_t pixels = 0;
+		uint32_t panelBytes = 0;
+		uint32_t tileWrites = 0;
+		getPlugin().withDeviceLocked([&](synthLib::Device* const _device)
+		{
+			auto* const device = dynamic_cast<md::Device*>(_device);
+			if(!device)
+				return;
+			const auto panel = device->getHardware().getFrontPanelSnapshot();
+			cycles = device->getHardware().hostCurrentCycle();
+			epoch = device->hardwareEpoch();
+			pixels = panel.countLitPixels();
+			panelBytes = panel.getByteCount();
+			tileWrites = panel.getTileWriteCount();
+		});
+
+		juce::String line;
+		line << "ms=" << static_cast<int64_t>(elapsed)
+			<< " device=" << static_cast<int>(audioDevice != nullptr)
+			<< " playing=" << static_cast<int>(audioDevice && audioDevice->isPlaying())
+			<< " cycles=" << static_cast<int64_t>(cycles)
+			<< " epoch=" << static_cast<int64_t>(epoch)
+			<< " pixels=" << static_cast<int64_t>(pixels)
+			<< " panelBytes=" << static_cast<int64_t>(panelBytes)
+			<< " tileWrites=" << static_cast<int64_t>(tileWrites)
+			<< " editor=" << static_cast<int>(getActiveEditor() != nullptr) << "\n";
+		m_startupDiagnosticsFile.appendText(line);
+	}
+
 	void AudioPluginAudioProcessor::timerCallback()
 	{
+		recordStandaloneStartupDiagnostics();
 		if(serviceProjectStateRestore())
 			return;
 		(void)serviceFactoryInitialization();

--- a/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
+++ b/source/elektron/md/mdJucePlugin/mdPluginProcessor.h
@@ -65,6 +65,7 @@ namespace mdJucePlugin
 			std::optional<std::string> _deviceHomePath = std::nullopt);
 		bool serviceDeferredStateRestore();
 		bool serviceStateRestoreFailure();
+		void recordStandaloneStartupDiagnostics();
 		void reportProjectStateRestoreFailure(const std::string& _error);
 		void timerCallback() override;
 
@@ -76,6 +77,9 @@ namespace mdJucePlugin
 		const std::optional<std::string> m_deviceHomePath;
 		std::mutex m_storageLoadMutex;
 		uint64_t m_reportedRestoreFailureGeneration = 0;
+		juce::File m_startupDiagnosticsFile;
+		double m_startupDiagnosticsStartMilliseconds = 0.0;
+		bool m_startupDiagnosticsEnabled = false;
 		JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioPluginAudioProcessor)
 	};
 }

--- a/source/juce.cmake
+++ b/source/juce.cmake
@@ -130,6 +130,8 @@ macro(createJucePlugin targetName productName isSynth plugin4CC binaryDataProjec
 		IS_MIDI_EFFECT FALSE                              # Is this plugin a MIDI effect?
 		EDITOR_WANTS_KEYBOARD_FOCUS TRUE                  # Does the editor need keyboard focus?
 		COPY_PLUGIN_AFTER_BUILD FALSE                     # Should the plugin be installed to a default location after building?
+		MICROPHONE_PERMISSION_ENABLED TRUE               # Standalone exposes the physical stereo input
+		MICROPHONE_PERMISSION_TEXT "Gearmulator uses audio input for processing external instruments."
 		PLUGIN_MANUFACTURER_CODE GmPv                     # A four-character manufacturer id with at least one upper-case character
 		PLUGIN_CODE ${plugin4CC}                          # A unique four-character plugin id with exactly one upper-case character
 		PRODUCTS_FOLDER "${CMAKE_SOURCE_DIR}/bin/plugins/$<CONFIG>"


### PR DESCRIPTION
The MD/MM standalone can open its window after audio-device initialization leaves no current, playing device. Because the emulated machine advances from the audio callback, that state produces a silent blank LCD with no visible explanation.

This change pins [JUCE-md-mm PR #1](https://github.com/joelanders/JUCE-md-mm/pull/1), adds the required macOS microphone-purpose declaration, and writes a bounded 20-second standalone startup log. The JUCE change falls back to output-only startup when full-duplex initialization fails, preserves the saved full-duplex setup, and retries device discovery for five seconds. The product log records the audio device state, ColdFire cycles, hardware epoch, published LCD pixels, panel-byte/tile activity, and editor existence so a future report identifies the failing layer directly.

Validation:

- rebased onto the merged panel-UART fix at `d86311bf`;
- exact arm64 Release MD and MM standalone targets built and passed strict ad-hoc signature verification;
- both generated app plists contain `NSMicrophoneUsageDescription`;
- normal signed MD startup opened full duplex, advanced cycles, and reached 748 populated LCD pixels;
- a test-only input-open fault used output-only fallback with a playing MacBook Pro Speakers device while cycles and LCD pixels continued advancing;
- a test-only temporary device-loss fault first produced `device=0`, zero cycles, and zero pixels, then recovered on the first retry and populated the LCD;
- all fault-injection code was reverted before the final exact MD/MM rebuild.

The historical blank process was closed before an internal trace was captured, so this does not claim retrospective proof of the original macOS trigger. It fixes and diagnoses the complete blank-from-start mechanism we reproduced.
