### PR TITLE
Harden MD/MM standalone defaults and optimized macOS releases

### DIFF
--- a/.github/workflows/elektron-macos.yml
+++ b/.github/workflows/elektron-macos.yml
@@ -63,12 +63,17 @@ jobs:
         run: |
           /bin/bash -n scripts/macos/build_mdmm.sh scripts/macos/verify_mdmm_package.sh
           python3 scripts/macos/test_write_mdmm_receipt.py
+          python3 scripts/macos/test_check_mdmm_core_capacity.py
 
       - name: Build, test, sign, and package MD/MM
         env:
           # Hosted runners have no secure firmware-fixture channel. Local
           # release verification defaults to requiring both validated images.
           GEARMULATOR_REQUIRE_FIRMWARE_TESTS: "0"
+          # CI always exercises the reproducible universal baseline. A local
+          # single-architecture PGO candidate must opt in with a matched profile.
+          GEARMULATOR_MDMM_MACOS_ARCHITECTURES: "arm64;x86_64"
+          GEARMULATOR_MDMM_APPLE_PGO_MODE: "none"
         run: >-
           ./scripts/macos/build_mdmm.sh
           "${{ github.workspace }}"

--- a/doc/mdmm-apple-optimization.md
+++ b/doc/mdmm-apple-optimization.md
@@ -1,9 +1,19 @@
 # MD/MM Apple compiler optimization
 
-MD/MM provides opt-in compiler settings for Release builds on macOS. The
-default configuration uses the existing compiler settings. The options apply
-to shared emulation libraries, so other products linked to those libraries
-also consume the selected build.
+MD/MM provides compiler settings for Release builds on macOS. They remain
+opt-in for developer builds because they apply to shared emulation libraries,
+so other products linked to those libraries also consume the selected build.
+The official `scripts/macos/build_mdmm.sh` release path explicitly enables
+ThinLTO for the MCU and DSP cores, reads the generated CMake cache back, and
+fails before compilation if either setting is absent. An ordinary Release
+build is not an acceptable macOS MD/MM release artifact.
+
+The same script sets `GEARMULATOR_JUCE_PRODUCTS_ROOT` to `products` inside its
+owned build directory. Ordinary developer builds retain the historical
+`bin/plugins` destination, but they cannot overwrite a release build while its
+cache is being validated, its modules are being measured, or its receipt is
+being written. The receipt writer rejects a release cache whose products root
+is not the expected build-local directory.
 
 | CMake option | Default | Effect |
 | --- | --- | --- |
@@ -12,15 +22,43 @@ also consume the selected build.
 | `GEARMULATOR_MDMM_APPLE_PGO_MODE` | `none` | Select `none`, `generate`, or `use` for profile-guided optimization. |
 | `GEARMULATOR_MDMM_APPLE_PGO_PROFILE` | Empty | Path to the merged profile for `use` mode. |
 
-Add these options to the normal MD/MM build configuration. PGO requires
-ThinLTO and one explicit `CMAKE_OSX_ARCHITECTURES` value. Train and build each
-architecture separately. ThinLTO alone can also be used in a universal build.
-The flags apply only to Release configurations.
+`build_mdmm.sh` defaults to `arm64;x86_64` and `pgo_mode=none`, producing
+`Gearmulator-Elektron-macOS-Universal.zip`. Those defaults are also explicit in
+the hosted workflow. A local, guarded arm64 PGO candidate uses the same build,
+test, signing, measurement, packaging, and receipt path:
+
+```sh
+GEARMULATOR_MDMM_MACOS_ARCHITECTURES=arm64 \
+GEARMULATOR_MDMM_APPLE_PGO_MODE=use \
+GEARMULATOR_MDMM_APPLE_PGO_PROFILE=/private/path/arm64.profdata \
+GEARMULATOR_MDMM_APPLE_PGO_PROVENANCE=/private/path/arm64.provenance.json \
+GEARMULATOR_MD_FIRMWARE_BIN=/private/path/md-1.63.bin \
+GEARMULATOR_MM_FIRMWARE_BIN=/private/path/mm-1.32b.bin \
+scripts/macos/build_mdmm.sh SOURCE BUILD OUTPUT
+```
+
+That command produces `Gearmulator-Elektron-macOS-arm64-PGO.zip`. The script
+accepts only `arm64`, `x86_64`, or the normalized universal pair. PGO `use`
+requires one architecture plus both existing profile and provenance files;
+`generate` is never accepted for a product package. Keep those inputs outside
+the owned build and output roots because the script cleans both roots first.
+
+PGO requires ThinLTO and one explicit `CMAKE_OSX_ARCHITECTURES` value. Train
+and build each architecture separately. One profile cannot be applied to a
+universal build. The official universal build therefore uses ThinLTO for the
+MCU and DSP cores as its reproducible baseline and records `pgo_mode: none`
+for both slices. A separately assembled universal PGO package must identify the
+profile and provenance of every optimized slice; it must not label the other
+slice as PGO optimized. The current official packager supports a guarded
+single-architecture PGO candidate, but does not yet assemble or receipt a
+mixed-slice package. Until that support exists, its universal output is the
+ThinLTO and DSP baseline. The flags apply only to Release configurations.
 
 ## Profile generation and use
 
-1. Pin the parent and submodule revisions, compiler, architecture, and build
-   definitions. Keep a record of these and the workload used for training.
+1. Pin the parent and submodule revisions, compiler, architecture, macOS
+   deployment target, and build definitions. Keep a record of these and the
+   workload used for training.
 2. Configure an instrumented Release build with
    `GEARMULATOR_MDMM_APPLE_THINLTO=ON` and
    `GEARMULATOR_MDMM_APPLE_PGO_MODE=generate`. Select the same DSP option for
@@ -55,3 +93,72 @@ validate a profile.
 
 Keep generated `.profraw` and `.profdata` files as local build inputs. The
 resulting optimized executable does not require the profile at runtime.
+
+## Release receipts and core-capacity check
+
+`write_mdmm_receipt.py` derives optimization claims from `CMakeCache.txt`.
+For every packaged architecture, the receipt records whether ThinLTO includes
+the DSP and whether PGO was used. A single-architecture PGO receipt records the
+SHA-256 of the exact profile and requires `--pgo-provenance` with schema
+`gearmulator.mdmm.apple-pgo-profile.v1`. Keep that private provenance record
+with the parent, DSP, MCU and JUCE revisions, compiler version, architecture,
+deployment target, build definitions and training workload. The writer rejects
+a source, compiler, architecture, deployment-target, profile or
+required-workload mismatch. A profile hash proves identity; the provenance
+record establishes whether that identity belongs to the build.
+The provenance JSON records the deployment target as
+`build.deployment_target`; the guarded alpha.11 path requires the string
+`"10.13"`.
+
+Local release builds require the pinned firmware and run
+`check_mdmm_core_capacity.py` against the exact signed VST3 modules. This is a
+headless, output-only microgate: the host opens zero input channels, creates no
+editor, and runs both products at 48 kHz with 128-sample blocks. For each
+product it makes three unpaced capacity measurements and three separately
+paced observations. The median capacity p50 must use at most 90% of the
+callback period. Three direct unpaced measurements of the preserved ThinLTO and
+DSP MD baseline used 86.2%, 84.4%, and 86.1% (86.1% median) under active system
+load. The ordinary alpha.11 result used about 101% in the comparable 48 kHz,
+128-sample workload. The final build must reproduce the capacity result for
+both products.
+
+The paced runs report p99, maximum duration, render overruns, scheduler arrival
+lateness, and completion-after-deadline counts. A paced tail is marked
+qualified only when every measured callback meets its render-duration budget;
+the core microgate never calls a run with occasional overruns qualified.
+Scheduler arrival lateness remains separate from plug-in render duration and
+does not make the capacity discriminator depend on OS wake-up jitter.
+
+The core receipt fixes and validates the duration, warm-up, callback counts,
+firmware hashes, host identity, bus layout, scenario, and hashes of every raw
+capture before the private captures are removed. It names the one selected
+architecture executed by the host; an explicit x86_64 single-slice run may be
+executing under Rosetta rather than on Intel hardware. The universal build
+receipt records the executed slice as measured and every other slice as
+`not_run`; overall release acceptance remains `partial`. Fixture-free hosted CI
+can build the optimized baseline but cannot issue this firmware-backed
+microgate.
+
+## Local acceptance after packaging
+
+The build script produces a signed, verified candidate. It does not approve a
+release. Before publication, exercise the exact extracted package and record:
+
+1. The output-only core-capacity check on every packaged architecture. On an
+   Apple-silicon build host, the automatic universal run covers arm64 only;
+   x86_64 still needs an Intel or explicitly selected Rosetta run.
+2. Three isolated, paced `latency/run.py --scenario input` captures for MD and
+   MM at 48 kHz with 128-sample blocks. Require finite, non-silent output, a
+   detected input correlation/delay in all four analysis windows, and review
+   every render overrun separately from scheduler lateness.
+3. A first-launch standalone run for MD and MM in fresh state. Confirm each
+   starts with output only, produces sustained clean audio, selects the
+   automatic Metal renderer on supported macOS systems, and settles to the
+   expected idle UI CPU while the panel is static.
+4. In another isolated standalone state, explicitly enable the physical stereo
+   input in Audio/MIDI Settings. Confirm the choice remains available and that
+   sustained input processing and the UI stay usable. Then relaunch fresh state
+   once more to confirm the default is still output only.
+
+Keep ROMs, NVRAM, rendered audio, and full run receipts in private evidence.
+Only sanitized summaries and their hashes belong beside the public package.

--- a/scripts/macos/build_mdmm.sh
+++ b/scripts/macos/build_mdmm.sh
@@ -11,6 +11,10 @@ output_dir="$(python3 -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).r
 require_firmware_tests="${GEARMULATOR_REQUIRE_FIRMWARE_TESTS:-1}"
 md_firmware_bin="${GEARMULATOR_MD_FIRMWARE_BIN:-}"
 mm_firmware_bin="${GEARMULATOR_MM_FIRMWARE_BIN:-}"
+release_architectures_input="${GEARMULATOR_MDMM_MACOS_ARCHITECTURES:-arm64;x86_64}"
+release_pgo_mode="${GEARMULATOR_MDMM_APPLE_PGO_MODE:-none}"
+release_pgo_profile="${GEARMULATOR_MDMM_APPLE_PGO_PROFILE:-}"
+release_pgo_provenance="${GEARMULATOR_MDMM_APPLE_PGO_PROVENANCE:-}"
 readonly md_firmware_bin_sha256="68542e30917b9918ccaee2b2237df62c8a00479938680b85aca93ce4fbca44c8"
 readonly mm_firmware_bin_sha256="369849175602e20a9dd2b6e0ad8ac404b76f82718b14afbf1cbc01b7acabec7e"
 
@@ -35,6 +39,50 @@ validate_firmware_bin() {
     return 1
   fi
 }
+
+selection_pgo_args=()
+if [[ -n "${release_pgo_profile}" ]]; then
+  selection_pgo_args+=(--release-pgo-profile "${release_pgo_profile}")
+fi
+if [[ -n "${release_pgo_provenance}" ]]; then
+  selection_pgo_args+=(--pgo-provenance "${release_pgo_provenance}")
+fi
+release_selection="$(python3 "${script_dir}/write_mdmm_receipt.py" \
+  --source "${source_dir}" \
+  --print-release-selection \
+  --release-architectures "${release_architectures_input}" \
+  --release-pgo-mode "${release_pgo_mode}" \
+  ${selection_pgo_args[@]+"${selection_pgo_args[@]}"})"
+if [[ "${release_selection}" != *"|"* ]]; then
+  echo "Release selection helper returned an invalid result: ${release_selection}" >&2
+  exit 2
+fi
+release_architectures="${release_selection%%|*}"
+package_name="${release_selection#*|}"
+IFS=';' read -r -a release_architecture_array <<< "${release_architectures}"
+
+if [[ "${release_pgo_mode}" == "use" ]]; then
+  release_pgo_profile="$(python3 -c \
+    'import pathlib, sys; print(pathlib.Path(sys.argv[1]).resolve(strict=True))' \
+    "${release_pgo_profile}")"
+  release_pgo_provenance="$(python3 -c \
+    'import pathlib, sys; print(pathlib.Path(sys.argv[1]).resolve(strict=True))' \
+    "${release_pgo_provenance}")"
+fi
+
+expected_architecture_args=()
+for architecture in "${release_architecture_array[@]}"; do
+  expected_architecture_args+=(--expected-architecture "${architecture}")
+done
+
+pgo_cache_args=(
+  -DGEARMULATOR_MDMM_APPLE_PGO_MODE="${release_pgo_mode}"
+  -DGEARMULATOR_MDMM_APPLE_PGO_PROFILE="${release_pgo_profile}"
+)
+pgo_provenance_args=()
+if [[ "${release_pgo_mode}" == "use" ]]; then
+  pgo_provenance_args=(--pgo-provenance "${release_pgo_provenance}")
+fi
 
 python3 "${script_dir}/write_mdmm_receipt.py" \
   --source "${source_dir}" \
@@ -64,7 +112,7 @@ source_tuple_before="$(python3 "${script_dir}/write_mdmm_receipt.py" \
   --allow-untracked-root "${build_dir}/.gearmulator-mdmm-release-root" \
   --allow-untracked-root "${output_dir}/.gearmulator-mdmm-release-root")"
 
-artifact_root="${source_dir}/bin/plugins/Release"
+artifact_root="${build_dir}/products/Release"
 md_app="${artifact_root}/Standalone/Gearmulator MD.app"
 mm_app="${artifact_root}/Standalone/Gearmulator MM.app"
 md_vst3="${artifact_root}/VST3/Gearmulator MD.vst3"
@@ -73,6 +121,7 @@ md_au="${artifact_root}/AU/Gearmulator MD.component"
 mm_au="${artifact_root}/AU/Gearmulator MM.component"
 build_runtime_home="${build_dir}/build-runtime-home"
 build_runtime_data="${build_runtime_home}/Documents"
+core_capacity_check="${build_dir}/mdmm-core-capacity.json"
 
 cleanup_build_runtime_home() {
   rm -rf -- "${build_runtime_home}"
@@ -101,17 +150,15 @@ if [[ "${require_firmware_tests}" == "1" ]]; then
     "${mm_firmware_bin_sha256}"
 fi
 
-# JUCE places products in a shared ignored source-tree directory rather than in
-# build_dir. Remove only this release's six exact bundles so stale resources
-# from an older build cannot enter the archive.
-rm -rf "${md_app}" "${mm_app}" "${md_vst3}" "${mm_vst3}" \
-  "${md_au}" "${mm_au}"
-
 cmake -S "${source_dir}" -B "${build_dir}" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
+  -DCMAKE_OSX_ARCHITECTURES="${release_architectures}" \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 \
   -DXCODE_VERSION="${XCODE_VERSION:-16}" \
+  -DGEARMULATOR_MDMM_APPLE_THINLTO=ON \
+  -DGEARMULATOR_MDMM_APPLE_OPTIMIZE_DSP=ON \
+  "${pgo_cache_args[@]}" \
+  -DGEARMULATOR_JUCE_PRODUCTS_ROOT="${build_dir}/products" \
   -DBUILD_TESTING=ON \
   -Dgearmulator_BUILD_JUCEPLUGIN=ON \
   -Dgearmulator_BUILD_FX_PLUGIN=OFF \
@@ -129,6 +176,15 @@ cmake -S "${source_dir}" -B "${build_dir}" \
   -Dgearmulator_SYNTH_NODALRED2X=OFF \
   -Dgearmulator_SYNTH_JE8086=OFF
 
+# Read back the generated cache. This prevents a renamed option, stale cache,
+# or later CMake change from silently producing an ordinary Release package.
+python3 "${script_dir}/write_mdmm_receipt.py" \
+  --source "${source_dir}" \
+  --validate-build-optimization "${build_dir}/CMakeCache.txt" \
+  "${expected_architecture_args[@]}" \
+  --expected-products-root "${build_dir}/products" \
+  ${pgo_provenance_args[@]+"${pgo_provenance_args[@]}"}
+
 HOME="${build_runtime_home}" GEARMULATOR_DATA_ROOT="${build_runtime_data}" \
 cmake --build "${build_dir}" --parallel 4 --target \
   mdJucePlugin_VST3 \
@@ -138,6 +194,7 @@ cmake --build "${build_dir}" --parallel 4 --target \
   mdJucePlugin_Standalone \
   mmJucePlugin_Standalone \
   pluginTester \
+  latency_host \
   baseLibBinaryStreamTest \
   synthLibAudioTest \
   mdLibTest \
@@ -149,6 +206,9 @@ cmake --build "${build_dir}" --parallel 4 --target \
   mdAudioIoLayoutTest \
   mdProjectStateRestoreTest \
   mdAudioProbePlugin_VST3 \
+  mdStandaloneRendererPolicyTest \
+  mdPanelRenderingTest \
+  juceRmlMouseInputTest \
   mdFrontPanelPresentationTest \
   mdFirmwareImageTest \
   mc68kColdFireDivideTest
@@ -174,6 +234,9 @@ for test_name in \
   mdLibTests \
   mdStateTest \
   mdFlashTest \
+  mdStandaloneRendererPolicyTest \
+  mdPanelRenderingTest \
+  juceRmlMouseInputTest \
   mdFrontPanelPresentationTests \
   mdAudioQueueTest \
   mdAudioIoLayoutTest \
@@ -225,6 +288,34 @@ cleanup_build_runtime_home
 mkdir -p "${build_runtime_data}"
 
 plugin_tester="${build_dir}/source/pluginTester/pluginTester_artefacts/Release/pluginTester"
+latency_host="${build_dir}/source/pluginTester/latency/latency_host"
+
+validate_binary_architectures() {
+  local executable="$1"
+  local actual_architectures
+  actual_architectures="$(lipo -archs "${executable}")"
+  local expected_architecture
+  local actual_architecture
+  local found
+  for expected_architecture in "${release_architecture_array[@]}"; do
+    if [[ " ${actual_architectures} " != *" ${expected_architecture} "* ]]; then
+      echo "Binary is missing ${expected_architecture}: ${executable} (${actual_architectures})" >&2
+      return 1
+    fi
+  done
+  for actual_architecture in ${actual_architectures}; do
+    found=0
+    for expected_architecture in "${release_architecture_array[@]}"; do
+      if [[ "${actual_architecture}" == "${expected_architecture}" ]]; then
+        found=1
+      fi
+    done
+    if [[ "${found}" != "1" ]]; then
+      echo "Binary has unexpected architecture ${actual_architecture}: ${executable}" >&2
+      return 1
+    fi
+  done
+}
 
 for bundle in "${md_vst3}" "${mm_vst3}"; do
   rm -f "${bundle}/Contents/Resources/moduleinfo.json"
@@ -239,12 +330,43 @@ for bundle in "${md_app}" "${mm_app}" "${md_vst3}" "${mm_vst3}" \
   codesign --force --deep --sign - "${bundle}"
   codesign --verify --deep --strict "${bundle}"
   executable="${bundle}/Contents/MacOS/$(basename "${bundle}" | sed -E 's/\.(app|vst3|component)$//')"
-  archs="$(lipo -archs "${executable}")"
-  [[ " ${archs} " == *" arm64 "* && " ${archs} " == *" x86_64 "* ]] || {
-    echo "Bundle is not universal: ${bundle} (${archs})" >&2
-    exit 4
-  }
+  validate_binary_architectures "${executable}"
 done
+
+validate_binary_architectures "${plugin_tester}"
+validate_binary_architectures "${latency_host}"
+
+if [[ ${#release_architecture_array[@]} -eq 1 ]]; then
+  qualification_architecture="${release_architecture_array[0]}"
+else
+  qualification_architecture="$(/usr/bin/uname -m)"
+fi
+if [[ " ${release_architectures//;/ } " != *" ${qualification_architecture} "* ]]; then
+  echo "Native qualification architecture is not in the package: ${qualification_architecture}" >&2
+  exit 4
+fi
+
+if [[ "${require_firmware_tests}" == "1" ]]; then
+  # Three unpaced measurements form a reproducible output-only core-capacity
+  # microgate. Paced runs report tail behavior without claiming that a headless
+  # selected-host run qualifies the other slice, physical input, or standalone UI.
+  python3 "${script_dir}/check_mdmm_core_capacity.py" \
+    --host "${latency_host}" \
+    --host-architecture "${qualification_architecture}" \
+    --md-plugin "${md_vst3}" \
+    --mm-plugin "${mm_vst3}" \
+    --md-firmware "${md_firmware_bin}" \
+    --mm-firmware "${mm_firmware_bin}" \
+    --work-root "${build_runtime_home}/core-capacity" \
+    --output "${core_capacity_check}" \
+    --rate 48000 \
+    --block 128 \
+    --seconds 20 \
+    --warm-start-seconds 12 \
+    --capacity-repeats 3 \
+    --paced-repeats 3 \
+    --capacity-p50-limit 0.90
+fi
 
 if [[ ! -x "${plugin_tester}" ]]; then
   echo "Expected VST3 host is missing: ${plugin_tester}" >&2
@@ -277,7 +399,7 @@ if find "${md_app}" "${mm_app}" "${md_vst3}" "${mm_vst3}" \
   exit 5
 fi
 
-package_dir="${output_dir}/Gearmulator-Elektron-macOS-Universal"
+package_dir="${output_dir}/${package_name}"
 mkdir -p "${package_dir}"
 /usr/bin/ditto "${md_app}" "${package_dir}/Gearmulator MD.app"
 /usr/bin/ditto "${mm_app}" "${package_dir}/Gearmulator MM.app"
@@ -289,7 +411,7 @@ mkdir -p "${package_dir}"
 /usr/bin/ditto "${script_dir}/INSTALL-macOS.txt" \
   "${package_dir}/INSTALL-macOS.txt"
 
-archive="${output_dir}/Gearmulator-Elektron-macOS-Universal.zip"
+archive="${output_dir}/${package_name}.zip"
 /usr/bin/ditto -c -k --sequesterRsrc --keepParent "${package_dir}" "${archive}"
 if [[ "${require_firmware_tests}" == "1" ]]; then
   "${script_dir}/verify_mdmm_package.sh" "${archive}" "${plugin_tester}" \
@@ -298,7 +420,11 @@ else
   "${script_dir}/verify_mdmm_package.sh" "${archive}" "${plugin_tester}"
 fi
 
-receipt="${output_dir}/Gearmulator-Elektron-macOS-Universal-receipt.json"
+receipt="${output_dir}/${package_name}-receipt.json"
+core_capacity_receipt_args=()
+if [[ "${require_firmware_tests}" == "1" ]]; then
+  core_capacity_receipt_args=(--core-capacity-check "${core_capacity_check}")
+fi
 python3 "${script_dir}/write_mdmm_receipt.py" \
   --source "${source_dir}" \
   --expected-source-tuple "${source_tuple_before}" \
@@ -306,6 +432,11 @@ python3 "${script_dir}/write_mdmm_receipt.py" \
   --allow-untracked-root "${archive}" \
   --allow-untracked-root "${output_dir}/.gearmulator-mdmm-release-root" \
   --firmware-tests-required "${require_firmware_tests}" \
+  --build-cache "${build_dir}/CMakeCache.txt" \
+  "${expected_architecture_args[@]}" \
+  --expected-products-root "${build_dir}/products" \
+  ${pgo_provenance_args[@]+"${pgo_provenance_args[@]}"} \
+  ${core_capacity_receipt_args[@]+"${core_capacity_receipt_args[@]}"} \
   --output "${receipt}" \
   --archive "${archive}" \
   --artifact "${package_dir}/Gearmulator MD.app" \

--- a/scripts/macos/check_mdmm_core_capacity.py
+++ b/scripts/macos/check_mdmm_core_capacity.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Run the native, output-only MD/MM core-capacity release microgate."""
+
+from __future__ import annotations
+
+import argparse
+import atexit
+import csv
+import hashlib
+import json
+import math
+import os
+import pathlib
+import platform
+import shutil
+import statistics
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from typing import Iterable, Optional
+
+
+FIRMWARE_SHA256 = {
+    "MD": "68542e30917b9918ccaee2b2237df62c8a00479938680b85aca93ce4fbca44c8",
+    "MM": "369849175602e20a9dd2b6e0ad8ac404b76f82718b14afbf1cbc01b7acabec7e",
+}
+PRODUCT_FOLDER = {"MD": "Machinedrum", "MM": "Monomachine"}
+NOTE_NUMBER = {"MD": 36, "MM": 60}
+RECEIPT_SCHEMA = "gearmulator-mdmm-core-capacity-v1"
+SCOPE = "executed VST3 output-only core callback duration"
+
+
+def sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def bundle_module(bundle: pathlib.Path) -> pathlib.Path:
+    modules = [path for path in (bundle / "Contents" / "MacOS").iterdir() if path.is_file()]
+    if len(modules) != 1:
+        raise RuntimeError(f"expected one executable module in {bundle}, found {len(modules)}")
+    return modules[0]
+
+
+def percentile(values: Iterable[float], quantile: float) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        raise RuntimeError("cannot calculate a percentile of no values")
+    position = (len(ordered) - 1) * quantile
+    below = int(position)
+    above = min(below + 1, len(ordered) - 1)
+    fraction = position - below
+    return ordered[below] * (1 - fraction) + ordered[above] * fraction
+
+
+def analyze_blocks(path: pathlib.Path, rate: int, warm_start_seconds: int) -> dict[str, object]:
+    with path.open(newline="", encoding="utf-8") as stream:
+        rows = list(csv.DictReader(stream))
+    if not rows:
+        raise RuntimeError(f"callback capture is empty: {path}")
+
+    position = 0
+    warm = []
+    for row in rows:
+        sample = int(row["sample"])
+        count = int(row["count"])
+        if sample != position or count <= 0:
+            raise RuntimeError(f"callback timeline has a gap, overlap, or empty block: {path}")
+        position += count
+        if sample >= warm_start_seconds * rate:
+            period_ms = count * 1000.0 / rate
+            render_ms = float(row["render_ms"])
+            late_ms = float(row["late_ms"])
+            if render_ms < 0 or not math.isfinite(render_ms) or not math.isfinite(late_ms):
+                raise RuntimeError(f"callback capture contains invalid timing data: {path}")
+            warm.append((render_ms, late_ms, period_ms))
+    if not warm:
+        raise RuntimeError(f"callback capture has no warm samples: {path}")
+
+    durations = [row[0] for row in warm]
+    scheduler_lateness = [row[1] for row in warm]
+    budget_fractions = [row[0] / row[2] for row in warm]
+    over_budget = sum(row[0] > row[2] for row in warm)
+    completed_late = sum(row[0] + row[1] > row[2] for row in warm)
+    return {
+        "total_callbacks": len(rows),
+        "total_samples": position,
+        "warm_callbacks": len(warm),
+        "p50_ms": percentile(durations, 0.50),
+        "p99_ms": percentile(durations, 0.99),
+        "max_ms": max(durations),
+        "p50_budget_fraction": percentile(budget_fractions, 0.50),
+        "p99_budget_fraction": percentile(budget_fractions, 0.99),
+        "max_budget_fraction": max(budget_fractions),
+        "over_budget": over_budget,
+        "over_budget_fraction": over_budget / len(warm),
+        # Scheduler arrival time is reported separately from plug-in duration.
+        # It is useful live-system evidence but is not a portable CPU-capacity gate.
+        "scheduler_late_p99_ms": percentile(scheduler_lateness, 0.99),
+        "completion_after_deadline": completed_late,
+        "completion_after_deadline_fraction": completed_late / len(warm),
+    }
+
+
+def aggregate(
+    capacity: list[dict[str, object]],
+    paced: list[dict[str, object]],
+    capacity_p50_limit: float,
+) -> dict[str, object]:
+    capacity_p50 = statistics.median(float(run["p50_budget_fraction"]) for run in capacity)
+    paced_p99 = statistics.median(float(run["p99_budget_fraction"]) for run in paced)
+    paced_over_budget = statistics.median(
+        float(run["over_budget_fraction"]) for run in paced
+    )
+    if not all(
+        math.isfinite(value)
+        for value in (capacity_p50, paced_p99, paced_over_budget)
+    ):
+        raise RuntimeError("core-capacity check contains non-finite measurements")
+    core_microgate_passed = capacity_p50 <= capacity_p50_limit
+    paced_render_overruns = sum(int(run["over_budget"]) for run in paced)
+    # A paced tail is called qualified only when every measured callback met
+    # its render-duration budget. Scheduler wake-up lateness remains separate.
+    paced_tail_qualification_passed = paced_render_overruns == 0
+    return {
+        "capacity_median_p50_budget_fraction": capacity_p50,
+        "capacity_limit": capacity_p50_limit,
+        "core_microgate_passed": core_microgate_passed,
+        "paced_median_p99_budget_fraction": paced_p99,
+        "paced_median_over_budget_fraction": paced_over_budget,
+        "paced_render_overruns": paced_render_overruns,
+        "paced_tail_qualification_rule": "zero render-duration overruns in every paced run",
+        "paced_tail_qualification_passed": paced_tail_qualification_passed,
+    }
+
+
+def write_settings(data_root: pathlib.Path, model: str) -> None:
+    config = (
+        data_root
+        / "Gearmulator Preview"
+        / PRODUCT_FOLDER[model]
+        / "config"
+        / f"Gearmulator {model}.xml"
+    )
+    config.parent.mkdir(parents=True)
+    tree = ET.ElementTree(ET.Element("PROPERTIES"))
+    ET.SubElement(tree.getroot(), "VALUE", name="enableMcpServer", val="0")
+    ET.SubElement(tree.getroot(), "VALUE", name="latencyBlocks", val="0")
+    tree.write(config, encoding="utf-8", xml_declaration=True)
+
+
+def run_capture(
+    host: pathlib.Path,
+    plugin: pathlib.Path,
+    firmware: pathlib.Path,
+    work_root: pathlib.Path,
+    model: str,
+    mode: str,
+    repetition: int,
+    rate: int,
+    block: int,
+    seconds: int,
+    warm_start_seconds: int,
+) -> dict[str, object]:
+    case = work_root / f"{model.lower()}-{mode}-{repetition}"
+    data_root = case / "data"
+    home = case / "home"
+    rom_dir = data_root / "Gearmulator Preview" / PRODUCT_FOLDER[model] / "roms"
+    rom_dir.mkdir(parents=True)
+    home.mkdir(parents=True)
+    shutil.copyfile(firmware, rom_dir / f"validated-{model.lower()}.bin")
+    write_settings(data_root, model)
+
+    prefix = case / "capture"
+    command = [
+        str(host),
+        str(plugin),
+        str(prefix),
+        str(rate),
+        str(block),
+        str(seconds),
+        "-1",
+        "fixed",
+        "0" if mode == "capacity" else "-1",
+        "fast" if mode == "capacity" else "paced",
+        str(NOTE_NUMBER[model]),
+        str(block - 1),
+        "notes",
+        "messages",
+        "-1",
+    ]
+    environment = {
+        key: value for key, value in os.environ.items() if not key.startswith("GEARMULATOR_")
+    }
+    environment["HOME"] = str(home)
+    environment["GEARMULATOR_DATA_ROOT"] = str(data_root)
+    log_path = case / "host.log"
+    with log_path.open("w", encoding="utf-8") as log:
+        result = subprocess.run(
+            command,
+            env=environment,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            timeout=max(180, seconds * 4),
+        )
+    if result.returncode:
+        sys.stderr.write(log_path.read_text(encoding="utf-8", errors="replace"))
+        raise RuntimeError(
+            f"{model} {mode} core-capacity capture {repetition} failed with {result.returncode}"
+        )
+    metadata_path = prefix.with_suffix(".json")
+    blocks_path = prefix.with_suffix(".blocks.csv")
+    audio_path = prefix.with_suffix(".wav")
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    expected_metadata = {
+        "format": "VST3",
+        "sample_rate": float(rate),
+        "block_size": block,
+        "seconds": float(seconds),
+        "variable_blocks": False,
+        "reprepare_seconds": -1.0,
+        "offline_after_seconds": 0.0 if mode == "capacity" else -1.0,
+        "pace_offline": mode == "paced",
+        "note_number": NOTE_NUMBER[model],
+        "note_phase": block - 1,
+        "scenario": "notes",
+        "suppress_message_loop": False,
+        "audio_finite_before_quantization": True,
+    }
+    actual_metadata = {key: metadata.get(key) for key in expected_metadata}
+    if actual_metadata != expected_metadata:
+        raise RuntimeError(
+            f"{model} {mode} capture metadata mismatch: "
+            f"expected {expected_metadata}, found {actual_metadata}"
+        )
+    audio_peak = float(metadata.get("audio_peak_before_quantization", 0.0))
+    if not math.isfinite(audio_peak) or audio_peak <= 1e-5:
+        raise RuntimeError(f"{model} {mode} capture produced no finite audible output")
+
+    measurement = analyze_blocks(blocks_path, rate, warm_start_seconds)
+    if measurement["total_samples"] != round(rate * seconds):
+        raise RuntimeError(f"{model} {mode} capture length does not match the workload")
+    measurement["audio_peak_before_quantization"] = audio_peak
+    measurement["capture_sha256"] = {
+        "capture.blocks.csv": sha256(blocks_path),
+        "capture.json": sha256(metadata_path),
+        "capture.wav": sha256(audio_path),
+        "host.log": sha256(log_path),
+    }
+    # The public receipt retains hashes and measurements, never the private ROM
+    # copy or rendered audio. Bound disk use by removing each case immediately.
+    shutil.rmtree(case)
+    return measurement
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", type=pathlib.Path, required=True)
+    parser.add_argument(
+        "--host-architecture", choices=("arm64", "x86_64"), default=platform.machine()
+    )
+    parser.add_argument("--md-plugin", type=pathlib.Path, required=True)
+    parser.add_argument("--mm-plugin", type=pathlib.Path, required=True)
+    parser.add_argument("--md-firmware", type=pathlib.Path, required=True)
+    parser.add_argument("--mm-firmware", type=pathlib.Path, required=True)
+    parser.add_argument("--work-root", type=pathlib.Path, required=True)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    parser.add_argument("--rate", type=int, default=48000)
+    parser.add_argument("--block", type=int, default=128)
+    parser.add_argument("--seconds", type=int, default=20)
+    parser.add_argument("--warm-start-seconds", type=int, default=12)
+    parser.add_argument("--capacity-repeats", type=int, default=3)
+    parser.add_argument("--paced-repeats", type=int, default=3)
+    parser.add_argument("--capacity-p50-limit", type=float, default=0.90)
+    return parser.parse_args(argv)
+
+
+def main() -> None:
+    args = parse_args()
+    if (
+        args.rate < 8000
+        or args.block < 1
+        or args.seconds < 20
+        or args.warm_start_seconds < 0
+        or args.warm_start_seconds >= args.seconds
+        or args.capacity_repeats < 1
+        or args.paced_repeats < 1
+    ):
+        raise RuntimeError("invalid core-capacity timing or repetition count")
+    if args.capacity_p50_limit < 0:
+        raise RuntimeError("core-capacity limit must be nonnegative")
+
+    host = args.host.resolve(strict=True)
+    plugins = {
+        "MD": args.md_plugin.resolve(strict=True),
+        "MM": args.mm_plugin.resolve(strict=True),
+    }
+    firmware = {
+        "MD": args.md_firmware.resolve(strict=True),
+        "MM": args.mm_firmware.resolve(strict=True),
+    }
+    for model in ("MD", "MM"):
+        if sha256(firmware[model]) != FIRMWARE_SHA256[model]:
+            raise RuntimeError(f"{model} firmware hash does not match the pinned release image")
+    work_root = args.work_root.resolve()
+    work_root.mkdir(parents=True, exist_ok=False)
+    # Captures contain private firmware and rendered audio. The build wrapper
+    # has its own trap as a second line of defense, but direct runs clean too.
+    atexit.register(shutil.rmtree, work_root, ignore_errors=True)
+    output = args.output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if output.exists():
+        raise RuntimeError(f"refusing to replace core-capacity receipt: {output}")
+
+    models = {}
+    for model in ("MD", "MM"):
+        capacity = [
+            run_capture(
+                host,
+                plugins[model],
+                firmware[model],
+                work_root,
+                model,
+                "capacity",
+                repetition,
+                args.rate,
+                args.block,
+                args.seconds,
+                args.warm_start_seconds,
+            )
+            for repetition in range(1, args.capacity_repeats + 1)
+        ]
+        paced = [
+            run_capture(
+                host,
+                plugins[model],
+                firmware[model],
+                work_root,
+                model,
+                "paced",
+                repetition,
+                args.rate,
+                args.block,
+                args.seconds,
+                args.warm_start_seconds,
+            )
+            for repetition in range(1, args.paced_repeats + 1)
+        ]
+        models[model] = {
+            "capacity_runs": capacity,
+            "paced_runs": paced,
+            "gate": aggregate(
+                capacity,
+                paced,
+                args.capacity_p50_limit,
+            ),
+        }
+
+    core_microgate_passed = all(
+        model["gate"]["core_microgate_passed"] for model in models.values()
+    )
+    paced_tail_qualification_passed = all(
+        model["gate"]["paced_tail_qualification_passed"] for model in models.values()
+    )
+    receipt = {
+        "schema": RECEIPT_SCHEMA,
+        "scope": SCOPE,
+        "core_microgate_passed": core_microgate_passed,
+        "paced_tail_qualification_passed": paced_tail_qualification_passed,
+        "limitations": [
+            "headless host; no standalone editor or renderer",
+            "zero input channels; physical and plug-in audio input are not exercised",
+            "only the selected architecture executed by the host is measured",
+            "scheduler lateness is reported separately from plug-in render duration",
+        ],
+        "host_architecture": args.host_architecture,
+        "host_os": platform.platform(),
+        "host_name": host.name,
+        "sample_rate": args.rate,
+        "block_size": args.block,
+        "period_ms": args.block * 1000.0 / args.rate,
+        "seconds": args.seconds,
+        "warm_start_seconds": args.warm_start_seconds,
+        "repetitions": {"capacity": args.capacity_repeats, "paced": args.paced_repeats},
+        "workload": {
+            "plugin_format": "VST3",
+            "audio_input_channels": 0,
+            "audio_output_channels": 2,
+            "scenario": "notes",
+            "fixed_block_size": True,
+            "note_phase": args.block - 1,
+            "message_loop": True,
+            "capacity_mode": "unpaced offline render",
+            "paced_mode": "paced render",
+        },
+        "plugin_module_sha256": {
+            plugins[model].name: sha256(bundle_module(plugins[model]))
+            for model in ("MD", "MM")
+        },
+        "host_sha256": sha256(host),
+        "firmware_sha256": FIRMWARE_SHA256,
+        "models": models,
+    }
+    output.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+    if not paced_tail_qualification_passed:
+        print(
+            "Paced tail observation is not qualified: at least one callback exceeded "
+            "its render-duration budget",
+            file=sys.stderr,
+        )
+    if not core_microgate_passed:
+        raise RuntimeError("MD/MM output-only core-capacity microgate failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/macos/test_check_mdmm_core_capacity.py
+++ b/scripts/macos/test_check_mdmm_core_capacity.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import csv
+import pathlib
+import tempfile
+import unittest
+
+import check_mdmm_core_capacity as capacity_check
+
+
+class CoreCapacityCheckTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = pathlib.Path(self.temporary.name)
+
+    def write_blocks(self, durations: list[float], late_ms: float = 0.0) -> pathlib.Path:
+        path = self.root / "capture.blocks.csv"
+        with path.open("w", newline="", encoding="utf-8") as stream:
+            writer = csv.writer(stream)
+            writer.writerow(
+                ["sample", "count", "late_ms", "render_ms", "reported_latency_samples"]
+            )
+            for index, duration in enumerate(durations):
+                writer.writerow([index * 128, 128, late_ms, duration, 0])
+        return path
+
+    def test_explicit_host_architecture_is_recordable_for_single_slice_builds(self) -> None:
+        args = capacity_check.parse_args(
+            [
+                "--host",
+                "host",
+                "--host-architecture",
+                "x86_64",
+                "--md-plugin",
+                "md.vst3",
+                "--mm-plugin",
+                "mm.vst3",
+                "--md-firmware",
+                "md.bin",
+                "--mm-firmware",
+                "mm.bin",
+                "--work-root",
+                "work",
+                "--output",
+                "receipt.json",
+            ]
+        )
+
+        self.assertEqual(args.host_architecture, "x86_64")
+
+    def test_block_analysis_separates_duration_and_scheduler_lateness(self) -> None:
+        result = capacity_check.analyze_blocks(
+            self.write_blocks([2.0, 2.2, 2.4], late_ms=1.0),
+            rate=48000,
+            warm_start_seconds=0,
+        )
+
+        self.assertEqual(result["over_budget"], 0)
+        self.assertEqual(result["completion_after_deadline"], 3)
+        self.assertAlmostEqual(result["p50_budget_fraction"], 0.825)
+
+    def test_analysis_rejects_callback_timeline_gaps(self) -> None:
+        path = self.write_blocks([1.0, 1.0])
+        rows = path.read_text(encoding="utf-8").replace("128,128", "129,128")
+        path.write_text(rows, encoding="utf-8")
+
+        with self.assertRaisesRegex(RuntimeError, "timeline has a gap"):
+            capacity_check.analyze_blocks(path, rate=48000, warm_start_seconds=0)
+
+    def test_repeated_medians_reject_the_ordinary_md_capacity_regression(self) -> None:
+        def run(p50: float, p99: float, over: float = 0.0) -> dict[str, float]:
+            return {
+                "p50_budget_fraction": p50,
+                "p99_budget_fraction": p99,
+                "over_budget": int(over > 0),
+                "over_budget_fraction": over,
+            }
+
+        result = capacity_check.aggregate(
+            [run(1.01, 1.03), run(1.02, 1.04), run(1.01, 1.05)],
+            [run(1.01, 1.04, 0.02), run(1.02, 1.05, 0.02), run(1.01, 1.03, 0.01)],
+            capacity_p50_limit=0.90,
+        )
+
+        self.assertFalse(result["core_microgate_passed"])
+        self.assertFalse(result["paced_tail_qualification_passed"])
+
+    def test_scheduler_lateness_is_not_a_duration_gate(self) -> None:
+        healthy = {
+            "p50_budget_fraction": 0.80,
+            "p99_budget_fraction": 0.90,
+            "over_budget": 0,
+            "over_budget_fraction": 0.0,
+            "completion_after_deadline_fraction": 1.0,
+        }
+        result = capacity_check.aggregate(
+            [healthy, healthy, healthy],
+            [healthy, healthy, healthy],
+            capacity_p50_limit=0.90,
+        )
+
+        self.assertTrue(result["core_microgate_passed"])
+        self.assertTrue(result["paced_tail_qualification_passed"])
+
+    def test_any_render_overrun_keeps_the_paced_tail_unqualified(self) -> None:
+        clean = {
+            "p50_budget_fraction": 0.80,
+            "p99_budget_fraction": 0.90,
+            "over_budget": 0,
+            "over_budget_fraction": 0.0,
+        }
+        overrun = {**clean, "over_budget": 1, "over_budget_fraction": 1 / 3000}
+
+        result = capacity_check.aggregate(
+            [clean, clean, clean], [clean, overrun, clean], capacity_p50_limit=0.90
+        )
+
+        self.assertTrue(result["core_microgate_passed"])
+        self.assertFalse(result["paced_tail_qualification_passed"])
+        self.assertEqual(result["paced_render_overruns"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/macos/test_write_mdmm_receipt.py
+++ b/scripts/macos/test_write_mdmm_receipt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import pathlib
 import subprocess
 import tempfile
@@ -67,6 +68,520 @@ class ReceiptPathSafetyTest(unittest.TestCase):
             args.package_file,
             [pathlib.Path("setup.command"), pathlib.Path("INSTALL.txt")],
         )
+
+    def test_release_selection_defaults_to_universal_without_pgo(self) -> None:
+        result = receipt.release_selection(
+            "arm64;x86_64", "none", None, None
+        )
+
+        self.assertEqual(result["architectures"], ("arm64", "x86_64"))
+        self.assertEqual(result["cmake_architectures"], "arm64;x86_64")
+        self.assertEqual(
+            result["package_name"], "Gearmulator-Elektron-macOS-Universal"
+        )
+
+    def test_release_selection_accepts_single_architecture_pgo(self) -> None:
+        profile = self.root / "arm64.profdata"
+        provenance = self.root / "arm64.provenance.json"
+        profile.write_bytes(b"profile")
+        provenance.write_text("{}", encoding="utf-8")
+
+        result = receipt.release_selection(
+            "arm64", "use", profile, provenance
+        )
+
+        self.assertEqual(result["architectures"], ("arm64",))
+        self.assertEqual(
+            result["package_name"], "Gearmulator-Elektron-macOS-arm64-PGO"
+        )
+
+    def test_release_selection_rejects_universal_or_incomplete_pgo(self) -> None:
+        profile = self.root / "arm64.profdata"
+        provenance = self.root / "arm64.provenance.json"
+        profile.write_bytes(b"profile")
+        provenance.write_text("{}", encoding="utf-8")
+
+        cases = (
+            ("arm64;x86_64", "use", profile, provenance, "exactly one"),
+            ("arm64", "use", profile, None, "both profile and provenance"),
+            ("arm64", "generate", None, None, "none or use"),
+            ("arm64", "none", profile, None, "while PGO mode is none"),
+            ("native", "none", None, None, "must be arm64"),
+        )
+        for architectures, mode, profile_path, provenance_path, message in cases:
+            with self.subTest(architectures=architectures, mode=mode):
+                with self.assertRaisesRegex(RuntimeError, message):
+                    receipt.release_selection(
+                        architectures,
+                        mode,
+                        profile_path,
+                        provenance_path,
+                    )
+
+    def write_cache(
+        self,
+        *,
+        architectures: str = "arm64;x86_64",
+        thinlto: str = "ON",
+        optimize_dsp: str = "ON",
+        pgo_mode: str = "none",
+        profile: pathlib.Path | None = None,
+    ) -> pathlib.Path:
+        cache = self.root / f"cache-{len(list(self.root.glob('cache-*')))}.txt"
+        compiler_metadata = self.root / "CMakeFiles" / "fixture" / "CMakeCXXCompiler.cmake"
+        compiler_metadata.parent.mkdir(parents=True, exist_ok=True)
+        compiler_metadata.write_text(
+            'set(CMAKE_CXX_COMPILER_ID "AppleClang")\n'
+            'set(CMAKE_CXX_COMPILER_VERSION "16.0")\n',
+            encoding="utf-8",
+        )
+        cache.write_text(
+            "CMAKE_BUILD_TYPE:STRING=Release\n"
+            f"CMAKE_OSX_DEPLOYMENT_TARGET:STRING={receipt.MACOS_DEPLOYMENT_TARGET}\n"
+            f"CMAKE_OSX_ARCHITECTURES:STRING={architectures}\n"
+            f"GEARMULATOR_JUCE_PRODUCTS_ROOT:PATH={self.root / 'products'}\n"
+            f"GEARMULATOR_MDMM_APPLE_THINLTO:BOOL={thinlto}\n"
+            f"GEARMULATOR_MDMM_APPLE_OPTIMIZE_DSP:BOOL={optimize_dsp}\n"
+            f"GEARMULATOR_MDMM_APPLE_PGO_MODE:STRING={pgo_mode}\n"
+            f"GEARMULATOR_MDMM_APPLE_PGO_PROFILE:FILEPATH={profile or ''}\n"
+            f"GEARMULATOR_MDMM_APPLE_OPTIMIZATION_APPLIED_TARGETS:INTERNAL="
+            f"mdLib;68kEmu;dsp56kEmu;dsp56kBase\n"
+            f"GEARMULATOR_MDMM_APPLE_OPTIMIZATION_APPLIED_PGO_MODE:INTERNAL={pgo_mode}\n"
+            f"GEARMULATOR_MDMM_APPLE_OPTIMIZATION_APPLIED_PROFILE_SHA256:INTERNAL="
+            f"{receipt.sha256(profile) if profile else ''}\n",
+            encoding="utf-8",
+        )
+        return cache
+
+    def test_universal_release_optimization_is_cache_derived(self) -> None:
+        result = receipt.release_optimization(
+            self.write_cache(), ("arm64", "x86_64")
+        )
+
+        self.assertEqual(result["deployment_target"], receipt.MACOS_DEPLOYMENT_TARGET)
+        self.assertEqual(set(result["slices"]), {"arm64", "x86_64"})
+        for settings in result["slices"].values():
+            self.assertEqual(
+                settings,
+                {
+                    "thinlto": True,
+                    "dsp_optimization": True,
+                    "pgo_mode": "none",
+                    "profile_sha256": None,
+                },
+            )
+
+    def test_release_optimization_rejects_silent_fallbacks(self) -> None:
+        cases = (
+            ({"thinlto": "OFF"}, "require ThinLTO"),
+            ({"optimize_dsp": "OFF"}, "require ThinLTO"),
+            ({"pgo_mode": "generate"}, "PGO mode none or use"),
+        )
+        for options, message in cases:
+            with self.subTest(options=options), self.assertRaisesRegex(RuntimeError, message):
+                receipt.release_optimization(self.write_cache(**options))
+
+    def test_release_optimization_requires_an_applied_target_marker(self) -> None:
+        cache = self.write_cache()
+        cache.write_text(
+            cache.read_text(encoding="utf-8").replace(
+                "GEARMULATOR_MDMM_APPLE_OPTIMIZATION_APPLIED_TARGETS:INTERNAL="
+                "mdLib;68kEmu;dsp56kEmu;dsp56kBase\n",
+                "",
+            ),
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "did not apply"):
+            receipt.release_optimization(cache)
+
+    def test_release_optimization_rejects_shared_product_output(self) -> None:
+        cache = self.write_cache()
+        cache.write_text(
+            cache.read_text(encoding="utf-8").replace(
+                f"GEARMULATOR_JUCE_PRODUCTS_ROOT:PATH={self.root / 'products'}",
+                f"GEARMULATOR_JUCE_PRODUCTS_ROOT:PATH={self.source / 'bin/plugins'}",
+            ),
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "owned by the build directory"):
+            receipt.release_optimization(cache)
+
+    def test_release_optimization_rejects_architecture_mismatch(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "architecture mismatch"):
+            receipt.release_optimization(
+                self.write_cache(architectures="arm64"), ("arm64", "x86_64")
+            )
+
+    def test_release_optimization_rejects_wrong_deployment_target(self) -> None:
+        cache = self.write_cache()
+        cache.write_text(
+            cache.read_text(encoding="utf-8").replace(
+                f"CMAKE_OSX_DEPLOYMENT_TARGET:STRING={receipt.MACOS_DEPLOYMENT_TARGET}",
+                "CMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.12",
+            ),
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "deployment target"):
+            receipt.release_optimization(cache)
+
+    def test_pgo_receipt_hashes_a_single_architecture_profile(self) -> None:
+        profile = self.root / "current.profdata"
+        profile.write_bytes(b"profile-data")
+        result = receipt.release_optimization(
+            self.write_cache(
+                architectures="arm64", pgo_mode="use", profile=profile
+            ),
+            ("arm64",),
+        )
+
+        self.assertEqual(
+            result["slices"]["arm64"]["profile_sha256"], receipt.sha256(profile)
+        )
+
+    def test_one_profile_cannot_claim_a_universal_pgo_build(self) -> None:
+        profile = self.root / "current.profdata"
+        profile.write_bytes(b"profile-data")
+        with self.assertRaisesRegex(RuntimeError, "cannot qualify a universal build"):
+            receipt.release_optimization(
+                self.write_cache(pgo_mode="use", profile=profile)
+            )
+
+    def test_pgo_provenance_binds_profile_source_compiler_and_training(self) -> None:
+        profile = self.root / "current.profdata"
+        profile.write_bytes(b"profile-data")
+        optimization = receipt.release_optimization(
+            self.write_cache(
+                architectures="arm64", pgo_mode="use", profile=profile
+            )
+        )
+        commits = {
+            "source_commit": "parent",
+            "dsp56300_commit": "dsp",
+            "mc68k_commit": "mcu",
+            "juce_commit": "juce",
+        }
+        provenance = self.root / "current.provenance.json"
+        provenance.write_text(
+            json.dumps(
+                {
+                    "schema": "gearmulator.mdmm.apple-pgo-profile.v1",
+                    "profile": {"sha256": receipt.sha256(profile)},
+                    "build": {
+                        "architecture": "arm64",
+                        "configuration": "Release",
+                        "deployment_target": receipt.MACOS_DEPLOYMENT_TARGET,
+                        "compiler_id": "AppleClang",
+                        "compiler_version": "16.0",
+                        "thinlto": True,
+                        "dsp_optimization": True,
+                        "pgo_mode": "generate",
+                        "optimized_targets": [
+                            "mdLib",
+                            "68kEmu",
+                            "dsp56kEmu",
+                            "dsp56kBase",
+                        ],
+                    },
+                    "source": {
+                        "parent_revision": "parent",
+                        "dsp_revision": "dsp",
+                        "mc68k_revision": "mcu",
+                        "juce_revision": "juce",
+                    },
+                    "training": {
+                        "host_sample_rate_hz": 48000,
+                        "block_frames": 128,
+                        "callbacks_per_model": 12000,
+                        "measured_callbacks_per_model": 7500,
+                        "models": [
+                            {
+                                "model": model,
+                                "firmware_sha256": receipt.FIRMWARE_SHA256[model],
+                                "raw_profile_sha256": "c" * 64 if model == "MD" else "d" * 64,
+                            }
+                            for model in ("MD", "MM")
+                        ],
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = receipt.validate_pgo_provenance(
+            provenance, optimization, commits
+        )
+
+        self.assertEqual(result["profile_sha256"], receipt.sha256(profile))
+        self.assertEqual(result["source"]["juce_revision"], "juce")
+        self.assertEqual(result["deployment_target"], receipt.MACOS_DEPLOYMENT_TARGET)
+
+        wrong_target = json.loads(provenance.read_text(encoding="utf-8"))
+        wrong_target["build"]["deployment_target"] = "10.12"
+        provenance.write_text(json.dumps(wrong_target), encoding="utf-8")
+        with self.assertRaisesRegex(RuntimeError, "build configuration"):
+            receipt.validate_pgo_provenance(provenance, optimization, commits)
+
+    def test_pgo_provenance_rejects_a_different_parent_source(self) -> None:
+        profile = self.root / "current.profdata"
+        profile.write_bytes(b"profile-data")
+        optimization = receipt.release_optimization(
+            self.write_cache(
+                architectures="arm64", pgo_mode="use", profile=profile
+            )
+        )
+        provenance = self.root / "current.provenance.json"
+        provenance.write_text(
+            json.dumps(
+                {
+                    "schema": "gearmulator.mdmm.apple-pgo-profile.v1",
+                    "profile": {"sha256": receipt.sha256(profile)},
+                    "build": {},
+                    "source": {
+                        "parent_revision": "old-parent",
+                        "dsp_revision": "dsp",
+                        "mc68k_revision": "mcu",
+                        "juce_revision": "juce",
+                    },
+                    "training": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "profile source mismatch"):
+            receipt.validate_pgo_provenance(
+                provenance,
+                optimization,
+                {
+                    "source_commit": "parent",
+                    "dsp56300_commit": "dsp",
+                    "mc68k_commit": "mcu",
+                    "juce_commit": "juce",
+                },
+            )
+
+    def core_capacity_check(self) -> dict[str, object]:
+        period = 128 * 1000 / 48000
+
+        def run(p50: float = 0.8, p99: float = 0.9) -> dict[str, object]:
+            return {
+                "total_callbacks": 7500,
+                "total_samples": 960000,
+                "warm_callbacks": 3000,
+                "p50_ms": p50 * period,
+                "p99_ms": p99 * period,
+                "max_ms": 0.95 * period,
+                "p50_budget_fraction": p50,
+                "p99_budget_fraction": p99,
+                "max_budget_fraction": 0.95,
+                "over_budget": 0,
+                "over_budget_fraction": 0.0,
+                "scheduler_late_p99_ms": 0.01,
+                "completion_after_deadline": 0,
+                "completion_after_deadline_fraction": 0.0,
+                "audio_peak_before_quantization": 0.1,
+                "capture_sha256": {
+                    "capture.blocks.csv": "1" * 64,
+                    "capture.json": "2" * 64,
+                    "capture.wav": "3" * 64,
+                    "host.log": "4" * 64,
+                },
+            }
+
+        gate = {
+            "capacity_median_p50_budget_fraction": 0.8,
+            "capacity_limit": 0.90,
+            "core_microgate_passed": True,
+            "paced_median_p99_budget_fraction": 0.9,
+            "paced_median_over_budget_fraction": 0.0,
+            "paced_render_overruns": 0,
+            "paced_tail_qualification_rule": (
+                "zero render-duration overruns in every paced run"
+            ),
+            "paced_tail_qualification_passed": True,
+        }
+        return {
+            "schema": receipt.CORE_CAPACITY_SCHEMA,
+            "scope": receipt.CORE_CAPACITY_SCOPE,
+            "core_microgate_passed": True,
+            "paced_tail_qualification_passed": True,
+            "host_architecture": "arm64",
+            "host_os": "Mac OSX test",
+            "host_name": "latency_host",
+            "host_sha256": "0" * 64,
+            "sample_rate": 48000,
+            "block_size": 128,
+            "period_ms": period,
+            "seconds": 20,
+            "warm_start_seconds": 12,
+            "repetitions": {"capacity": 3, "paced": 3},
+            "workload": receipt.CORE_CAPACITY_WORKLOAD,
+            "firmware_sha256": receipt.FIRMWARE_SHA256,
+            "plugin_module_sha256": {
+                "Gearmulator MD.vst3": "a" * 64,
+                "Gearmulator MM.vst3": "b" * 64,
+            },
+            "models": {
+                model: {
+                    "capacity_runs": [run(), run(), run()],
+                    "paced_runs": [run(), run(), run()],
+                    "gate": dict(gate),
+                }
+                for model in ("MD", "MM")
+            },
+        }
+
+    def artifact_hashes(self) -> dict[str, str]:
+        return {
+            "Gearmulator MD.vst3": "a" * 64,
+            "Gearmulator MM.vst3": "b" * 64,
+        }
+
+    def test_core_check_is_bound_to_native_slice_and_packaged_plugins(self) -> None:
+        result = receipt.validate_core_capacity_check(
+            self.core_capacity_check(),
+            self.artifact_hashes(),
+            {"slices": {"arm64": {}, "x86_64": {}}},
+        )
+
+        self.assertEqual(result["host_architecture"], "arm64")
+        self.assertTrue(result["core_microgate_passed"])
+        self.assertTrue(result["paced_tail_qualification_passed"])
+
+    def test_core_check_rejects_a_weaker_microgate(self) -> None:
+        check = self.core_capacity_check()
+        check["models"]["MD"]["gate"]["capacity_limit"] = 0.95
+
+        with self.assertRaisesRegex(RuntimeError, "weaker than release policy"):
+            receipt.validate_core_capacity_check(
+                check,
+                self.artifact_hashes(),
+                {"slices": {"arm64": {}, "x86_64": {}}},
+            )
+
+    def test_core_check_recomputes_the_microgate_from_measurements(self) -> None:
+        check = self.core_capacity_check()
+        period = check["period_ms"]
+        for run in check["models"]["MD"]["capacity_runs"]:
+            run["p50_budget_fraction"] = 0.91
+            run["p50_ms"] = 0.91 * period
+            run["p99_budget_fraction"] = 0.92
+            run["p99_ms"] = 0.92 * period
+
+        with self.assertRaisesRegex(RuntimeError, "weaker than release policy"):
+            receipt.validate_core_capacity_check(
+                check,
+                self.artifact_hashes(),
+                {"slices": {"arm64": {}, "x86_64": {}}},
+            )
+
+    def test_core_check_rejects_an_unmeasured_architecture(self) -> None:
+        check = self.core_capacity_check()
+        check["host_architecture"] = "x86_64"
+
+        with self.assertRaisesRegex(RuntimeError, "host architecture is not packaged"):
+            receipt.validate_core_capacity_check(
+                check,
+                self.artifact_hashes(),
+                {"slices": {"arm64": {}}},
+            )
+
+    def test_core_check_validates_fixed_workload_and_raw_hashes(self) -> None:
+        mutations = (
+            (lambda check: check.__setitem__("seconds", 21), "fixed release workload"),
+            (
+                lambda check: check["models"]["MD"]["capacity_runs"][0].__setitem__(
+                    "warm_callbacks", 2999
+                ),
+                "wrong capture length",
+            ),
+            (
+                lambda check: check.__setitem__(
+                    "firmware_sha256", {**receipt.FIRMWARE_SHA256, "MD": "f" * 64}
+                ),
+                "pinned firmware",
+            ),
+            (lambda check: check.__setitem__("scope", "generic timing"), "wrong scope"),
+            (lambda check: check.__setitem__("host_name", "other-host"), "host identity"),
+            (
+                lambda check: check["models"]["MM"]["paced_runs"][0][
+                    "capture_sha256"
+                ].__setitem__("capture.wav", "not-a-hash"),
+                "SHA-256",
+            ),
+        )
+        for mutate, message in mutations:
+            check = self.core_capacity_check()
+            mutate(check)
+            with self.subTest(message=message), self.assertRaisesRegex(RuntimeError, message):
+                receipt.validate_core_capacity_check(
+                    check,
+                    self.artifact_hashes(),
+                    {"slices": {"arm64": {}, "x86_64": {}}},
+                )
+
+    def test_render_overrun_is_reported_as_an_unqualified_tail(self) -> None:
+        check = self.core_capacity_check()
+        run = check["models"]["MD"]["paced_runs"][0]
+        run["over_budget"] = 1
+        run["over_budget_fraction"] = 1 / 3000
+        run["max_ms"] = 1.01 * check["period_ms"]
+        run["max_budget_fraction"] = 1.01
+        gate = check["models"]["MD"]["gate"]
+        gate["paced_render_overruns"] = 1
+        gate["paced_tail_qualification_passed"] = False
+        check["paced_tail_qualification_passed"] = False
+
+        result = receipt.validate_core_capacity_check(
+            check,
+            self.artifact_hashes(),
+            {"slices": {"arm64": {}, "x86_64": {}}},
+        )
+
+        self.assertTrue(result["core_microgate_passed"])
+        self.assertFalse(result["paced_tail_qualification_passed"])
+
+    def test_core_check_rejects_impossible_zero_overrun_tail(self) -> None:
+        check = self.core_capacity_check()
+        run = check["models"]["MD"]["paced_runs"][0]
+        run["max_ms"] = 2 * check["period_ms"]
+        run["max_budget_fraction"] = 2.0
+
+        with self.assertRaisesRegex(RuntimeError, "maximum and render-overrun"):
+            receipt.validate_core_capacity_check(
+                check,
+                self.artifact_hashes(),
+                {"slices": {"arm64": {}, "x86_64": {}}},
+            )
+
+    def test_universal_acceptance_is_partial_and_reports_each_slice(self) -> None:
+        result = receipt.release_acceptance(
+            {"slices": {"arm64": {}, "x86_64": {}}},
+            {
+                "host_architecture": "arm64",
+                "core_microgate_passed": True,
+                "paced_tail_qualification_passed": False,
+            },
+        )
+
+        self.assertEqual(result["status"], "partial")
+        self.assertEqual(
+            result["per_slice"],
+            {
+                "arm64": {
+                    "output_only_core_microgate": "passed",
+                    "output_only_paced_tail": "not_qualified",
+                },
+                "x86_64": {
+                    "output_only_core_microgate": "not_run",
+                    "output_only_paced_tail": "not_run",
+                },
+            },
+        )
+        self.assertFalse(result["output_only_core_microgate_all_slices_measured"])
 
     def test_exact_untracked_package_and_archive_are_allowed(self) -> None:
         package = self.source / "artifacts" / "package"

--- a/scripts/macos/write_mdmm_receipt.py
+++ b/scripts/macos/write_mdmm_receipt.py
@@ -6,15 +6,278 @@ import argparse
 import datetime
 import hashlib
 import json
+import math
 import os
 import pathlib
+import re
 import shutil
+import statistics
 import subprocess
 from typing import Optional
 
 
 RELEASE_ROOT_MARKER = ".gearmulator-mdmm-release-root"
 RELEASE_ROOT_MARKER_VERSION = "gearmulator-mdmm-release-root-v1"
+FIRMWARE_SHA256 = {
+    "MD": "68542e30917b9918ccaee2b2237df62c8a00479938680b85aca93ce4fbca44c8",
+    "MM": "369849175602e20a9dd2b6e0ad8ac404b76f82718b14afbf1cbc01b7acabec7e",
+}
+SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+CORE_CAPACITY_SCHEMA = "gearmulator-mdmm-core-capacity-v1"
+CORE_CAPACITY_SCOPE = "executed VST3 output-only core callback duration"
+CORE_CAPACITY_LIMIT = 0.90
+MACOS_DEPLOYMENT_TARGET = "10.13"
+SUPPORTED_MACOS_ARCHITECTURES = ("arm64", "x86_64")
+CORE_CAPACITY_WORKLOAD = {
+    "plugin_format": "VST3",
+    "audio_input_channels": 0,
+    "audio_output_channels": 2,
+    "scenario": "notes",
+    "fixed_block_size": True,
+    "note_phase": 127,
+    "message_loop": True,
+    "capacity_mode": "unpaced offline render",
+    "paced_mode": "paced render",
+}
+
+
+def release_selection(
+    architectures_value: str,
+    pgo_mode: str,
+    pgo_profile: pathlib.Path | None,
+    pgo_provenance: pathlib.Path | None,
+    require_pgo_files: bool = True,
+) -> dict[str, object]:
+    requested = tuple(architectures_value.split(";"))
+    if (
+        not requested
+        or any(not architecture for architecture in requested)
+        or len(set(requested)) != len(requested)
+        or any(
+            architecture not in SUPPORTED_MACOS_ARCHITECTURES
+            for architecture in requested
+        )
+    ):
+        raise RuntimeError(
+            "GEARMULATOR_MDMM_MACOS_ARCHITECTURES must be arm64, x86_64, "
+            "or arm64;x86_64"
+        )
+    architectures = tuple(
+        architecture
+        for architecture in SUPPORTED_MACOS_ARCHITECTURES
+        if architecture in requested
+    )
+    if pgo_mode not in {"none", "use"}:
+        raise RuntimeError(
+            "GEARMULATOR_MDMM_APPLE_PGO_MODE must be none or use for product builds"
+        )
+    if pgo_mode == "use":
+        if len(architectures) != 1:
+            raise RuntimeError(
+                "PGO product builds require exactly one macOS architecture"
+            )
+        if pgo_profile is None or pgo_provenance is None:
+            raise RuntimeError(
+                "PGO product builds require both profile and provenance paths"
+            )
+        if require_pgo_files:
+            if not pgo_profile.is_file():
+                raise RuntimeError(f"PGO profile does not exist: {pgo_profile}")
+            if not pgo_provenance.is_file():
+                raise RuntimeError(f"PGO provenance does not exist: {pgo_provenance}")
+    elif pgo_profile is not None or pgo_provenance is not None:
+        raise RuntimeError("PGO inputs were supplied while PGO mode is none")
+
+    architecture_label = "Universal" if len(architectures) == 2 else architectures[0]
+    pgo_suffix = "-PGO" if pgo_mode == "use" else ""
+    return {
+        "architectures": architectures,
+        "cmake_architectures": ";".join(architectures),
+        "pgo_mode": pgo_mode,
+        "package_name": f"Gearmulator-Elektron-macOS-{architecture_label}{pgo_suffix}",
+    }
+
+
+def _cmake_bool(value: str, name: str) -> bool:
+    normalized = value.upper()
+    if normalized in {"1", "ON", "TRUE", "YES", "Y"}:
+        return True
+    if normalized in {"0", "OFF", "FALSE", "NO", "N", "", "NOTFOUND"}:
+        return False
+    raise RuntimeError(f"invalid CMake boolean for {name}: {value}")
+
+
+def read_cmake_cache(path: pathlib.Path) -> dict[str, str]:
+    path = path.resolve()
+    if not path.is_file():
+        raise RuntimeError(f"CMake cache does not exist: {path}")
+    values: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8", errors="surrogateescape").splitlines():
+        if not line or line.startswith(("#", "//")) or "=" not in line:
+            continue
+        key_and_type, value = line.split("=", 1)
+        if ":" not in key_and_type:
+            continue
+        key, _ = key_and_type.split(":", 1)
+        values[key] = value
+    return values
+
+
+def read_cmake_compiler_identity(cache_path: pathlib.Path) -> dict[str, str]:
+    metadata_files = list(
+        cache_path.resolve().parent.glob("CMakeFiles/*/CMakeCXXCompiler.cmake")
+    )
+    if len(metadata_files) != 1:
+        raise RuntimeError(
+            "expected one CMake C++ compiler identity file next to the release cache; "
+            f"found {len(metadata_files)}"
+        )
+    text = metadata_files[0].read_text(encoding="utf-8", errors="replace")
+    values = {}
+    for name in ("ID", "VERSION"):
+        match = re.search(
+            rf'^set\(CMAKE_CXX_COMPILER_{name} "([^"]+)"\)$', text, re.MULTILINE
+        )
+        if match is None:
+            raise RuntimeError(f"CMake compiler metadata has no C++ compiler {name.lower()}")
+        values[name.lower()] = match.group(1)
+    return values
+
+
+def release_optimization(
+    cache_path: pathlib.Path,
+    expected_architectures: tuple[str, ...] = (),
+    expected_products_root: pathlib.Path | None = None,
+) -> dict[str, object]:
+    cache_path = cache_path.resolve()
+    cache = read_cmake_cache(cache_path)
+    compiler = read_cmake_compiler_identity(cache_path)
+    if compiler["id"] not in {"AppleClang", "Clang"}:
+        raise RuntimeError(
+            f"MD/MM Apple release optimization requires Clang; found {compiler['id']}"
+        )
+
+    configuration = cache.get("CMAKE_BUILD_TYPE", "")
+    if configuration != "Release":
+        raise RuntimeError(
+            f"MD/MM release artifacts require CMAKE_BUILD_TYPE=Release; found {configuration!r}"
+        )
+
+    deployment_target = cache.get("CMAKE_OSX_DEPLOYMENT_TARGET", "")
+    if deployment_target != MACOS_DEPLOYMENT_TARGET:
+        raise RuntimeError(
+            "MD/MM release artifacts require macOS deployment target "
+            f"{MACOS_DEPLOYMENT_TARGET}; found {deployment_target!r}"
+        )
+
+    configured_products = cache.get("GEARMULATOR_JUCE_PRODUCTS_ROOT", "")
+    if not configured_products:
+        raise RuntimeError("release build did not set a build-local JUCE products root")
+    products_root = pathlib.Path(configured_products).resolve()
+    required_products_root = (
+        expected_products_root.resolve()
+        if expected_products_root is not None
+        else cache_path.parent / "products"
+    )
+    if products_root != required_products_root:
+        raise RuntimeError(
+            "release JUCE products root is not owned by the build directory: "
+            f"expected {required_products_root}, found {products_root}"
+        )
+
+    architectures = tuple(
+        architecture
+        for architecture in cache.get("CMAKE_OSX_ARCHITECTURES", "").split(";")
+        if architecture
+    )
+    if not architectures:
+        raise RuntimeError("CMAKE_OSX_ARCHITECTURES must explicitly name each release architecture")
+    if len(set(architectures)) != len(architectures):
+        raise RuntimeError(f"duplicate CMAKE_OSX_ARCHITECTURES entries: {architectures}")
+    if expected_architectures and set(architectures) != set(expected_architectures):
+        raise RuntimeError(
+            "release architecture mismatch: "
+            f"expected {sorted(expected_architectures)}, found {sorted(architectures)}"
+        )
+
+    thinlto = _cmake_bool(
+        cache.get("GEARMULATOR_MDMM_APPLE_THINLTO", "OFF"),
+        "GEARMULATOR_MDMM_APPLE_THINLTO",
+    )
+    optimize_dsp = _cmake_bool(
+        cache.get("GEARMULATOR_MDMM_APPLE_OPTIMIZE_DSP", "OFF"),
+        "GEARMULATOR_MDMM_APPLE_OPTIMIZE_DSP",
+    )
+    if not thinlto or not optimize_dsp:
+        raise RuntimeError(
+            "MD/MM macOS release artifacts require ThinLTO for the MCU and DSP cores "
+            "(GEARMULATOR_MDMM_APPLE_THINLTO=ON and "
+            "GEARMULATOR_MDMM_APPLE_OPTIMIZE_DSP=ON)"
+        )
+
+    required_targets = {"mdLib", "68kEmu", "dsp56kEmu", "dsp56kBase"}
+    applied_targets = {
+        target
+        for target in cache.get(
+            "GEARMULATOR_MDMM_APPLE_OPTIMIZATION_APPLIED_TARGETS", ""
+        ).split(";")
+        if target
+    }
+    if applied_targets != required_targets:
+        raise RuntimeError(
+            "generated build did not apply MD/MM Apple optimization to every MCU/DSP "
+            f"target: expected {sorted(required_targets)}, found {sorted(applied_targets)}"
+        )
+
+    pgo_mode = cache.get("GEARMULATOR_MDMM_APPLE_PGO_MODE", "none")
+    if pgo_mode not in {"none", "use"}:
+        raise RuntimeError(
+            f"release artifacts require PGO mode none or use; found {pgo_mode!r}"
+        )
+    applied_pgo_mode = cache.get(
+        "GEARMULATOR_MDMM_APPLE_OPTIMIZATION_APPLIED_PGO_MODE", ""
+    )
+    if applied_pgo_mode != pgo_mode:
+        raise RuntimeError(
+            f"configured PGO mode {pgo_mode!r} was not applied; found {applied_pgo_mode!r}"
+        )
+    profile_sha256 = None
+    if pgo_mode == "use":
+        if len(architectures) != 1:
+            raise RuntimeError(
+                "one PGO profile cannot qualify a universal build; build and record each "
+                "architecture separately"
+            )
+        profile = pathlib.Path(cache.get("GEARMULATOR_MDMM_APPLE_PGO_PROFILE", ""))
+        if not profile.is_file():
+            raise RuntimeError(f"configured PGO profile does not exist: {profile}")
+        profile_sha256 = sha256(profile)
+        applied_profile_sha256 = cache.get(
+            "GEARMULATOR_MDMM_APPLE_OPTIMIZATION_APPLIED_PROFILE_SHA256", ""
+        )
+        if applied_profile_sha256 != profile_sha256:
+            raise RuntimeError(
+                "generated build did not apply the configured PGO profile SHA-256"
+            )
+    elif cache.get(
+        "GEARMULATOR_MDMM_APPLE_OPTIMIZATION_APPLIED_PROFILE_SHA256", ""
+    ):
+        raise RuntimeError("non-PGO release build retained an applied profile marker")
+
+    slices = {}
+    for architecture in sorted(architectures):
+        slices[architecture] = {
+            "thinlto": True,
+            "dsp_optimization": True,
+            "pgo_mode": pgo_mode,
+            "profile_sha256": profile_sha256,
+        }
+    return {
+        "compiler": compiler,
+        "deployment_target": deployment_target,
+        "products_build_local": True,
+        "slices": slices,
+    }
 
 
 def binary_flag(value: str) -> bool:
@@ -222,6 +485,7 @@ def source_tuple(source: pathlib.Path) -> dict[str, str]:
         "source_commit": git(source, "rev-parse", "HEAD"),
         "dsp56300_commit": submodule_commit(source, "source/dsp56300"),
         "mc68k_commit": submodule_commit(source, "source/mc68k"),
+        "juce_commit": submodule_commit(source, "source/JUCE"),
     }
 
 
@@ -240,6 +504,388 @@ def bundle_module(bundle: pathlib.Path) -> pathlib.Path:
     return candidates[0]
 
 
+def _require_sha256(value: object, label: str) -> None:
+    if not isinstance(value, str) or SHA256_PATTERN.fullmatch(value) is None:
+        raise RuntimeError(f"{label} is not a SHA-256 digest")
+
+
+def _finite_number(value: object, label: str) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as error:
+        raise RuntimeError(f"{label} is not numeric") from error
+    if not math.isfinite(number):
+        raise RuntimeError(f"{label} is non-finite")
+    return number
+
+
+def validate_core_capacity_check(
+    check: dict[str, object],
+    artifact_hashes: dict[str, str],
+    optimization: dict[str, object],
+) -> dict[str, object]:
+    if check.get("schema") != CORE_CAPACITY_SCHEMA:
+        raise RuntimeError("unknown core-capacity check schema")
+    if check.get("scope") != CORE_CAPACITY_SCOPE:
+        raise RuntimeError("core-capacity check has the wrong scope")
+    if check.get("core_microgate_passed") is not True:
+        raise RuntimeError("output-only core-capacity microgate did not pass")
+    if (
+        check.get("sample_rate") != 48000
+        or check.get("block_size") != 128
+        or check.get("seconds") != 20
+        or check.get("warm_start_seconds") != 12
+        or check.get("repetitions") != {"capacity": 3, "paced": 3}
+        or check.get("workload") != CORE_CAPACITY_WORKLOAD
+    ):
+        raise RuntimeError("core-capacity check does not match the fixed release workload")
+    period_ms = _finite_number(check.get("period_ms"), "core-capacity period")
+    if not math.isclose(period_ms, 128 * 1000.0 / 48000, rel_tol=0, abs_tol=1e-12):
+        raise RuntimeError("core-capacity check has the wrong callback period")
+
+    host_architecture = check.get("host_architecture")
+    slices = optimization.get("slices")
+    if not isinstance(slices, dict) or host_architecture not in slices:
+        raise RuntimeError(
+            f"core-capacity host architecture is not packaged: {host_architecture!r}"
+        )
+    if check.get("host_name") != "latency_host" or not check.get("host_os"):
+        raise RuntimeError("core-capacity check has an invalid host identity")
+    _require_sha256(check.get("host_sha256"), "core-capacity host")
+    if check.get("firmware_sha256") != FIRMWARE_SHA256:
+        raise RuntimeError("core-capacity check did not use the pinned firmware images")
+
+    qualified_hashes = check.get("plugin_module_sha256")
+    if not isinstance(qualified_hashes, dict):
+        raise RuntimeError("core-capacity check has no plug-in module hashes")
+    expected_hashes = {
+        name: artifact_hashes[name]
+        for name in ("Gearmulator MD.vst3", "Gearmulator MM.vst3")
+        if name in artifact_hashes
+    }
+    if qualified_hashes != expected_hashes:
+        raise RuntimeError(
+            "core-capacity plug-ins do not match the packaged VST3 modules"
+        )
+    for name, digest in qualified_hashes.items():
+        _require_sha256(digest, f"{name} module")
+
+    models = check.get("models")
+    if not isinstance(models, dict) or set(models) != {"MD", "MM"}:
+        raise RuntimeError("core-capacity check must cover MD and MM")
+    paced_tail_by_model = {}
+    for model_name, model in models.items():
+        if not isinstance(model, dict):
+            raise RuntimeError(f"invalid {model_name} core-capacity check")
+        capacity_runs = model.get("capacity_runs")
+        paced_runs = model.get("paced_runs")
+        gate = model.get("gate")
+        if (
+            not isinstance(capacity_runs, list)
+            or len(capacity_runs) != 3
+            or not isinstance(paced_runs, list)
+            or len(paced_runs) != 3
+            or not isinstance(gate, dict)
+        ):
+            raise RuntimeError(
+                f"{model_name} core-capacity check requires exactly three capacity and paced runs"
+            )
+        for mode, runs in (("capacity", capacity_runs), ("paced", paced_runs)):
+            for index, run in enumerate(runs, 1):
+                if not isinstance(run, dict):
+                    raise RuntimeError(f"invalid {model_name} {mode} run {index}")
+                if (
+                    run.get("total_callbacks") != 7500
+                    or run.get("total_samples") != 960000
+                    or run.get("warm_callbacks") != 3000
+                ):
+                    raise RuntimeError(
+                        f"{model_name} {mode} run {index} has the wrong capture length"
+                    )
+                for field in (
+                    "p50_ms",
+                    "p99_ms",
+                    "max_ms",
+                    "p50_budget_fraction",
+                    "p99_budget_fraction",
+                    "max_budget_fraction",
+                    "over_budget_fraction",
+                    "completion_after_deadline_fraction",
+                    "audio_peak_before_quantization",
+                ):
+                    if _finite_number(run.get(field), f"{model_name} {mode} {field}") < 0:
+                        raise RuntimeError(f"{model_name} {mode} {field} is negative")
+                _finite_number(
+                    run.get("scheduler_late_p99_ms"),
+                    f"{model_name} {mode} scheduler_late_p99_ms",
+                )
+                if float(run["audio_peak_before_quantization"]) <= 1e-5:
+                    raise RuntimeError(f"{model_name} {mode} run produced no audible output")
+                for duration_field, fraction_field in (
+                    ("p50_ms", "p50_budget_fraction"),
+                    ("p99_ms", "p99_budget_fraction"),
+                    ("max_ms", "max_budget_fraction"),
+                ):
+                    if not math.isclose(
+                        float(run[fraction_field]),
+                        float(run[duration_field]) / period_ms,
+                        rel_tol=0,
+                        abs_tol=1e-9,
+                    ):
+                        raise RuntimeError(
+                            f"{model_name} {mode} duration fractions are inconsistent"
+                        )
+                p50_ms = float(run["p50_ms"])
+                p99_ms = float(run["p99_ms"])
+                max_ms = float(run["max_ms"])
+                if not 0 <= p50_ms <= p99_ms <= max_ms:
+                    raise RuntimeError(
+                        f"{model_name} {mode} duration quantiles are inconsistent"
+                    )
+                over_budget = run.get("over_budget")
+                completed_late = run.get("completion_after_deadline")
+                if (
+                    not isinstance(over_budget, int)
+                    or not 0 <= over_budget <= 3000
+                    or not isinstance(completed_late, int)
+                    or not 0 <= completed_late <= 3000
+                    or not math.isclose(
+                        float(run["over_budget_fraction"]),
+                        over_budget / 3000,
+                        rel_tol=0,
+                        abs_tol=1e-12,
+                    )
+                    or not math.isclose(
+                        float(run["completion_after_deadline_fraction"]),
+                        completed_late / 3000,
+                        rel_tol=0,
+                        abs_tol=1e-12,
+                    )
+                ):
+                    raise RuntimeError(f"{model_name} {mode} run counts are inconsistent")
+                if (max_ms > period_ms) is not (over_budget > 0):
+                    raise RuntimeError(
+                        f"{model_name} {mode} maximum and render-overrun count are inconsistent"
+                    )
+                capture_hashes = run.get("capture_sha256")
+                required_captures = {
+                    "capture.blocks.csv",
+                    "capture.json",
+                    "capture.wav",
+                    "host.log",
+                }
+                if not isinstance(capture_hashes, dict) or set(capture_hashes) != required_captures:
+                    raise RuntimeError(f"{model_name} {mode} run has incomplete capture hashes")
+                for capture_name, digest in capture_hashes.items():
+                    _require_sha256(digest, f"{model_name} {mode} {capture_name}")
+
+        capacity_limit = _finite_number(gate.get("capacity_limit"), "capacity limit")
+        capacity_value = statistics.median(
+            float(run["p50_budget_fraction"]) for run in capacity_runs
+        )
+        recorded_capacity = _finite_number(
+            gate.get("capacity_median_p50_budget_fraction"), "capacity median"
+        )
+        if (
+            gate.get("core_microgate_passed") is not True
+            or capacity_limit > CORE_CAPACITY_LIMIT
+            or capacity_value > capacity_limit
+            or not math.isclose(recorded_capacity, capacity_value, rel_tol=0, abs_tol=1e-12)
+        ):
+            raise RuntimeError(
+                f"{model_name} output-only core microgate is missing or weaker than release policy"
+            )
+
+        paced_p99 = statistics.median(
+            float(run["p99_budget_fraction"]) for run in paced_runs
+        )
+        paced_over = statistics.median(
+            float(run["over_budget_fraction"]) for run in paced_runs
+        )
+        paced_overruns = sum(int(run["over_budget"]) for run in paced_runs)
+        tail_qualified = paced_overruns == 0
+        if (
+            not math.isclose(
+                _finite_number(gate.get("paced_median_p99_budget_fraction"), "paced p99"),
+                paced_p99,
+                rel_tol=0,
+                abs_tol=1e-12,
+            )
+            or not math.isclose(
+                _finite_number(
+                    gate.get("paced_median_over_budget_fraction"), "paced over-budget median"
+                ),
+                paced_over,
+                rel_tol=0,
+                abs_tol=1e-12,
+            )
+            or gate.get("paced_render_overruns") != paced_overruns
+            or gate.get("paced_tail_qualification_rule")
+            != "zero render-duration overruns in every paced run"
+            or gate.get("paced_tail_qualification_passed") is not tail_qualified
+        ):
+            raise RuntimeError(f"{model_name} paced tail observation is inconsistent")
+        paced_tail_by_model[model_name] = tail_qualified
+
+    paced_tail_qualified = all(paced_tail_by_model.values())
+    if check.get("paced_tail_qualification_passed") is not paced_tail_qualified:
+        raise RuntimeError("overall paced tail qualification is inconsistent")
+    return {
+        "host_architecture": host_architecture,
+        "core_microgate_passed": True,
+        "paced_tail_qualification_passed": paced_tail_qualified,
+    }
+
+
+def release_acceptance(
+    optimization: dict[str, object],
+    core_capacity_result: dict[str, object] | None,
+) -> dict[str, object]:
+    slices = optimization.get("slices")
+    if not isinstance(slices, dict) or not slices:
+        raise RuntimeError("release optimization has no packaged architecture slices")
+
+    measured_architecture = (
+        core_capacity_result.get("host_architecture")
+        if core_capacity_result is not None
+        else None
+    )
+    per_slice = {}
+    for architecture in slices:
+        measured = measured_architecture == architecture
+        per_slice[architecture] = {
+            "output_only_core_microgate": "passed" if measured else "not_run",
+            "output_only_paced_tail": (
+                "qualified"
+                if measured
+                and core_capacity_result is not None
+                and core_capacity_result["paced_tail_qualification_passed"]
+                else "not_qualified" if measured else "not_run"
+            ),
+        }
+
+    all_slices_measured = all(
+        status["output_only_core_microgate"] == "passed"
+        for status in per_slice.values()
+    )
+    return {
+        # Input, standalone, and renderer checks remain human/local even when
+        # the output-only microgate has covered every architecture.
+        "status": "partial",
+        "per_slice": per_slice,
+        "output_only_core_microgate_all_slices_measured": all_slices_measured,
+        "remaining_local_checks": [
+            "output-only core capacity on every packaged architecture",
+            "input-enabled VST3 audio function and callback timing",
+            "standalone output-only first launch and sustained audio",
+            "standalone input opt-in with sustained audio",
+            "standalone renderer selection and idle UI CPU",
+        ],
+    }
+
+
+def validate_pgo_provenance(
+    path: pathlib.Path | None,
+    optimization: dict[str, object],
+    commits: dict[str, str],
+) -> dict[str, object] | None:
+    slices = optimization["slices"]
+    pgo_slices = {
+        architecture: settings
+        for architecture, settings in slices.items()
+        if settings["pgo_mode"] == "use"
+    }
+    if not pgo_slices:
+        if path is not None:
+            raise RuntimeError("PGO provenance was supplied for a build that does not use PGO")
+        return None
+    if path is None:
+        raise RuntimeError("PGO release receipts require profile provenance")
+    if len(pgo_slices) != 1:
+        raise RuntimeError("each PGO provenance receipt must describe one architecture")
+
+    path = path.resolve()
+    provenance = json.loads(path.read_text(encoding="utf-8"))
+    if provenance.get("schema") != "gearmulator.mdmm.apple-pgo-profile.v1":
+        raise RuntimeError("unknown PGO profile provenance schema")
+    architecture, settings = next(iter(pgo_slices.items()))
+    profile = provenance.get("profile")
+    build = provenance.get("build")
+    source = provenance.get("source")
+    training = provenance.get("training")
+    if not all(isinstance(value, dict) for value in (profile, build, source, training)):
+        raise RuntimeError("incomplete PGO profile provenance")
+    if profile.get("sha256") != settings["profile_sha256"]:
+        raise RuntimeError("PGO provenance does not match the configured profile")
+    expected_source = {
+        "parent_revision": commits["source_commit"],
+        "dsp_revision": commits["dsp56300_commit"],
+        "mc68k_revision": commits["mc68k_commit"],
+        "juce_revision": commits["juce_commit"],
+    }
+    actual_source = {key: source.get(key) for key in expected_source}
+    if actual_source != expected_source:
+        raise RuntimeError(
+            f"PGO profile source mismatch: expected {expected_source}, found {actual_source}"
+        )
+    if (
+        build.get("architecture") != architecture
+        or build.get("configuration") != "Release"
+        or build.get("deployment_target") != optimization["deployment_target"]
+        or build.get("thinlto") is not True
+        or build.get("dsp_optimization") is not True
+        or build.get("pgo_mode") != "generate"
+        or set(build.get("optimized_targets", ()))
+        != {"mdLib", "68kEmu", "dsp56kEmu", "dsp56kBase"}
+        or not build.get("compiler_id")
+        or not build.get("compiler_version")
+    ):
+        raise RuntimeError("PGO provenance build configuration does not match release policy")
+    if (
+        build["compiler_id"] != optimization["compiler"]["id"]
+        or build["compiler_version"] != optimization["compiler"]["version"]
+    ):
+        raise RuntimeError("PGO profile compiler does not match the release compiler")
+    trained_models = training.get("models")
+    if not isinstance(trained_models, list):
+        raise RuntimeError("PGO provenance does not cover the required MD/MM workload")
+    trained_by_name = {
+        model.get("model"): model for model in trained_models if isinstance(model, dict)
+    }
+    if (
+        set(trained_by_name) != {"MD", "MM"}
+        or training.get("host_sample_rate_hz") != 48000
+        or training.get("block_frames") != 128
+        or int(training.get("callbacks_per_model", 0)) < 12000
+        or int(training.get("measured_callbacks_per_model", 0)) < 7500
+        or any(
+            trained_by_name[model].get("firmware_sha256") != FIRMWARE_SHA256[model]
+            or not trained_by_name[model].get("raw_profile_sha256")
+            for model in ("MD", "MM")
+        )
+    ):
+        raise RuntimeError("PGO provenance does not cover the required MD/MM workload")
+    for model in ("MD", "MM"):
+        _require_sha256(
+            trained_by_name[model]["raw_profile_sha256"],
+            f"{model} raw PGO profile",
+        )
+    return {
+        "sha256": sha256(path),
+        "profile_sha256": profile["sha256"],
+        "architecture": architecture,
+        "compiler_id": build["compiler_id"],
+        "compiler_version": build["compiler_version"],
+        "deployment_target": build["deployment_target"],
+        "source": expected_source,
+        "training": {
+            "host_sample_rate_hz": training["host_sample_rate_hz"],
+            "block_frames": training["block_frames"],
+            "models": ["MD", "MM"],
+        },
+    }
+
+
 def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--source", type=pathlib.Path, required=True)
@@ -247,7 +893,21 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     parser.add_argument("--artifact", type=pathlib.Path, action="append", default=[])
     parser.add_argument("--package-file", type=pathlib.Path, action="append", default=[])
     parser.add_argument("--archive", type=pathlib.Path)
+    parser.add_argument("--build-cache", type=pathlib.Path)
+    parser.add_argument("--core-capacity-check", type=pathlib.Path)
+    parser.add_argument("--pgo-provenance", type=pathlib.Path)
+    parser.add_argument("--print-release-selection", action="store_true")
+    parser.add_argument(
+        "--release-architectures", default="arm64;x86_64", metavar="ARCH[;ARCH]"
+    )
+    parser.add_argument("--release-pgo-mode", default="none")
+    parser.add_argument("--release-pgo-profile", type=pathlib.Path)
     parser.add_argument("--check-source-only", action="store_true")
+    parser.add_argument("--validate-build-optimization", type=pathlib.Path)
+    parser.add_argument(
+        "--expected-architecture", action="append", default=[], metavar="ARCH"
+    )
+    parser.add_argument("--expected-products-root", type=pathlib.Path)
     parser.add_argument(
         "--firmware-tests-required",
         nargs="?",
@@ -269,14 +929,45 @@ def main() -> None:
     args = parse_args()
 
     source = args.source.resolve()
+    if args.print_release_selection:
+        selection = release_selection(
+            args.release_architectures,
+            args.release_pgo_mode,
+            args.release_pgo_profile,
+            args.pgo_provenance,
+        )
+        print(f"{selection['cmake_architectures']}|{selection['package_name']}")
+        return
+    if args.validate_build_optimization is not None:
+        optimization = release_optimization(
+            args.validate_build_optimization,
+            tuple(args.expected_architecture),
+            args.expected_products_root,
+        )
+        provenance = validate_pgo_provenance(
+            args.pgo_provenance,
+            optimization,
+            source_tuple(source),
+        )
+        print(
+            json.dumps(
+                {"optimization": optimization, "pgo_profile_provenance": provenance},
+                sort_keys=True,
+            )
+        )
+        return
     if args.validate_build_root is not None or args.validate_output_root is not None:
         if args.validate_build_root is None or args.validate_output_root is None:
-            parser.error("--validate-build-root and --validate-output-root are required together")
+            raise RuntimeError(
+                "--validate-build-root and --validate-output-root are required together"
+            )
         validate_release_directories(source, args.validate_build_root, args.validate_output_root)
         return
     if args.prepare_build_root is not None or args.prepare_output_root is not None:
         if args.prepare_build_root is None or args.prepare_output_root is None:
-            parser.error("--prepare-build-root and --prepare-output-root are required together")
+            raise RuntimeError(
+                "--prepare-build-root and --prepare-output-root are required together"
+            )
         prepare_release_directories(source, args.prepare_build_root, args.prepare_output_root)
         return
     require_clean(
@@ -296,8 +987,23 @@ def main() -> None:
     if args.check_source_only:
         print(json.dumps(commits, sort_keys=True))
         return
-    if args.output is None or not args.artifact or args.archive is None:
-        parser.error("--output, --archive, and at least one --artifact are required when writing a receipt")
+    if (
+        args.output is None
+        or not args.artifact
+        or args.archive is None
+        or args.build_cache is None
+    ):
+        raise RuntimeError(
+            "--output, --archive, --build-cache, and at least one --artifact "
+            "are required when writing a receipt"
+        )
+
+    optimization = release_optimization(
+        args.build_cache,
+        tuple(args.expected_architecture),
+        args.expected_products_root,
+    )
+    pgo_provenance = validate_pgo_provenance(args.pgo_provenance, optimization, commits)
 
     artifacts = []
     for bundle in args.artifact:
@@ -332,11 +1038,32 @@ def main() -> None:
             "source/dependency commits changed while hashing release artifacts: "
             f"started with {commits}, finished with {final_commits}"
         )
+    core_capacity_check = None
+    core_capacity_result = None
+    if args.core_capacity_check is not None:
+        check_path = args.core_capacity_check.resolve()
+        if not check_path.is_file():
+            raise RuntimeError(
+                f"core-capacity receipt does not exist: {check_path}"
+            )
+        core_capacity_check = json.loads(check_path.read_text(encoding="utf-8"))
+        core_capacity_result = validate_core_capacity_check(
+            core_capacity_check,
+            {artifact["name"]: artifact["sha256"] for artifact in artifacts},
+            optimization,
+        )
+    if args.firmware_tests_required and core_capacity_check is None:
+        raise RuntimeError(
+            "firmware-backed release receipts require a passing output-only core microgate"
+        )
+
+    acceptance = release_acceptance(optimization, core_capacity_result)
+
     receipt = {
-        "schema": "gearmulator-elektron-macos-build-v1",
+        "schema": "gearmulator-elektron-macos-build-v2",
         "created_utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
         "configuration": "Release",
-        "architecture": "x86_64 arm64",
+        "architecture": " ".join(sorted(optimization["slices"])),
         "signing": "ad-hoc",
         "notarized": False,
         **final_commits,
@@ -344,12 +1071,23 @@ def main() -> None:
         "firmware_included": False,
         "tests_run": True,
         "firmware_tests_required": args.firmware_tests_required,
+        "release_approved": False,
+        "release_acceptance": acceptance,
+        "automated_output_only_core_microgate_passed_for_measured_slice": bool(
+            core_capacity_result is not None
+        ),
+        "automated_output_only_core_microgate_all_slices_measured": acceptance[
+            "output_only_core_microgate_all_slices_measured"
+        ],
+        "optimization": optimization,
+        "pgo_profile_provenance": pgo_provenance,
+        "core_capacity_check": core_capacity_check,
         "packaged_firmware_smoke": {
             "required": args.firmware_tests_required,
             "fixture_format": "external complete 8 MiB .bin",
             "fixture_sha256": {
-                "md": "68542e30917b9918ccaee2b2237df62c8a00479938680b85aca93ce4fbca44c8",
-                "mm": "369849175602e20a9dd2b6e0ad8ac404b76f82718b14afbf1cbc01b7acabec7e",
+                "md": FIRMWARE_SHA256["MD"],
+                "mm": FIRMWARE_SHA256["MM"],
             },
             "audio_callback_blocks": 256 if args.firmware_tests_required else 16,
             "scope": "exact extracted VST3 load, device initialization, and callback execution",

--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -68,6 +68,16 @@ juce_add_binary_data(mmJucePlugin_BinaryData SOURCES
 createJucePlugin(mdJucePlugin "Gearmulator MD" TRUE "Tmdr" mdJucePlugin_BinaryData mdLib)
 createJucePlugin(mmJucePlugin "Gearmulator MM" TRUE "Tmno" mmJucePlugin_BinaryData mdLib)
 
+# MD/MM expose an optional stereo input to plug-in hosts. Starting the
+# standalone with that input active makes CoreAudio combine the built-in input
+# and output devices on common Mac setups, which can consume the real-time
+# deadline. Keep the input selectable, but start new standalone configurations
+# with output only.
+foreach(plugin_target mdJucePlugin mmJucePlugin)
+	target_compile_definitions(${plugin_target} PUBLIC
+		JUCE_STANDALONE_PLUGIN_AUTO_OPEN_AUDIO_INPUT=0)
+endforeach()
+
 # JUCE can populate bundle resources after its first ad-hoc signing pass on
 # macOS. Re-sign the completed VST3 and Standalone bundles so hosts and Finder
 # do not reject their final on-disk contents.
@@ -123,7 +133,8 @@ if(BUILD_TESTING)
 		mdJucePlugin jucePluginEditorLib mdLib juce_plugin_modules
 		juce::juce_opengl)
 	target_compile_definitions(mdAudioIoLayoutTest PRIVATE
-		JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1)
+		JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1
+		JUCE_STANDALONE_PLUGIN_AUTO_OPEN_AUDIO_INPUT=0)
 	set_property(TARGET mdAudioIoLayoutTest PROPERTY FOLDER "Elektron/test")
 	add_test(NAME mdAudioIoLayoutTest COMMAND mdAudioIoLayoutTest)
 	set_tests_properties(mdAudioIoLayoutTest PROPERTIES LABELS "UnitTest;AudioIo")

--- a/source/elektron/md/mdJucePlugin/CMakeLists.txt
+++ b/source/elektron/md/mdJucePlugin/CMakeLists.txt
@@ -101,6 +101,12 @@ endif()
 target_compile_definitions(mmJucePlugin PRIVATE MD_JUCEPLUGIN_MONOMACHINE=1)
 
 if(BUILD_TESTING)
+	add_executable(mdStandaloneRendererPolicyTest mdStandaloneRendererPolicyTest.cpp)
+	add_test(NAME mdStandaloneRendererPolicyTest COMMAND mdStandaloneRendererPolicyTest)
+	set_tests_properties(mdStandaloneRendererPolicyTest PROPERTIES
+		LABELS "UnitTest;Rendering")
+	set_property(TARGET mdStandaloneRendererPolicyTest PROPERTY FOLDER "Elektron/test")
+
 	add_executable(mdPanelRenderingTest mdPanelRenderingTest.cpp mdPixelPerfectPanel.cpp)
 	target_link_libraries(mdPanelRenderingTest PRIVATE juceRmlUi juceUiLib juce_plugin_modules juce::juce_opengl)
 	target_compile_definitions(mdPanelRenderingTest PRIVATE JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1)

--- a/source/elektron/md/mdJucePlugin/mdAudioIoLayoutTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdAudioIoLayoutTest.cpp
@@ -1,6 +1,7 @@
 #include "mdPluginProcessor.h"
 
 #include "juce_audio_utils/juce_audio_utils.h"
+#include "juce_audio_plugin_client/Standalone/juce_StandaloneFilterWindow.h"
 #include "juce_events/juce_events.h"
 #include "jucePluginLib/controller.h"
 #include "jucePluginLib/processor.h"
@@ -292,6 +293,24 @@ namespace
 
 	void verifyStandaloneLayout(const md::MachineModel _model)
 	{
+		require(!juce::StandalonePluginHolder::shouldAutoOpenAudioInput(2),
+			"MD/MM Standalone unexpectedly auto-opened its optional audio input");
+		require(!juce::StandalonePluginHolder::shouldAutoOpenAudioInput(0),
+			"Standalone requested input when no input channels were available");
+		require(juce::StandalonePluginHolder::shouldAutoOpenAudioInput(2, true),
+			"Standalone did not restore an explicitly enabled audio input");
+
+		juce::XmlElement savedDeviceState("DEVICESETUP");
+		savedDeviceState.setAttribute("audioInputDeviceName", "Internal Microphone");
+		savedDeviceState.setAttribute("audioOutputDeviceName", "MacBook Pro Speakers");
+		savedDeviceState.setAttribute("audioDeviceInChans", "11");
+		juce::StandalonePluginHolder::disableAudioInputInSavedState(savedDeviceState);
+		require(savedDeviceState.getStringAttribute("audioInputDeviceName").isEmpty()
+			&& savedDeviceState.getStringAttribute("audioOutputDeviceName")
+				== "MacBook Pro Speakers"
+			&& savedDeviceState.getStringAttribute("audioDeviceInChans") == "0",
+			"Standalone did not remove an implicit input from saved device state");
+
 		const auto previousWrapper = juce::PluginHostType::getPluginLoadedAs();
 		juce::PluginHostType::jucePlugInClientCurrentWrapperType
 			= juce::AudioProcessor::wrapperType_Standalone;

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -1886,7 +1886,9 @@ namespace mdJucePlugin
 		// until an unrelated repaint (normally up to 500 ms later).
 		if(updateLeds())
 			if(auto* rml = getRmlComponent())
-				rml->enqueueUpdate();
+				// These class changes are resolved in the next RmlUi update. Avoid
+				// asking the software fallback to rasterize three unchanged frames.
+				rml->enqueueUpdateOnce();
 	}
 
 	std::pair<std::string, std::string> Editor::getDemoRestrictionText() const

--- a/source/elektron/md/mdJucePlugin/mdPanelRenderingTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPanelRenderingTest.cpp
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 
 namespace juceRmlUi
 {
@@ -24,6 +25,29 @@ namespace juceRmlUi
 		{
 			return _component.m_pendingUpdates;
 		}
+		static float targetFPS(const RmlComponent& _component)
+		{
+			return _component.m_targetFPS;
+		}
+		static bool hasCustomFPS(const RmlComponent& _component)
+		{
+			return _component.m_hasCustomFPS;
+		}
+		static void useDefaultFrameRateFor(RmlComponent& _component,
+			const RmlComponent::Renderer _renderer)
+		{
+			_component.useDefaultFrameRateFor(_renderer);
+		}
+#ifdef RMLUI_METAL_RENDERER
+		static bool hasMetalContext(const RmlComponent& _component)
+		{
+			return _component.m_metalContext != nullptr;
+		}
+		static void fallBackFromMetalToSoftware(RmlComponent& _component)
+		{
+			_component.fallBackFromMetalToSoftware();
+		}
+#endif
 		static void requirePaddedTextures(RmlComponent& _component)
 		{
 			_component.m_renderProxy->setTextureParameters(4096, false);
@@ -226,6 +250,41 @@ namespace
 			== Rml::Colourb(0x34, 0x56, 0x78), "removing experiment did not restore the authored rule");
 	}
 
+	void testSoftwareFrameRatePolicy()
+	{
+	#if JUCE_MAC
+		constexpr float defaultAcceleratedFPS = 60.0f;
+	#else
+		constexpr float defaultAcceleratedFPS = 30.0f;
+	#endif
+		Resources resources;
+		juceRmlUi::RmlInterfaces interfaces(resources);
+		for (const auto [configured, expected, custom] : {
+			std::tuple{-1, 30.0f, false}, std::tuple{0, 30.0f, false},
+			std::tuple{1, 1.0f, true}, std::tuple{47, 47.0f, true},
+			std::tuple{300, 300.0f, true}, std::tuple{301, 30.0f, false}})
+		{
+			juceRmlUi::RmlComponentConfig config;
+			config.forceSoftwareRenderer = juceRmlUi::SoftwareRendererMode::ForceOn;
+			config.refreshRateLimitHz = configured;
+			juceRmlUi::RmlComponent component(interfaces, resources, "test.rml",
+				1.f, {}, {}, config);
+			require(juceRmlUi::RenderingTestAccess::targetFPS(component) == expected,
+				"software frame-rate policy did not preserve the configured/default rate");
+			require(juceRmlUi::RenderingTestAccess::hasCustomFPS(component) == custom,
+				"software frame-rate policy misclassified the configured rate");
+			juceRmlUi::RenderingTestAccess::useDefaultFrameRateFor(component,
+				juceRmlUi::RmlComponent::Renderer::Gl3);
+			require(juceRmlUi::RenderingTestAccess::targetFPS(component)
+				== (custom ? expected : defaultAcceleratedFPS),
+				"accelerated renderer did not select/preserve the configured rate");
+			juceRmlUi::RenderingTestAccess::useDefaultFrameRateFor(component,
+				juceRmlUi::RmlComponent::Renderer::Software);
+			require(juceRmlUi::RenderingTestAccess::targetFPS(component) == expected,
+				"software fallback did not restore/preserve the configured rate");
+		}
+	}
+
 #ifdef RMLUI_METAL_RENDERER
 	void testPeerlessMetalAttachment()
 	{
@@ -240,6 +299,45 @@ namespace
 			"Metal native view could not attach before peer creation");
 		context.detach();
 	}
+
+	void testMetalFallbackFrameRatePolicy()
+	{
+		{
+			Resources resources;
+			juceRmlUi::RmlInterfaces interfaces(resources);
+			juceRmlUi::RmlComponentConfig config;
+			juceRmlUi::RmlComponent component(interfaces, resources, "test.rml",
+				1.f, {}, {}, config);
+			if (!juceRmlUi::RenderingTestAccess::hasMetalContext(component))
+				return;
+
+			juceRmlUi::RenderingTestAccess::useDefaultFrameRateFor(component,
+				juceRmlUi::RmlComponent::Renderer::Metal);
+#if JUCE_MAC
+			require(juceRmlUi::RenderingTestAccess::targetFPS(component) == 60.0f,
+				"Metal did not select the default accelerated frame rate");
+#endif
+			juceRmlUi::RenderingTestAccess::fallBackFromMetalToSoftware(component);
+			require(juceRmlUi::RenderingTestAccess::targetFPS(component) == 30.0f,
+				"Metal fallback did not restore the default software frame rate");
+		}
+
+		{
+			Resources resources;
+			juceRmlUi::RmlInterfaces interfaces(resources);
+			juceRmlUi::RmlComponentConfig config;
+			config.refreshRateLimitHz = 47;
+			juceRmlUi::RmlComponent component(interfaces, resources, "test.rml",
+				1.f, {}, {}, config);
+			if (!juceRmlUi::RenderingTestAccess::hasMetalContext(component))
+				return;
+			juceRmlUi::RenderingTestAccess::useDefaultFrameRateFor(component,
+				juceRmlUi::RmlComponent::Renderer::Metal);
+			juceRmlUi::RenderingTestAccess::fallBackFromMetalToSoftware(component);
+			require(juceRmlUi::RenderingTestAccess::targetFPS(component) == 47.0f,
+				"Metal fallback replaced an explicit frame rate");
+		}
+	}
 #endif
 }
 
@@ -248,11 +346,13 @@ int main()
 	try
 	{
 		juce::ScopedJuceInitialiser_GUI gui;
+		testSoftwareFrameRatePolicy();
 		// Cover both native and portable software Graphics destinations.
 		testRendering(juce::NativeImageType());
 		testRendering(juce::SoftwareImageType());
 #ifdef RMLUI_METAL_RENDERER
 		testPeerlessMetalAttachment();
+		testMetalFallbackFrameRatePolicy();
 #endif
 		std::cout << "Panel rendering: toggles, density transitions, integer LCD, padded fallback, and removal passed\n";
 		return 0;

--- a/source/elektron/md/mdJucePlugin/mdPanelRenderingTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPanelRenderingTest.cpp
@@ -4,6 +4,9 @@
 #include "juceRmlUi/juceRmlLookAndFeel.h"
 #include "juceRmlUi/rmlDataProvider.h"
 #include "juceRmlUi/rmlElemCanvas.h"
+#ifdef RMLUI_METAL_RENDERER
+#include "juceRmlUi/MetalContext.h"
+#endif
 #include "RmlUi/Core/Context.h"
 #include "RmlUi/Core/ElementDocument.h"
 
@@ -17,6 +20,10 @@ namespace juceRmlUi
 	struct RenderingTestAccess
 	{
 		static void update(RmlComponent& _component) { _component.update(); }
+		static uint32_t pendingUpdates(const RmlComponent& _component)
+		{
+			return _component.m_pendingUpdates;
+		}
 		static void requirePaddedTextures(RmlComponent& _component)
 		{
 			_component.m_renderProxy->setTextureParameters(4096, false);
@@ -37,11 +44,14 @@ namespace
 		const std::string rml = R"(<rml><head ><style>
 			body { width: 512dp; height: 256dp; background-color: #8899aa; }
 			div { position: absolute; }
+			.panel-led { background-color: #000000; }
+			.panel-led.lit { background-color: #00ff00; }
 			</style></head><body>
 			<div id="lcd" style="left: 30.25dp; top: 40.25dp; width: 220.5dp; height: 116.5dp;"/>
 			<div id="rule" class="elektronPixelRule" style="left: 300.25dp; top: 50.25dp; width: 51.25dp; height: 1dp; background-color: #345678;"/>
 			<div id="unmarked" style="left: 300.25dp; top: 60.25dp; width: 51.25dp; height: 1dp; background-color: #345678;"/>
 			<div id="teardown" class="elektronPixelRule" style="left: 300.25dp; top: 70.25dp; width: 51.25dp; height: 1dp; background-color: #345678;"/>
+			<div id="led" class="panel-led" style="left: 400dp; top: 50dp; width: 20dp; height: 20dp;"/>
 			<div id="sentinel" style="left: 400dp; top: 200dp; width: 20dp; height: 20dp; background-color: #ff0000;"/>
 			</body></rml>)";
 	public:
@@ -80,8 +90,10 @@ namespace
 		for (int y = 0; y < 64; ++y)
 			for (int x = 0; x < 128; ++x)
 				lcd.setPixelAt(x, y, (x + y) % 2 ? juce::Colours::white : juce::Colours::black);
+		int canvasPaintCount = 0;
 		canvas->setRepaintGraphicsCallback([&](juce::Image& _target, juce::Graphics& _g)
 		{
+			++canvasPaintCount;
 			_g.fillAll(juce::Colours::green);
 			_g.setImageResamplingQuality(juce::Graphics::lowResamplingQuality);
 			if (!experiment || !experiment->paintLcd(lcd, _g))
@@ -134,6 +146,36 @@ namespace
 			samePixels(baseline, settle(dpi), "restored baseline");
 		}
 
+		// A canvas texture replacement and the class changes used by the MD/MM
+		// LEDs are each fully visible after one Update/Render pass. They must not
+		// refill the generic three-frame property-settling allowance. Keep that
+		// allowance available to generic callers whose properties may cascade.
+		settle(1.f);
+		component.enqueueUpdate();
+		require(juceRmlUi::RenderingTestAccess::pendingUpdates(component) == 3,
+			"generic update lost its property-settling allowance");
+		settle(1.f);
+		const auto canvasPaintCountBefore = canvasPaintCount;
+		canvas->repaint();
+		require(juceRmlUi::RenderingTestAccess::pendingUpdates(component) == 0,
+			"canvas repaint requested redundant settling frames");
+		juceRmlUi::RenderingTestAccess::update(component);
+		auto singleFrame = paint(1.f);
+		require(canvasPaintCount == canvasPaintCountBefore + 1,
+			"one frame did not consume the canvas repaint");
+
+		auto* led = doc->GetElementById("led");
+		led->SetClass("lit", true);
+		component.enqueueUpdateOnce();
+		require(juceRmlUi::RenderingTestAccess::pendingUpdates(component) == 0,
+			"LED class update requested redundant settling frames");
+		juceRmlUi::RenderingTestAccess::update(component);
+		singleFrame = paint(1.f);
+		const auto ledPixel = singleFrame.getPixelAt(410, 60);
+		require(ledPixel.getGreen() > 250 && ledPixel.getRed() < 5
+			&& ledPixel.getBlue() < 5,
+			"one frame did not resolve the LED class change");
+
 		// Display changes can produce another paint before RML lays out a new frame.
 		experiment->apply(component, canvas, true);
 		settle(1.f);
@@ -183,6 +225,22 @@ namespace
 		require(doc->GetElementById("teardown")->GetProperty("background-color")->Get<Rml::Colourb>(doc->GetCoreInstance())
 			== Rml::Colourb(0x34, 0x56, 0x78), "removing experiment did not restore the authored rule");
 	}
+
+#ifdef RMLUI_METAL_RENDERER
+	void testPeerlessMetalAttachment()
+	{
+		juce::Component peerlessComponent;
+		juceRmlUi::MetalContext context;
+		if (!context.getDevice())
+			return;
+
+		require(peerlessComponent.getPeer() == nullptr,
+			"Metal attachment test unexpectedly has a peer");
+		require(context.attachTo(peerlessComponent),
+			"Metal native view could not attach before peer creation");
+		context.detach();
+	}
+#endif
 }
 
 int main()
@@ -193,6 +251,9 @@ int main()
 		// Cover both native and portable software Graphics destinations.
 		testRendering(juce::NativeImageType());
 		testRendering(juce::SoftwareImageType());
+#ifdef RMLUI_METAL_RENDERER
+		testPeerlessMetalAttachment();
+#endif
 		std::cout << "Panel rendering: toggles, density transitions, integer LCD, padded fallback, and removal passed\n";
 		return 0;
 	}

--- a/source/elektron/md/mdJucePlugin/mdPluginEditorState.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPluginEditorState.cpp
@@ -8,6 +8,7 @@
 #include "mdProductSkins.h"
 
 #include "juce_events/juce_events.h"
+#include "jucePluginEditorLib/rendererPreferenceKeys.h"
 #include "juceRmlUi/rmlMenu.h"
 
 namespace mdJucePlugin
@@ -23,20 +24,15 @@ namespace mdJucePlugin
 		#endif
 
 		auto& config = _processor.getConfig();
-		constexpr auto rendererPreferenceKey = "forceSoftwareRenderer";
-		constexpr auto rendererAutoMigrationKey = "standaloneRendererAutoV1";
-		if(shouldMigrateStandaloneRendererDefaultToAuto(isMacOS,
+		using namespace jucePluginEditorLib;
+		if(shouldRemoveLegacyStandaloneSoftwareRenderer(isMacOS,
 			juce::JUCEApplicationBase::isStandaloneApp(),
 			_processor.getForceSoftwareRendererForSession().has_value(),
-			config.getBoolValue(rendererAutoMigrationKey, false)))
+			config.getBoolValue(forceSoftwareRendererUserSelectedKey, false),
+			config.containsKey(forceSoftwareRendererKey),
+			config.getBoolValue(forceSoftwareRendererKey, false)))
 		{
-			// `false` was never written by the old standalone default, so it is an
-			// explicit request for Metal and can be preserved. A stored `true` has
-			// no provenance: old alpha builds wrote it automatically, so clear it
-			// once and let the renderer select Metal with its normal fallback.
-			if(config.getBoolValue(rendererPreferenceKey, true))
-				config.removeValue(rendererPreferenceKey);
-			config.setValue(rendererAutoMigrationKey, true);
+			config.removeValue(forceSoftwareRendererKey);
 			config.saveIfNeeded();
 		}
 

--- a/source/elektron/md/mdJucePlugin/mdPluginEditorState.cpp
+++ b/source/elektron/md/mdJucePlugin/mdPluginEditorState.cpp
@@ -24,12 +24,19 @@ namespace mdJucePlugin
 
 		auto& config = _processor.getConfig();
 		constexpr auto rendererPreferenceKey = "forceSoftwareRenderer";
-		if(shouldPersistStandaloneSoftwareRendererDefault(isMacOS,
+		constexpr auto rendererAutoMigrationKey = "standaloneRendererAutoV1";
+		if(shouldMigrateStandaloneRendererDefaultToAuto(isMacOS,
 			juce::JUCEApplicationBase::isStandaloneApp(),
 			_processor.getForceSoftwareRendererForSession().has_value(),
-			config.containsKey(rendererPreferenceKey)))
+			config.getBoolValue(rendererAutoMigrationKey, false)))
 		{
-			config.setValue(rendererPreferenceKey, true);
+			// `false` was never written by the old standalone default, so it is an
+			// explicit request for Metal and can be preserved. A stored `true` has
+			// no provenance: old alpha builds wrote it automatically, so clear it
+			// once and let the renderer select Metal with its normal fallback.
+			if(config.getBoolValue(rendererPreferenceKey, true))
+				config.removeValue(rendererPreferenceKey);
+			config.setValue(rendererAutoMigrationKey, true);
 			config.saveIfNeeded();
 		}
 

--- a/source/elektron/md/mdJucePlugin/mdStandaloneRendererPolicy.h
+++ b/source/elektron/md/mdJucePlugin/mdStandaloneRendererPolicy.h
@@ -2,17 +2,18 @@
 
 namespace mdJucePlugin
 {
-	// The macOS Metal child view can disagree with the JUCE component's pointer
-	// geometry. Default the directly-hosted standalone products to the composited
-	// software path, while leaving an explicit user preference, a composite-host
-	// override (MachineRack), and plug-in hosts authoritative.
-	constexpr bool shouldPersistStandaloneSoftwareRendererDefault(
+	// Early MD/MM alpha builds persisted software rendering for every macOS
+	// standalone instance. That avoids Metal-specific failures, but permanently
+	// opts users out of the much cheaper renderer even when Metal works. Clear
+	// that old default once and return to the renderer's automatic selection.
+	// A software preference chosen after this migration remains authoritative.
+	constexpr bool shouldMigrateStandaloneRendererDefaultToAuto(
 		const bool _isMacOS, const bool _isStandalone,
 		const bool _hasSessionRendererOverride,
-		const bool _hasPersistedRendererPreference)
+		const bool _migrationComplete)
 	{
 		return _isMacOS && _isStandalone
 			&& !_hasSessionRendererOverride
-			&& !_hasPersistedRendererPreference;
+			&& !_migrationComplete;
 	}
 }

--- a/source/elektron/md/mdJucePlugin/mdStandaloneRendererPolicy.h
+++ b/source/elektron/md/mdJucePlugin/mdStandaloneRendererPolicy.h
@@ -4,16 +4,21 @@ namespace mdJucePlugin
 {
 	// Early MD/MM alpha builds persisted software rendering for every macOS
 	// standalone instance. That avoids Metal-specific failures, but permanently
-	// opts users out of the much cheaper renderer even when Metal works. Clear
-	// that old default once and return to the renderer's automatic selection.
-	// A software preference chosen after this migration remains authoritative.
-	constexpr bool shouldMigrateStandaloneRendererDefaultToAuto(
+	// opts users out of the much cheaper renderer even when Metal works. Clear a
+	// stored legacy `true` whenever it has no user-selection provenance. This is
+	// deliberately repeatable: launching an older alpha can write the legacy
+	// value again after a newer build has already migrated the configuration.
+	constexpr bool shouldRemoveLegacyStandaloneSoftwareRenderer(
 		const bool _isMacOS, const bool _isStandalone,
 		const bool _hasSessionRendererOverride,
-		const bool _migrationComplete)
+		const bool _userSelectedRenderer,
+		const bool _hasPersistedRendererPreference,
+		const bool _persistedSoftwareRenderer)
 	{
 		return _isMacOS && _isStandalone
 			&& !_hasSessionRendererOverride
-			&& !_migrationComplete;
+			&& !_userSelectedRenderer
+			&& _hasPersistedRendererPreference
+			&& _persistedSoftwareRenderer;
 	}
 }

--- a/source/elektron/md/mdJucePlugin/mdStandaloneRendererPolicyTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdStandaloneRendererPolicyTest.cpp
@@ -16,18 +16,22 @@ namespace
 
 int main()
 {
-	using mdJucePlugin::shouldMigrateStandaloneRendererDefaultToAuto;
+	using mdJucePlugin::shouldRemoveLegacyStandaloneSoftwareRenderer;
 
-	expect(shouldMigrateStandaloneRendererDefaultToAuto(true, true, false, false),
-		"unmigrated macOS standalone did not select automatic rendering");
-	expect(!shouldMigrateStandaloneRendererDefaultToAuto(false, true, false, false),
+	expect(shouldRemoveLegacyStandaloneSoftwareRenderer(true, true, false, false, true, true),
+		"legacy macOS standalone software default was not removed");
+	expect(!shouldRemoveLegacyStandaloneSoftwareRenderer(true, true, false, false, false, false),
+		"missing renderer preference was treated as a legacy software default");
+	expect(!shouldRemoveLegacyStandaloneSoftwareRenderer(true, true, false, false, true, false),
+		"persisted automatic renderer preference was removed");
+	expect(!shouldRemoveLegacyStandaloneSoftwareRenderer(true, true, false, true, true, true),
+		"explicit user software preference was removed");
+	expect(!shouldRemoveLegacyStandaloneSoftwareRenderer(false, true, false, false, true, true),
 		"non-macOS standalone attempted the macOS migration");
-	expect(!shouldMigrateStandaloneRendererDefaultToAuto(true, false, false, false),
+	expect(!shouldRemoveLegacyStandaloneSoftwareRenderer(true, false, false, false, true, true),
 		"plug-in instance attempted the standalone migration");
-	expect(!shouldMigrateStandaloneRendererDefaultToAuto(true, true, true, false),
+	expect(!shouldRemoveLegacyStandaloneSoftwareRenderer(true, true, true, false, true, true),
 		"session renderer override was not authoritative");
-	expect(!shouldMigrateStandaloneRendererDefaultToAuto(true, true, false, true),
-		"completed migration ran a second time");
 
 	std::cout << "MD/MM standalone renderer policy: PASS\n";
 	return 0;

--- a/source/elektron/md/mdJucePlugin/mdStandaloneRendererPolicyTest.cpp
+++ b/source/elektron/md/mdJucePlugin/mdStandaloneRendererPolicyTest.cpp
@@ -1,0 +1,34 @@
+#include "mdStandaloneRendererPolicy.h"
+
+#include <cstdlib>
+#include <iostream>
+
+namespace
+{
+	void expect(const bool _condition, const char* const _message)
+	{
+		if(_condition)
+			return;
+		std::cerr << "mdStandaloneRendererPolicyTest: " << _message << '\n';
+		std::exit(1);
+	}
+}
+
+int main()
+{
+	using mdJucePlugin::shouldMigrateStandaloneRendererDefaultToAuto;
+
+	expect(shouldMigrateStandaloneRendererDefaultToAuto(true, true, false, false),
+		"unmigrated macOS standalone did not select automatic rendering");
+	expect(!shouldMigrateStandaloneRendererDefaultToAuto(false, true, false, false),
+		"non-macOS standalone attempted the macOS migration");
+	expect(!shouldMigrateStandaloneRendererDefaultToAuto(true, false, false, false),
+		"plug-in instance attempted the standalone migration");
+	expect(!shouldMigrateStandaloneRendererDefaultToAuto(true, true, true, false),
+		"session renderer override was not authoritative");
+	expect(!shouldMigrateStandaloneRendererDefaultToAuto(true, true, false, true),
+		"completed migration ran a second time");
+
+	std::cout << "MD/MM standalone renderer policy: PASS\n";
+	return 0;
+}

--- a/source/elektron/md/optimization.cmake
+++ b/source/elektron/md/optimization.cmake
@@ -10,6 +10,13 @@ set_property(CACHE GEARMULATOR_MDMM_APPLE_PGO_MODE PROPERTY STRINGS none generat
 set(GEARMULATOR_MDMM_APPLE_PGO_PROFILE "" CACHE FILEPATH
 	"Merged profile from the same source, compiler and architecture")
 
+# Release tooling reads these INTERNAL values back from the generated cache.
+# Clear them first so disabling or breaking this file cannot leave a stale
+# successful marker after reconfiguration.
+unset(GEARMULATOR_MDMM_APPLE_OPTIMIZATION_APPLIED_TARGETS CACHE)
+unset(GEARMULATOR_MDMM_APPLE_OPTIMIZATION_APPLIED_PGO_MODE CACHE)
+unset(GEARMULATOR_MDMM_APPLE_OPTIMIZATION_APPLIED_PROFILE_SHA256 CACHE)
+
 if(NOT GEARMULATOR_MDMM_APPLE_PGO_MODE MATCHES "^(none|generate|use)$")
 	message(FATAL_ERROR "GEARMULATOR_MDMM_APPLE_PGO_MODE must be none, generate, or use")
 endif()
@@ -72,5 +79,15 @@ foreach(_mdmm_target IN LISTS _mdmm_optimization_targets)
 		endif()
 	endif()
 endforeach()
+
+set(GEARMULATOR_MDMM_APPLE_OPTIMIZATION_APPLIED_TARGETS
+	"${_mdmm_optimization_targets}" CACHE INTERNAL
+	"MD/MM targets that received Apple Release optimization" FORCE)
+set(GEARMULATOR_MDMM_APPLE_OPTIMIZATION_APPLIED_PGO_MODE
+	"${GEARMULATOR_MDMM_APPLE_PGO_MODE}" CACHE INTERNAL
+	"PGO mode actually applied to MD/MM Release targets" FORCE)
+set(GEARMULATOR_MDMM_APPLE_OPTIMIZATION_APPLIED_PROFILE_SHA256
+	"${_mdmm_profile_sha256}" CACHE INTERNAL
+	"SHA-256 of the profile actually applied to MD/MM Release targets" FORCE)
 
 message(STATUS "MD/MM Apple Release optimization: ThinLTO, PGO=${GEARMULATOR_MDMM_APPLE_PGO_MODE}, targets=${_mdmm_optimization_targets}")

--- a/source/juce.cmake
+++ b/source/juce.cmake
@@ -99,6 +99,12 @@ target_include_directories(juce_plugin_modules
 
 _juce_fixup_module_source_groups()
 
+# Keep the historical source-tree destination for ordinary developer builds,
+# while allowing release builds to own an isolated products directory.  A
+# build root is safe to clean and cannot be overwritten by another build tree.
+set(GEARMULATOR_JUCE_PRODUCTS_ROOT "${CMAKE_SOURCE_DIR}/bin/plugins" CACHE PATH
+	"Root directory for completed JUCE plug-in and standalone products")
+
 # juce::juce_audio_plugin_client is the lib that every plugin links. However, this pulls in lots of juce modules that are 
 # all INTERFACE targets, causing all the sources to end up in every plugin we build. We remove this dependency as we already
 # link them via our rebuilt static lib that we created above. This causes all juce modules to only show up in our static
@@ -134,7 +140,7 @@ macro(createJucePlugin targetName productName isSynth plugin4CC binaryDataProjec
 		MICROPHONE_PERMISSION_TEXT "Gearmulator uses audio input for processing external instruments."
 		PLUGIN_MANUFACTURER_CODE GmPv                     # A four-character manufacturer id with at least one upper-case character
 		PLUGIN_CODE ${plugin4CC}                          # A unique four-character plugin id with exactly one upper-case character
-		PRODUCTS_FOLDER "${CMAKE_SOURCE_DIR}/bin/plugins/$<CONFIG>"
+		PRODUCTS_FOLDER "${GEARMULATOR_JUCE_PRODUCTS_ROOT}/$<CONFIG>"
 		                                                  # GarageBand 10.3 requires the first letter to be upper-case, and the remaining letters to be lower-case
 		FORMATS ${juce_formats}                           # The formats to build. Other valid formats are: AAX Unity VST AU AUv3 LV2
 		PRODUCT_NAME ${productName}                       # The name of the final executable, which can differ from the target name

--- a/source/jucePluginEditorLib/CMakeLists.txt
+++ b/source/jucePluginEditorLib/CMakeLists.txt
@@ -4,6 +4,7 @@ project(jucePluginEditorLib VERSION ${CMAKE_PROJECT_VERSION})
 set(SOURCES
 	editorWindowScaleRestore.h
 	fileChooserFlow.h
+	rendererPreferenceKeys.h
 	focusedParameter.cpp focusedParameter.h
 	focusedParameterTooltip.cpp focusedParameterTooltip.h
 	lcd.cpp lcd.h

--- a/source/jucePluginEditorLib/pluginEditor.cpp
+++ b/source/jucePluginEditorLib/pluginEditor.cpp
@@ -2,6 +2,7 @@
 
 #include "fileChooserFlow.h"
 #include "pluginProcessor.h"
+#include "rendererPreferenceKeys.h"
 
 #include "settings.h"
 #include "settingsDspAudio.h"
@@ -865,7 +866,7 @@ namespace jucePluginEditorLib
 				: juceRmlUi::SoftwareRendererMode::ForceOff;
 		else
 		{
-			auto software = m_processor.getConfig().getIntValue("forceSoftwareRenderer", -1);
+			auto software = m_processor.getConfig().getIntValue(forceSoftwareRendererKey, -1);
 			if (software >= 0)
 				config.forceSoftwareRenderer = software > 0
 					? juceRmlUi::SoftwareRendererMode::ForceOn

--- a/source/jucePluginEditorLib/rendererPreferenceKeys.h
+++ b/source/jucePluginEditorLib/rendererPreferenceKeys.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace jucePluginEditorLib
+{
+	inline constexpr auto forceSoftwareRendererKey = "forceSoftwareRenderer";
+	inline constexpr auto forceSoftwareRendererUserSelectedKey =
+		"forceSoftwareRendererUserSelectedV1";
+}

--- a/source/jucePluginEditorLib/settingsGui.cpp
+++ b/source/jucePluginEditorLib/settingsGui.cpp
@@ -2,6 +2,7 @@
 
 #include "pluginProcessor.h"
 #include "pluginEditorState.h"
+#include "rendererPreferenceKeys.h"
 
 #include "juceRmlUi/rmlElemButton.h"
 #include "juceRmlUi/rmlEventListener.h"
@@ -13,8 +14,12 @@ namespace jucePluginEditorLib
 
 	void SettingsGui::createUi(Rml::Element* _root)
 	{
-		createToggleButton(_root, "btForceSoftwareRendering", "forceSoftwareRenderer", [this](bool)
+		createToggleButton(_root, "btForceSoftwareRendering", forceSoftwareRendererKey, [this](bool)
 		{
+			auto& config = m_processor.getConfig();
+			config.setValue(forceSoftwareRendererUserSelectedKey, true);
+			config.saveIfNeeded();
+
 			juce::MessageManager::callAsync([this]
 			{
 				auto* editorState = m_processor.getEditorState();

--- a/source/juceRmlUi/CMakeLists.txt
+++ b/source/juceRmlUi/CMakeLists.txt
@@ -110,3 +110,10 @@ if(APPLE)
 endif()
 
 target_include_directories(juceRmlUi PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+if(BUILD_TESTING)
+	add_executable(juceRmlMouseInputTest test/rmlMouseInput_test.cpp)
+	target_link_libraries(juceRmlMouseInputTest PRIVATE juceRmlUi)
+	set_property(TARGET juceRmlMouseInputTest PROPERTY FOLDER "juceRmlUi/test")
+	add_test(NAME juceRmlMouseInputTest COMMAND juceRmlMouseInputTest)
+endif()

--- a/source/juceRmlUi/MetalContext.h
+++ b/source/juceRmlUi/MetalContext.h
@@ -36,7 +36,9 @@ namespace juceRmlUi
 		MetalContext& operator=(MetalContext&&) = delete;
 
 		void setListener(Listener* _listener);
-		void attachTo(juce::Component& _component);
+		// The native view attachment can be created before the component has a
+		// peer; JUCE will attach it when the peer appears.
+		bool attachTo(juce::Component& _component);
 		void detach();
 		void updateViewBounds();
 		void triggerRepaint();
@@ -55,7 +57,7 @@ namespace juceRmlUi
 
 	private:
 		void renderLoop();
-		void createMetalLayer();
+		bool createMetalLayer();
 		void destroyMetalLayer();
 		void updateDrawableSize();
 

--- a/source/juceRmlUi/MetalContext.mm
+++ b/source/juceRmlUi/MetalContext.mm
@@ -277,17 +277,11 @@ namespace juceRmlUi
 		m_renderingScale = scale;
 		layer.contentsScale = scale;
 
-		// The NSView auto-resizes via autoresizingMask. Just sync the
-		// layer frame to the view bounds and update the drawable size.
+		// The CAMetalLayer is this NSView's backing layer, so AppKit owns its
+		// frame in the parent view's coordinate space. Setting the layer frame
+		// to the local view bounds would reset its origin to (0, 0), allowing it
+		// to cover JUCE siblings such as a standalone window's title bar.
 		const CGRect viewBounds = metalView.bounds;
-
-		if (!CGRectEqualToRect(layer.frame, viewBounds))
-		{
-			[CATransaction begin];
-			[CATransaction setDisableActions:YES];
-			layer.frame = viewBounds;
-			[CATransaction commit];
-		}
 
 		const auto drawableWidth = static_cast<int>(viewBounds.size.width * scale);
 		const auto drawableHeight = static_cast<int>(viewBounds.size.height * scale);

--- a/source/juceRmlUi/MetalContext.mm
+++ b/source/juceRmlUi/MetalContext.mm
@@ -40,31 +40,30 @@ namespace juceRmlUi
 		m_listener = _listener;
 	}
 
-	void MetalContext::attachTo(juce::Component& _component)
+	bool MetalContext::attachTo(juce::Component& _component)
 	{
 		if (m_attached)
-			return; // Already attached, don't re-attach
+			return true; // Already attached, don't re-attach
 
 		m_component = &_component;
 
 		if (!m_device)
 		{
 			NSLog(@"MetalContext::attachTo: no device");
-			return;
+			return false;
 		}
 
-		createMetalLayer();
-
-		if (!m_attached)
+		if (!createMetalLayer())
 		{
-			NSLog(@"MetalContext::attachTo: createMetalLayer failed, peer=%p",
-				_component.getPeer() ? _component.getPeer()->getNativeHandle() : nullptr);
-			return;
+			NSLog(@"MetalContext::attachTo: createMetalLayer failed");
+			m_component = nullptr;
+			return false;
 		}
 
 		NSLog(@"MetalContext::attachTo: success, starting render thread");
 		m_shouldExit = false;
 		m_renderThread = std::make_unique<std::thread>([this] { renderLoop(); });
+		return true;
 	}
 
 	void MetalContext::detach()
@@ -179,20 +178,14 @@ namespace juceRmlUi
 		}
 	}
 
-	void MetalContext::createMetalLayer()
+	bool MetalContext::createMetalLayer()
 	{
 		if (!m_component || !m_device)
-			return;
-
-		auto* peer = m_component->getPeer();
-		if (!peer)
-			return;
-
-		NSView* nativeView = (__bridge NSView*)peer->getNativeHandle();
-		if (!nativeView)
-			return;
+			return false;
 
 		CAMetalLayer* layer = [CAMetalLayer layer];
+		if (!layer)
+			return false;
 		layer.device = MTL_DEVICE;
 		layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
 		layer.framebufferOnly = NO; // We need to read back for screenshots
@@ -200,6 +193,8 @@ namespace juceRmlUi
 
 		// Create an NSView backed by the Metal layer.
 		NSView* metalView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)];
+		if (!metalView)
+			return false;
 		metalView.wantsLayer = YES;
 		metalView.layer = layer;
 
@@ -208,16 +203,24 @@ namespace juceRmlUi
 		// including peer changes when the editor is closed and reopened.
 		// attachViewToComponent returns a ref-counted object that manages the view lifecycle
 		auto* attachment = juce::NSViewComponent::attachViewToComponent(*m_component, metalView);
-		if (attachment) attachment->incReferenceCount();
+		if (!attachment)
+		{
+			[metalView release];
+			return false;
+		}
+		attachment->incReferenceCount();
 		m_viewAttachment = attachment;
 
-		m_metalView = (void*)[metalView retain];
+		// Keep the ownership returned by alloc. NSViewAttachment holds its own
+		// reference until destroyMetalLayer() releases the attachment.
+		m_metalView = (void*)metalView;
 		m_metalLayer = (void*)[layer retain];
 
 		m_attached = true;
 
 		updateViewBounds();
 		updateDrawableSize();
+		return true;
 	}
 
 	void MetalContext::updateViewBounds()

--- a/source/juceRmlUi/juceRmlComponent.cpp
+++ b/source/juceRmlUi/juceRmlComponent.cpp
@@ -73,6 +73,12 @@ namespace juceRmlUi
 #ifdef RMLUI_METAL_RENDERER
 		static constexpr RendererProxy::RendererConfig g_renderConfigMetal {true, true, true};
 #endif
+		static constexpr float g_defaultSoftwareFPS = 30.0f;
+#if JUCE_MAC
+		static constexpr float g_defaultAcceleratedFPS = 60.0f;
+#else
+		static constexpr float g_defaultAcceleratedFPS = 30.0f;
+#endif
 	}
 
 	RmlComponent::RmlComponent(RmlInterfaces& _interfaces, DataProvider& _dataProvider, std::string _rootRmlFilename, const float _contentScale/* = 1.0f*/, const ContextCreatedCallback& _contextCreatedCallback, const DocumentLoadFailedCallback& _docLoadFailedCallback, const RmlComponentConfig& _config)
@@ -85,8 +91,12 @@ namespace juceRmlUi
 		, m_nextFrameTime(_interfaces.getSystemInterface().GetElapsedTime())
 		, m_config(_config)
 	{
-		if (_config.refreshRateLimitHz > 0 && _config.refreshRateLimitHz <= 300)
+		m_hasCustomFPS = _config.refreshRateLimitHz > 0
+			&& _config.refreshRateLimitHz <= 300;
+		if (m_hasCustomFPS)
 			m_targetFPS = static_cast<float>(_config.refreshRateLimitHz);
+		else
+			m_targetFPS = g_defaultSoftwareFPS;
 
 		m_renderProxy.reset(new RendererProxy(m_coreInstance, m_dataProvider));
 
@@ -207,6 +217,7 @@ namespace juceRmlUi
 			{
 				Rml::Log::Message(Rml::Log::LT_WARNING, "Detected software OpenGL renderer (%s), falling back to own software renderer instead", renderer);
 				m_renderType = Renderer::Software;
+				useDefaultFrameRateFor(Renderer::Software);
 				return;
 			}
 		}
@@ -216,6 +227,7 @@ namespace juceRmlUi
 			{
 				Rml::Log::Message(Rml::Log::LT_WARNING, "Could not determine OpenGL renderer, falling back to own software renderer");
 				m_renderType = Renderer::Software;
+				useDefaultFrameRateFor(Renderer::Software);
 				return;
 			}
 
@@ -224,16 +236,10 @@ namespace juceRmlUi
 
 		m_openGLContext->setSwapInterval(1);
 
-		bool haveCustomFPS = m_targetFPS >= 0;
+		const bool haveCustomFPS = m_hasCustomFPS;
 
 		if (!haveCustomFPS)
-		{
-#if JUCE_MAC
-			m_targetFPS = 60; // default limit is 60 Hz on macOS
-#else
-			m_targetFPS = 30; // default limit is 30 Hz, updated below if renderer is capable
-#endif
-		}
+			m_targetFPS = g_defaultAcceleratedFPS;
 		int major = 0, minor = 0;
 
 #if JUCE_MAC
@@ -396,6 +402,7 @@ namespace juceRmlUi
 	void RmlComponent::metalContextCreated(MetalContext& _context)
 	{
 		RmlInterfaces::ScopedAccess access(*this);
+		useDefaultFrameRateFor(Renderer::Metal);
 
 		m_renderInterface.reset(new RenderInterface_Metal(m_coreInstance, _context.getDevice()));
 		m_renderType = Renderer::Metal;
@@ -756,6 +763,7 @@ namespace juceRmlUi
 		m_metalContext.reset();
 		m_renderInterface.reset();
 		m_renderType = Renderer::Software;
+		useDefaultFrameRateFor(Renderer::Software);
 		m_renderDone = true;
 		enqueueUpdate();
 	}
@@ -1075,6 +1083,14 @@ namespace juceRmlUi
 		m_nextFrameTime = std::min(m_nextFrameTime, minTime);
 
 		startNextFrameTimer();
+	}
+
+	void RmlComponent::useDefaultFrameRateFor(const Renderer _renderer)
+	{
+		if (m_hasCustomFPS)
+			return;
+		m_targetFPS = _renderer == Renderer::Software
+			? g_defaultSoftwareFPS : g_defaultAcceleratedFPS;
 	}
 
 	void RmlComponent::enableDebugger(const bool _enable)

--- a/source/juceRmlUi/juceRmlComponent.cpp
+++ b/source/juceRmlUi/juceRmlComponent.cpp
@@ -405,7 +405,13 @@ namespace juceRmlUi
 		{
 			Rml::Log::Message(Rml::Log::LT_ERROR, "Failed to initialize Metal renderer, falling back to software");
 			m_renderInterface.reset();
-			m_renderType = Renderer::Software;
+			m_renderType = Renderer::None;
+			juce::Component::SafePointer<RmlComponent> safeComponent(this);
+			juce::MessageManager::callAsync([safeComponent]
+			{
+				if (safeComponent)
+					safeComponent->fallBackFromMetalToSoftware();
+			});
 			return;
 		}
 
@@ -503,7 +509,7 @@ namespace juceRmlUi
 
 #ifdef RMLUI_METAL_RENDERER
 		if (isVisible() && m_metalContext)
-			m_metalContext->attachTo(*this);
+			attachMetalContext();
 #endif
 	}
 
@@ -723,14 +729,37 @@ namespace juceRmlUi
 		rootComponent->setLookAndFeel(m_lookAndFeel);
 
 #ifdef RMLUI_METAL_RENDERER
-		// Retry Metal attachment now that we have a parent hierarchy (and likely a native peer)
+		// Keep bounds in sync when the component moves between parent hierarchies.
+		// The native view attachment itself is valid before a peer exists.
 		if (m_metalContext)
 		{
-			m_metalContext->attachTo(*this);
-			m_metalContext->updateViewBounds();
+			attachMetalContext();
+			if (m_metalContext)
+				m_metalContext->updateViewBounds();
 		}
 #endif
 	}
+
+#ifdef RMLUI_METAL_RENDERER
+	void RmlComponent::attachMetalContext()
+	{
+		if (m_metalContext && !m_metalContext->attachTo(*this))
+			fallBackFromMetalToSoftware();
+	}
+
+	void RmlComponent::fallBackFromMetalToSoftware()
+	{
+		if (!m_metalContext)
+			return;
+
+		m_metalContext->detach();
+		m_metalContext.reset();
+		m_renderInterface.reset();
+		m_renderType = Renderer::Software;
+		m_renderDone = true;
+		enqueueUpdate();
+	}
+#endif
 
 	void RmlComponent::timerCallback()
 	{
@@ -1013,8 +1042,29 @@ namespace juceRmlUi
 
 	void RmlComponent::enqueueUpdate()
 	{
-		// One is not enough, because RmlUi might do property changes that in turn require another update. We do three to be sure.
-		m_pendingUpdates = 3;
+		scheduleUpdate(true);
+	}
+
+	void RmlComponent::enqueueUpdateOnce()
+	{
+		scheduleUpdate(false);
+	}
+
+	void RmlComponent::scheduleUpdate(const bool _allowPropertySettling)
+	{
+		if (_allowPropertySettling)
+		{
+			// Some OnPropertyChange callbacks set another property which is only
+			// resolved by a later RmlUi update. Preserve the existing settling
+			// allowance for callers which may trigger such a cascade.
+			m_pendingUpdates = 3;
+		}
+		else if (m_updating || !m_renderDone)
+		{
+			// The requested change missed the frame currently being produced or
+			// presented, so retain exactly one follow-up frame.
+			m_pendingUpdates = std::max(m_pendingUpdates, 1u);
+		}
 
 		const auto t = m_rmlInterfaces.getSystemInterface().GetElapsedTime();
 		auto minTime = t;

--- a/source/juceRmlUi/juceRmlComponent.h
+++ b/source/juceRmlUi/juceRmlComponent.h
@@ -159,6 +159,7 @@ namespace juceRmlUi
 		void updateRmlContextDimensions();
 		void startNextFrameTimer();
 		void scheduleUpdate(bool _allowPropertySettling);
+		void useDefaultFrameRateFor(Renderer _renderer);
 #ifdef RMLUI_METAL_RENDERER
 		void attachMetalContext();
 		void fallBackFromMetalToSoftware();
@@ -217,7 +218,8 @@ namespace juceRmlUi
 
 		double m_time = 0;
 		float m_fps = 0;
-		float m_targetFPS = 0;
+		float m_targetFPS = 30;
+		bool m_hasCustomFPS = false;
 
 		uint32_t m_pendingUpdates = 0;
 		std::atomic<bool> m_renderDone;

--- a/source/juceRmlUi/juceRmlComponent.h
+++ b/source/juceRmlUi/juceRmlComponent.h
@@ -134,6 +134,9 @@ namespace juceRmlUi
 		static RmlComponent* fromElement(const Rml::Element* _element);
 
 		void enqueueUpdate();
+		// Schedule one Update/Render pass. Use this when the caller owns a change
+		// that is fully resolved by that pass, such as replacing a canvas texture.
+		void enqueueUpdateOnce();
 
 		void enableDebugger(bool _enable);
 
@@ -155,6 +158,11 @@ namespace juceRmlUi
 		void destroyRmlContext();
 		void updateRmlContextDimensions();
 		void startNextFrameTimer();
+		void scheduleUpdate(bool _allowPropertySettling);
+#ifdef RMLUI_METAL_RENDERER
+		void attachMetalContext();
+		void fallBackFromMetalToSoftware();
+#endif
 
 		Rml::Vector2i getRenderSize() const;
 

--- a/source/juceRmlUi/rmlElemCanvas.cpp
+++ b/source/juceRmlUi/rmlElemCanvas.cpp
@@ -39,7 +39,9 @@ namespace juceRmlUi
 		m_textureDirty = true;
 		auto* comp = RmlComponent::fromElement(this);
 		if (comp)
-			comp->enqueueUpdate();
+			// The texture dirty flag is consumed during this frame's Render pass;
+			// it cannot create a follow-on RmlUi property cascade.
+			comp->enqueueUpdateOnce();
 		else if (auto* context = GetContext())
 			context->RequestNextUpdate(0);
 	}

--- a/source/juceRmlUi/test/rmlMouseInput_test.cpp
+++ b/source/juceRmlUi/test/rmlMouseInput_test.cpp
@@ -1,0 +1,338 @@
+#include "juceRmlUi/rmlMouseInput.h"
+
+#include "RmlUi/Core/Context.h"
+#include "RmlUi/Core/Core.h"
+#include "RmlUi/Core/CoreInstance.h"
+#include "RmlUi/Core/ElementDocument.h"
+#include "RmlUi/Core/Event.h"
+#include "RmlUi/Core/EventListener.h"
+#include "RmlUi/Core/RenderInterface.h"
+#include "RmlUi/Core/SystemInterface.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace
+{
+	bool check(const bool _condition, const char* _message)
+	{
+		if(!_condition)
+			std::fprintf(stderr, "rmlMouseInput_test: %s\n", _message);
+		return _condition;
+	}
+
+	bool checkPosition(const Rml::Vector2i _actual, const Rml::Vector2i _expected,
+		const char* _message)
+	{
+		if(_actual == _expected)
+			return true;
+		std::fprintf(stderr, "rmlMouseInput_test: %s: got (%d,%d), expected (%d,%d)\n",
+			_message, _actual.x, _actual.y, _expected.x, _expected.y);
+		return false;
+	}
+
+	class RenderInterface final : public Rml::RenderInterface
+	{
+	public:
+		explicit RenderInterface(Rml::CoreInstance& _core) : Rml::RenderInterface(_core) {}
+
+		Rml::CompiledGeometryHandle CompileGeometry(Rml::Span<const Rml::Vertex>, Rml::Span<const int>) override
+		{
+			return Rml::CompiledGeometryHandle(++m_nextGeometry);
+		}
+		void RenderGeometry(Rml::CompiledGeometryHandle, Rml::Vector2f, Rml::TextureHandle) override {}
+		void ReleaseGeometry(Rml::CompiledGeometryHandle) override {}
+		Rml::TextureHandle LoadTexture(Rml::Vector2i&, const Rml::String&) override { return {}; }
+		Rml::TextureHandle GenerateTexture(Rml::Span<const Rml::byte>, Rml::Vector2i) override { return {}; }
+		void ReleaseTexture(Rml::TextureHandle) override {}
+		void EnableScissorRegion(bool) override {}
+		void SetScissorRegion(Rml::Rectanglei) override {}
+
+	private:
+		uintptr_t m_nextGeometry = 0;
+	};
+
+	class SystemInterface final : public Rml::SystemInterface
+	{
+	public:
+		explicit SystemInterface(Rml::CoreInstance& _core) : Rml::SystemInterface(_core) {}
+		double GetElapsedTime() override { return m_time; }
+		void setTime(const double _time) { m_time = _time; }
+
+	private:
+		double m_time = 1.0;
+	};
+
+	const char* eventName(const Rml::EventId _id)
+	{
+		switch(_id)
+		{
+		case Rml::EventId::Mouseover: return "mouseover";
+		case Rml::EventId::Mouseout: return "mouseout";
+		case Rml::EventId::Mousemove: return "mousemove";
+		case Rml::EventId::Mousedown: return "mousedown";
+		case Rml::EventId::Mouseup: return "mouseup";
+		case Rml::EventId::Click: return "click";
+		case Rml::EventId::Dblclick: return "dblclick";
+		case Rml::EventId::Dragstart: return "dragstart";
+		case Rml::EventId::Drag: return "drag";
+		case Rml::EventId::Dragend: return "dragend";
+		default: return "other";
+		}
+	}
+
+	class EventLog final : public Rml::EventListener
+	{
+	public:
+		void ProcessEvent(Rml::Event& _event) override
+		{
+			const auto* target = _event.GetTargetElement();
+			if(!target || target->GetId().empty())
+				return; // Pin control ordering; ancestor hover-chain order is not an input contract.
+			const auto& id = target->GetId();
+			events.emplace_back(std::string(eventName(_event.GetId())) + ":" + id);
+		}
+
+		void clear() { events.clear(); }
+		std::vector<std::string> events;
+	};
+
+	class Fixture
+	{
+	public:
+		Fixture() : renderer(core), system(core)
+		{
+			Rml::SetRenderInterface(core, &renderer);
+			Rml::SetSystemInterface(core, &system);
+			initialized = Rml::Initialise(core);
+			if(!initialized)
+				return;
+
+			context = Rml::CreateContext(core, "mouse-input-test", { 300, 200 });
+			if(!context)
+				return;
+
+			static constexpr const char* source = R"(
+<rml>
+<head><style>
+body { margin: 0; width: 300px; height: 200px; }
+#left { position: absolute; left: 0; top: 0; width: 150px; height: 200px; drag: drag; }
+#right { position: absolute; left: 150px; top: 0; width: 150px; height: 200px; }
+</style></head>
+<body><div id="left"></div><div id="right"></div></body>
+</rml>)";
+			document = context->LoadDocumentFromMemory(source);
+			if(!document)
+				return;
+
+			for(const auto event : { Rml::EventId::Mouseover, Rml::EventId::Mouseout,
+				Rml::EventId::Mousemove, Rml::EventId::Mousedown, Rml::EventId::Mouseup,
+				Rml::EventId::Click, Rml::EventId::Dblclick, Rml::EventId::Dragstart,
+				Rml::EventId::Drag, Rml::EventId::Dragend })
+				document->AddEventListener(event, &log);
+
+			document->Show();
+			context->Update();
+		}
+
+		~Fixture()
+		{
+			if(document)
+				document->Close();
+			if(context)
+				Rml::RemoveContext(core, "mouse-input-test");
+			if(initialized)
+				Rml::Shutdown(core);
+		}
+
+		bool valid() const { return initialized && context && document; }
+
+		Rml::CoreInstance core;
+		RenderInterface renderer;
+		SystemInterface system;
+		Rml::Context* context = nullptr;
+		Rml::ElementDocument* document = nullptr;
+		EventLog log;
+		bool initialized = false;
+	};
+
+	bool expectEvents(const EventLog& _log, const std::vector<std::string>& _expected,
+		const char* _scenario)
+	{
+		if(_log.events == _expected)
+			return true;
+
+		std::fprintf(stderr, "rmlMouseInput_test: %s ordering mismatch\n  actual:", _scenario);
+		for(const auto& event : _log.events)
+			std::fprintf(stderr, " %s", event.c_str());
+		std::fprintf(stderr, "\n  expected:");
+		for(const auto& event : _expected)
+			std::fprintf(stderr, " %s", event.c_str());
+		std::fprintf(stderr, "\n");
+		return false;
+	}
+
+	bool testCoordinateMatrix()
+	{
+		using juceRmlUi::mouseInput::mapComponentToContextPosition;
+		bool success = true;
+
+		for(const int percent : { 50, 100, 150, 200, 300 })
+		{
+			const Rml::Vector2i dimensions { 3 * percent, 2 * percent };
+			success &= checkPosition(mapComponentToContextPosition(0, 0,
+				dimensions.x, dimensions.y, dimensions), { 0, 0 }, "scaled top-left");
+			success &= checkPosition(mapComponentToContextPosition(dimensions.x / 2,
+				dimensions.y / 2, dimensions.x, dimensions.y, dimensions),
+				{ dimensions.x / 2, dimensions.y / 2 }, "scaled center");
+			success &= checkPosition(mapComponentToContextPosition(dimensions.x,
+				dimensions.y, dimensions.x, dimensions.y, dimensions),
+				dimensions, "scaled bottom-right boundary");
+		}
+
+		success &= checkPosition(mapComponentToContextPosition(500, 300,
+			1000, 600, { 1500, 800 }), { 750, 400 }, "nonuniform transient center");
+		success &= checkPosition(mapComponentToContextPosition(999, 599,
+			1000, 600, { 1500, 800 }), { 1498, 799 }, "nonuniform transient last pixel");
+		success &= checkPosition(mapComponentToContextPosition(1, 1,
+			2, 2, { 3, 5 }), { 2, 2 }, "JUCE-compatible half-to-even rounding");
+		success &= checkPosition(mapComponentToContextPosition(-20, 620,
+			1000, 600, { 1500, 800 }), { -30, 827 }, "out-of-bounds drag mapping");
+		success &= checkPosition(mapComponentToContextPosition(17, 23,
+			0, 600, { 1500, 800 }), { 17, 23 }, "zero-width fallback");
+		return success;
+	}
+
+	bool testHitMapping()
+	{
+		Fixture fixture;
+		if(!check(fixture.valid(), "failed to create RML input fixture"))
+			return false;
+
+		const auto leftPosition = juceRmlUi::mouseInput::mapComponentToContextPosition(
+			100, 75, 600, 300, fixture.context->GetDimensions());
+		const auto rightPosition = juceRmlUi::mouseInput::mapComponentToContextPosition(
+			500, 75, 600, 300, fixture.context->GetDimensions());
+		const auto* left = fixture.context->GetElementAtPoint(
+			{ static_cast<float>(leftPosition.x), static_cast<float>(leftPosition.y) });
+		const auto* right = fixture.context->GetElementAtPoint(
+			{ static_cast<float>(rightPosition.x), static_cast<float>(rightPosition.y) });
+		return check(left && left->GetId() == "left", "mapped left hit missed")
+			&& check(right && right->GetId() == "right", "mapped right hit missed");
+	}
+
+	bool testEventOrdering()
+	{
+		bool success = true;
+
+		{
+			Fixture fixture;
+			if(!check(fixture.valid(), "failed to create first-click fixture"))
+				return false;
+			auto& context = *fixture.context;
+
+			// Model the stale hover left behind when component and context sizes change
+			// on different turns: the pointer used to hit the right control, while the
+			// first post-resize click maps to the left control.
+			context.ProcessMouseMove(250, 50, 0);
+			fixture.log.clear();
+			const auto firstClick = juceRmlUi::mouseInput::mapComponentToContextPosition(
+				100, 75, 600, 300, context.GetDimensions());
+			juceRmlUi::mouseInput::processButtonDown(context, firstClick, 0, 0);
+			juceRmlUi::mouseInput::processButtonUp(context, firstClick, 0, 0);
+			success &= expectEvents(fixture.log, {
+				"mouseout:right", "mouseover:left", "mousemove:left",
+				"mousedown:left", "mouseup:left", "click:left"
+			}, "first click after resize/scale");
+		}
+
+		{
+			Fixture fixture;
+			if(!check(fixture.valid(), "failed to create drag fixture"))
+				return false;
+			auto& context = *fixture.context;
+			juceRmlUi::mouseInput::processButtonDown(context, { 50, 50 }, 0, 0);
+			context.ProcessMouseMove(75, 50, 0);
+			juceRmlUi::mouseInput::processButtonUp(context, { 75, 50 }, 0, 0);
+			success &= expectEvents(fixture.log, {
+				"mouseover:left", "mousemove:left", "mousedown:left",
+				"dragstart:left", "drag:left", "mousemove:left",
+				"mouseup:left", "click:left", "dragend:left"
+			}, "normal knob drag");
+		}
+
+		{
+			Fixture fixture;
+			if(!check(fixture.valid(), "failed to create outside-release fixture"))
+				return false;
+			auto& context = *fixture.context;
+			juceRmlUi::mouseInput::processButtonDown(context, { 50, 50 }, 0, 0);
+			context.ProcessMouseMove(250, 50, 0);
+			juceRmlUi::mouseInput::processButtonUp(context, { 250, 50 }, 0, 0);
+			success &= expectEvents(fixture.log, {
+				"mouseover:left", "mousemove:left", "mousedown:left",
+				"dragstart:left", "drag:left", "mouseout:left", "mouseover:right", "mousemove:right",
+				"mouseup:right", "dragend:left"
+			}, "release outside control");
+		}
+
+		{
+			Fixture fixture;
+			if(!check(fixture.valid(), "failed to create double-click fixture"))
+				return false;
+			auto& context = *fixture.context;
+			fixture.system.setTime(10.0);
+			juceRmlUi::mouseInput::processButtonDown(context, { 50, 50 }, 0, 0);
+			juceRmlUi::mouseInput::processButtonUp(context, { 50, 50 }, 0, 0);
+			fixture.system.setTime(10.1);
+			juceRmlUi::mouseInput::processButtonDown(context, { 50, 50 }, 0, 0);
+			juceRmlUi::mouseInput::processButtonUp(context, { 50, 50 }, 0, 0);
+			success &= expectEvents(fixture.log, {
+				"mouseover:left", "mousemove:left",
+				"mousedown:left", "mouseup:left", "click:left",
+				"mousedown:left", "dblclick:left", "mouseup:left", "click:left"
+			}, "double click");
+		}
+
+		{
+			Fixture fixture;
+			if(!check(fixture.valid(), "failed to create right-click fixture"))
+				return false;
+			auto& context = *fixture.context;
+			juceRmlUi::mouseInput::processButtonDown(context, { 50, 50 }, 1, 0);
+			juceRmlUi::mouseInput::processButtonUp(context, { 50, 50 }, 1, 0);
+			success &= expectEvents(fixture.log, {
+				"mouseover:left", "mousemove:left",
+				"mousedown:left", "mouseup:left"
+			}, "right click/context");
+		}
+
+		{
+			Fixture fixture;
+			if(!check(fixture.valid(), "failed to create hover fixture"))
+				return false;
+			auto& context = *fixture.context;
+			context.ProcessMouseMove(50, 50, 0);
+			context.ProcessMouseMove(250, 50, 0);
+			context.ProcessMouseLeave();
+			success &= expectEvents(fixture.log, {
+				"mouseover:left", "mousemove:left",
+				"mouseout:left", "mouseover:right", "mousemove:right",
+				"mouseout:right"
+			}, "hover transitions");
+		}
+
+		return success;
+	}
+}
+
+int main()
+{
+	const bool success = testCoordinateMatrix()
+		&& testHitMapping()
+		&& testEventOrdering();
+	if(success)
+		std::puts("rmlMouseInput_test: PASS");
+	return success ? 0 : 1;
+}


### PR DESCRIPTION
Several independent release regressions shared one symptom: a new standalone could open an unwanted full-duplex topology, the old renderer preference could leave a mostly static editor on the CPU, and the macOS packaging path allowed an ordinary `Release` build without the optimization stack needed by the emulators. On an M2 Pro at 48 kHz/128, that last path put MD around 2.70–2.75 ms against a 2.667 ms callback period and produced unusable audio.

This series makes the tested behavior explicit:

- new MD/MM standalones start output-only while keeping audio input selectable and persistent;
- standalone editors select Metal automatically when it attaches, retain an explicit software choice, migrate the old accidental software default, coalesce unchanged panel updates, and restore renderer-specific frame limits;
- the macOS release script requires ThinLTO and DSP optimization, records architecture/source provenance, validates an exact-source profile when single-architecture PGO is selected, audits the package, and runs a 128-frame core-capacity gate instead of treating every CMake `Release` build as equivalent.

The exact arm64 candidate was built from this PR head, `9fc79912e86582bce81b87f272a67256dce75dad`, with JUCE dependency `d5d501072e2f15485e1823576d45bd940782ffe5`. Its ad-hoc-signed test archive is SHA-256 `c74164ea7ced5304c90dec19535f2f880cafd157812c9c8186dbbe05af377b91`.

Validation:

- full optimized build and package verification passed; package audit passed 38/38 checks;
- controlled ThinLTO/PGO comparisons were byte-identical across 1.92 million MD sample values and across the tested MM outputs;
- exact first launches for both models opened output-only, advanced emulated cycles, populated the LCD, and attached Metal;
- exact 48 kHz/512 CoreAudio runs had zero settled internal deadline misses for MD and MM, including both apps concurrently; the enclosing concurrent HAL listener saw zero overload events;
- physical-input runs through JUCE's separate-device combiner had zero settled internal misses; deterministic packaged-VST3 input tests passed all 24 nonzero signal/correlation windows;
- warmed exact 48 kHz/128 active-note runs completed 15,797 MD and 15,782 MM settled callbacks with zero internal misses and zero HAL overload events. MD averaged 1.998 ms with a 2.533 ms exact maximum; MM averaged 1.686 ms with a 2.308 ms exact maximum;
- focused audio-I/O, renderer-policy, panel-rendering, mouse-input, receipt, and capacity-checker tests pass.

Qualification limits:

- cold first activation of a DSP path can compile JIT code in the callback; the first 128-frame campaign recorded one first-note overrun in each model, plus one marginal MD overrun that did not recur in the warmed control;
- manually paced custom-host tails remain unqualified and are recorded separately from the clean real CoreAudio default path;
- the candidate is arm64, ad-hoc signed, and not notarized. A public signed/notarized or universal artifact needs a new receipt, identity checks, and smoke test;
- human visual and audible acceptance passed for the focused combined MD/MM standalones described below; a normal-DAW VST3 smoke and qualification of the exact final release package remain release gates.

The separate DSP opcode-cache memory optimization is intentionally excluded so this PR remains identical to the fully profiled candidate.

Dependency: this PR pins JUCE commit `d5d501072e2f15485e1823576d45bd940782ffe5`, supplied by [JUCE-md-mm PR #3](https://github.com/joelanders/JUCE-md-mm/pull/3). Merge that PR with a normal merge commit so the pinned commit remains reachable. Squashing or rebasing JUCE PR #3 requires repinning this PR and rebuilding the frozen candidate.

Follow-up at `ddf479128c4168f993f00facaae884a9c74e5ba2`: automatic Metal selection exposed a Gearmulator backing-layer layout bug in the standalones. JUCE correctly placed the editor native view below its title bar at `(4,30)`, but the render loop reassigned the backing `CAMetalLayer.frame` from local `(0,0)` bounds, so Metal pixels covered the still-present Options button. The fix leaves backing-layer placement to AppKit and updates only drawable scale/size. LLDB confirmed the MD layer position changed from the incorrect `(0,0)` to `(4,30)` while the NSView remained `(4,30)`; MM retained the same nonzero origin. `mdPanelRenderingTest`, arm64 standalone builds, deep strict code-signature checks, and live launches of both products pass.

A focused combined tester including this PR plus stacked PR 68 was built from `7edc06f486fd8a8aafd835b4206569e50391ca67`. In a 44.1 kHz/512 MD run, 4,098 pre-shutdown callbacks produced one estimated 1.62 ms deadline miss during a 377-block live-JIT burst and no other pre-shutdown miss. The reused PGO data's formal receipt names the preceding source commit, so this is a visual/audio tester rather than a publishable release artifact; regenerate matching provenance for the final release build.

Human acceptance on 2026-09-11: the user tested the corrected MD and MM standalones from that focused package and reported that they both looked and sounded good.
