### PR TITLE
Remove Monomachine private parameter guard

### DIFF
--- a/source/elektron/md/mdLib/mddsp.cpp
+++ b/source/elektron/md/mdLib/mddsp.cpp
@@ -289,25 +289,6 @@ namespace md
 
 	void Dsp::writeWordToDsp(const uint32_t _word)
 	{
-		// Preserve MM parameter-transfer ordering while the previous block is active.
-		if(m_hardware.isMonomachine() && m_mmParamBlockVoice >= 0)
-		{
-			if(m_mmParamBlockWord == 0x28 && ((_word & 0xff) == 0x81 || (_word & 0xff) == 0x02))
-			{
-				const uint32_t targetHandle =
-					0x528 + static_cast<uint32_t>(m_mmParamBlockVoice) * 0x100;
-				if(m_dsp.memory().get(dsp56k::MemArea_Y, 0x123) == targetHandle)
-				{
-					const uint64_t clampStop = m_dsp.getCycles() + schedInlineClamp();
-					while(m_dsp.memory().get(dsp56k::MemArea_Y, 0x123) == targetHandle
-						&& m_dsp.getCycles() < clampStop)
-						m_dsp.exec();
-				}
-			}
-			if(++m_mmParamBlockWord >= 52)
-				m_mmParamBlockVoice = -1;
-		}
-
 		// The DSP56303 HI08 host data path has a host latch and a one-word HRX. Before placing
 		// a word in HRX, advance the target DSP until the previous word drains, bounded by the
 		// scheduler clamp. This preserves MAME's feed_host_rx_queue invariant without a wall-clock
@@ -349,12 +330,6 @@ namespace md
 		// dispatched (MAME catch_up_elapsed_time), so HCP is raised at a defined point in DSP time.
 		if(booted())
 			m_hardware.schedCatchUpDsp(m_index);
-		if(m_hardware.isMonomachine() && booted() && _irq >= 0x10 && _irq <= 0x14
-			&& (_irq & 1) == 0)
-		{
-			m_mmParamBlockVoice = static_cast<int32_t>((_irq - 0x10) >> 1);
-			m_mmParamBlockWord = 0;
-		}
 		// Preserve Monomachine host-command ordering. Data words precede the next
 		// command, so drain the receive path before dispatching that command. Run the DSP
 		// inline until HORX has drained before dispatching the CVR. This is needed

--- a/source/elektron/md/mdLib/mddsp.h
+++ b/source/elektron/md/mdLib/mddsp.h
@@ -93,10 +93,6 @@ namespace md
 		// Published once boot state is fully initialized; acquired by the scheduler.
 		std::atomic<bool> m_schedRunnable{false};
 
-		// Temporary transaction state for the compatibility guard in writeWordToDsp.
-		int32_t  m_mmParamBlockVoice = -1;
-		uint32_t m_mmParamBlockWord = 0;
-
 		uint64_t m_mmHostTxCycle = 0;
 		TimedHostRx m_timedHostRx;
 


### PR DESCRIPTION
Remove the Monomachine's firmware-private parameter-block tracking and Y-memory polling: 29 lines deleted, with the normal HI08 receive draining, command serialization, acknowledgement and bounded catch-up retained.

Reviewed head: `1a2546bab4cac312f10d5a6ebf6fbccccb1d3300`, based on release after #74 and #79. No dependency pins change relative to release.

Validation:

- 19 selected native arm64 core/firmware tests passed without skips, including MM six-track panel/MIDI sine, audio/input/boot, MD/MM randomized audio soak, state and host-receive checks.
- A real 64-wave DigiPRO bank passed import, state encode/decode and cold reload. All 64 wave payloads were verified; audio was checked at slots 0, 1, 45 and 63 before and after reload.
- These local runs used `f1f05546`; the subsequent #79 refresh leaves mdLib, mdLibTest and DSP/MCU source/pins unchanged. All five final-head GitHub checks pass, including compiled macOS VST3 tests with the newly merged JUCE support.

Ready for a merge decision. Merge this before #75 and #76, which carry the same reviewed removal and resolve their overlapping edits. No optimized-release performance or PGO qualification is claimed here.
