### PR TITLE
Reduce Apple silicon cold DSP JIT stalls

### DIFF
--- a/source/elektron/md/mdLib/mddsp.cpp
+++ b/source/elektron/md/mdLib/mddsp.cpp
@@ -108,6 +108,11 @@ namespace md
 		config.maxInstructionsPerBlock = 32;
 		// Likewise return from hardware DO loops regularly to service peripherals.
 		config.maxDoIterations = 4;
+#if defined(__APPLE__) && defined(__aarch64__)
+		// JIT blocks are first compiled synchronously by the audio thread. On Apple
+		// silicon, the optimizer's cold cost exceeds its measured steady-state gain.
+		config.enableOptimizer = false;
+#endif
 		config.getBlockConfig = [](const TWord)
 			-> std::optional<dsp56k::JitConfig>
 		{


### PR DESCRIPTION
Apple-silicon MD/MM currently optimizes unseen DSP JIT blocks synchronously in the host audio callback. At 48 kHz / 128 frames, that contributes directly to cold startup and first-note deadline overruns.

This disables the JIT optimizer only for MD/MM on Apple arm64. Matched reverse-order A/B runs reduced cold JIT callbacks as follows:

- MM startup: median 19.44 ms to 6.99 ms; first note: 4.53 ms to 2.91 ms.
- MD startup: median 11.54 ms to 5.36 ms; first note: 2.77 ms to 2.41 ms.
- One-note and six-voice rendered PCM was byte-identical between baseline and candidate.
- Broader chord runs showed no material steady callback regression: MM mean +0.28%; MD mean -1.43%.

The relinked source candidate passed the existing MD/MM state, firmware audio, boot, scheduler, UW, sine, input, and project-restore test executables (9/9). Non-Apple-arm64 builds keep the existing optimizer default.

A fresh source-matched Apple arm64 Release + ThinLTO + PGO test candidate was subsequently built from this exact head. Its package, architecture, signatures, firmware smoke, unit, state, automation, robustness, and soak checks passed. At 48 kHz / 128 frames, the three-run output-only core gate passed with median p50 usage of 76.34% of one callback period for MD and 64.52% for MM. The strict paced-tail diagnostic remains unqualified: MD recorded 6 render-duration overruns and MM 54 across three runs. Human listening, standalone/UI, physical-device, and input-enabled testing remain before release approval. The local test ZIP's SHA-256 is `cafc50d1450a497b6c047b7ff507187fded101008cf019c32f7069529234118f`.

This PR is stacked on #67 so that PR's exact tested commit remains unchanged. After #67 merges, retarget this PR to `release/md-mm-alpha`.
