### PR TITLE
Fix Machinedrum jog wheel sensitivity and rotation

### DIFF
--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -965,7 +965,7 @@ namespace mdJucePlugin
 		for (auto* knob : m_encoders)
 			apply(knob, encoderBase, encoderPercent);
 		apply(m_levelEncoder, isMonomachine ? 150.0f : 100.0f, encoderPercent);
-		apply(m_soundEncoder, 340.0f, wheelPercent);
+		apply(m_soundEncoder, 1360.0f, wheelPercent);
 	}
 
 	void Editor::loadInstalledFactoryStorage()

--- a/source/elektron/md/mdJucePlugin/mdEditor.cpp
+++ b/source/elektron/md/mdJucePlugin/mdEditor.cpp
@@ -965,7 +965,7 @@ namespace mdJucePlugin
 		for (auto* knob : m_encoders)
 			apply(knob, encoderBase, encoderPercent);
 		apply(m_levelEncoder, isMonomachine ? 150.0f : 100.0f, encoderPercent);
-		apply(m_soundEncoder, 170.0f, wheelPercent);
+		apply(m_soundEncoder, 340.0f, wheelPercent);
 	}
 
 	void Editor::loadInstalledFactoryStorage()

--- a/source/elektron/md/mdJucePlugin/skins/mdDefault/mdDefault.rcss
+++ b/source/elektron/md/mdJucePlugin/skins/mdDefault/mdDefault.rcss
@@ -413,6 +413,7 @@ body
 {
 	box-shadow: #0000002c 1dp 2dp 2dp -1dp;
 	decorator: image(mdSoundKnob_000 contain);
-	speed: 170;
+	frames: 48;
+	speed: 340;
 	spriteprefix: "mdSoundKnob_";
 }

--- a/source/elektron/md/mdJucePlugin/skins/mdDefault/mdDefault.rcss
+++ b/source/elektron/md/mdJucePlugin/skins/mdDefault/mdDefault.rcss
@@ -414,6 +414,6 @@ body
 	box-shadow: #0000002c 1dp 2dp 2dp -1dp;
 	decorator: image(mdSoundKnob_000 contain);
 	frames: 48;
-	speed: 340;
+	speed: 1360;
 	spriteprefix: "mdSoundKnob_";
 }


### PR DESCRIPTION
The Machinedrum sound-selection jog wheel moved about one detent per 1.7 pixels at the default setting and rendered only two visual positions. Its wheel-specific style inherited the shared two-frame knob setting even though the wheel artwork contains 48 rotation frames.

This change declares all 48 wheel frames and increases the default full-sweep drag distance from 170 to 1360 pixels. At the default 100% setting, the wheel now moves about one detent per 13.6 pixels: one eighth of its former input rate. The existing wheel-speed preference continues to scale that rate. The change is limited to the MD sound-selection wheel and does not touch shared input handling, MM controls, emulation, or audio processing.

Validation:

- built and ad-hoc signed the current arm64 Release standalone
- strict deep code-signature verification passed
- confirmed the current executable embeds `frames: 48` and `speed: 1360`
- launched that exact app with isolated HOME, data, config, ROM, and temp roots
- confirmed the live `encSound` element reported `speed=1360`
- a 136-pixel upward drag changed the value from 50.000 to 59.779, matching the intended one-eighth rate within pointer-coordinate rounding
- before/after screenshots confirmed that the wheel artwork rotates through the 48-frame sequence instead of jumping between two positions
