### PR TITLE
Include Audio Units in macOS release packages

### DIFF
--- a/doc/mdmm_automation_validation.md
+++ b/doc/mdmm_automation_validation.md
@@ -24,7 +24,7 @@ The automation controller treats three kinds of state differently:
 | `mdAutomationSoakTest` | MD + MM | Sustained writes and concurrent MD/MM instances without firmware MIDI overflow or cross-instance contamination |
 | `MD/MM automation core / fixture-free (asan-ubsan)` | No | The fixture-free gates under AddressSanitizer and UndefinedBehaviorSanitizer |
 | `MD/MM automation core / shared controller compatibility` | No | Virus, N2x, Vavra, Xenia, and JE-8086 controllers still compile against the changed shared `Parameter`, `Controller`, `Processor`, MIDI parser, and MIDI-output APIs |
-| `Elektron macOS universal artifacts` | No | Universal VST3 wrapper automation smoke, AU build/sign/plist validation, fixture-free tests, and packaging checks |
+| `Elektron macOS universal artifacts` | No | Universal VST3 wrapper automation smoke, packaged AU build/sign/plist validation, fixture-free tests, and packaging checks |
 | `Elektron Windows artifacts` | No | Windows VST3 wrapper automation smoke plus fixture-free tests and packaging checks |
 
 The two `fixture-free` jobs, `shared controller compatibility`, and both

--- a/scripts/macos/INSTALL-macOS.txt
+++ b/scripts/macos/INSTALL-macOS.txt
@@ -2,7 +2,7 @@ Gearmulator MD/MM for macOS
 ===========================
 
 This alpha is ad-hoc signed and is not notarized by Apple. macOS may quarantine
-the applications and VST3 plug-ins when you download them.
+the applications, VST3 plug-ins, and Audio Units when you download them.
 
 Installation
 ------------
@@ -15,9 +15,14 @@ Installation
        ~/Library/Audio/Plug-Ins/VST3
 
    Create that folder if it does not already exist.
-4. Optionally copy the standalone applications to /Applications or another
+4. Copy the Audio Units you want to use to:
+
+       ~/Library/Audio/Plug-Ins/Components
+
+   Create that folder if it does not already exist.
+5. Optionally copy the standalone applications to /Applications or another
    location of your choice.
-5. Restart your DAW or ask it to rescan plug-ins.
+6. Restart your DAW or ask it to rescan plug-ins.
 
 Run the setup command again whenever you install an updated download. The
 command only clears extended attributes from the Gearmulator MD/MM bundles in

--- a/scripts/macos/build_mdmm.sh
+++ b/scripts/macos/build_mdmm.sh
@@ -405,6 +405,8 @@ mkdir -p "${package_dir}"
 /usr/bin/ditto "${mm_app}" "${package_dir}/Gearmulator MM.app"
 /usr/bin/ditto "${md_vst3}" "${package_dir}/Gearmulator MD.vst3"
 /usr/bin/ditto "${mm_vst3}" "${package_dir}/Gearmulator MM.vst3"
+/usr/bin/ditto "${md_au}" "${package_dir}/Gearmulator MD.component"
+/usr/bin/ditto "${mm_au}" "${package_dir}/Gearmulator MM.component"
 /usr/bin/ditto "${source_dir}/LICENSE.md" "${package_dir}/LICENSE.md"
 /usr/bin/ditto "${script_dir}/macsetup_Gearmulator-Elektron.command" \
   "${package_dir}/macsetup_Gearmulator-Elektron.command"
@@ -443,6 +445,8 @@ python3 "${script_dir}/write_mdmm_receipt.py" \
   --artifact "${package_dir}/Gearmulator MM.app" \
   --artifact "${package_dir}/Gearmulator MD.vst3" \
   --artifact "${package_dir}/Gearmulator MM.vst3" \
+  --artifact "${package_dir}/Gearmulator MD.component" \
+  --artifact "${package_dir}/Gearmulator MM.component" \
   --package-file "${package_dir}/macsetup_Gearmulator-Elektron.command" \
   --package-file "${package_dir}/INSTALL-macOS.txt"
 

--- a/scripts/macos/macsetup_Gearmulator-Elektron.command
+++ b/scripts/macos/macsetup_Gearmulator-Elektron.command
@@ -7,7 +7,7 @@ set -u
 
 current_location="$(cd "$(dirname "$0")" && pwd)"
 products=("Gearmulator MD" "Gearmulator MM")
-formats=("app" "vst3")
+formats=("app" "vst3" "component")
 found=0
 failed=0
 
@@ -33,7 +33,7 @@ done
 
 echo
 if [[ ${found} -eq 0 ]]; then
-  echo "No Gearmulator MD/MM applications or VST3 plug-ins were found beside this script."
+  echo "No Gearmulator MD/MM applications, VST3 plug-ins, or Audio Units were found beside this script."
   exit 1
 fi
 if [[ ${failed} -ne 0 ]]; then
@@ -41,4 +41,4 @@ if [[ ${failed} -ne 0 ]]; then
   exit 1
 fi
 
-echo "Done. You can now copy the applications and VST3 plug-ins to their destinations."
+echo "Done. You can now copy the applications, VST3 plug-ins, and Audio Units to their destinations."

--- a/scripts/macos/verify_mdmm_package.sh
+++ b/scripts/macos/verify_mdmm_package.sh
@@ -125,13 +125,15 @@ bundles=(
   "${package_dir}/Gearmulator MM.app"
   "${package_dir}/Gearmulator MD.vst3"
   "${package_dir}/Gearmulator MM.vst3"
+  "${package_dir}/Gearmulator MD.component"
+  "${package_dir}/Gearmulator MM.component"
 )
 for bundle in "${bundles[@]}"; do
   if [[ ! -d "${bundle}" ]]; then
     echo "Expected bundle is missing from extracted package: ${bundle}" >&2
     exit 3
   fi
-  executable="${bundle}/Contents/MacOS/$(basename "${bundle}" | sed -E 's/\.(app|vst3)$//')"
+  executable="${bundle}/Contents/MacOS/$(basename "${bundle}" | sed -E 's/\.(app|vst3|component)$//')"
   if [[ ! -f "${executable}" ]]; then
     echo "Expected bundle executable is missing: ${executable}" >&2
     exit 3
@@ -146,7 +148,7 @@ done
 
 quarantined_paths=("${setup_command}")
 for bundle in "${bundles[@]}"; do
-  executable="${bundle}/Contents/MacOS/$(basename "${bundle}" | sed -E 's/\.(app|vst3)$//')"
+  executable="${bundle}/Contents/MacOS/$(basename "${bundle}" | sed -E 's/\.(app|vst3|component)$//')"
   quarantined_paths+=("${bundle}" "${executable}")
 done
 for path in "${quarantined_paths[@]}"; do
@@ -165,6 +167,9 @@ done
 for bundle in "${bundles[@]}"; do
   /usr/bin/codesign --verify --deep --strict "${bundle}"
 done
+/usr/bin/plutil -lint \
+  "${package_dir}/Gearmulator MD.component/Contents/Info.plist" \
+  "${package_dir}/Gearmulator MM.component/Contents/Info.plist"
 
 md_smoke_home="${verification_root}/smoke-home-md"
 mm_smoke_home="${verification_root}/smoke-home-mm"


### PR DESCRIPTION
The macOS release build already compiled, signed, and validated the MD and MM Audio Units, but the final ZIP and receipt omitted both `.component` bundles. As a result, alpha users could only install the packaged standalone apps and VST3s even though AU support had passed the build.

This adds both Audio Units to the package and release receipt. The extracted-package verifier now requires their executables, strict signatures, property lists, privacy scan, and quarantine cleanup, and the installation guide names the user Audio Unit directory.

No emulator, audio, renderer, or plug-in state code changes.

Validation:

- `bash -n` for all changed shell scripts
- 41 release-receipt unit tests
- 6 core-capacity unit tests
- the macOS artifact workflow will build and verify the complete extracted package
